### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ jobs:
   build_and_test:
     name: Build, Test, and Pack
     runs-on: ubuntu-latest # Use the latest Ubuntu runner
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/Agash/ObsWebSocket/security/code-scanning/1](https://github.com/Agash/ObsWebSocket/security/code-scanning/1)

Add an explicit `permissions` block to the `build_and_test` job so the `GITHUB_TOKEN` is constrained to least privilege for that job.  
Best fix without changing functionality: set `contents: read` on `build_and_test`. This is the minimal recommended baseline and is sufficient for checkout/build/test/pack/artifact upload behavior in this workflow. Keep `publish_nuget` permissions unchanged (`contents: read`, `id-token: write`) because it has separate auth requirements.

Edit only `.github/workflows/build.yml`, in the `build_and_test` job header area (right after `runs-on` is the cleanest place).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
