### PR TITLE
fix(core): stop dropping falsy request fields

### DIFF
--- a/ObsWebSocket.Codegen.Tasks/Generation/Emitter.JsonContext.cs
+++ b/ObsWebSocket.Codegen.Tasks/Generation/Emitter.JsonContext.cs
@@ -34,7 +34,7 @@ internal static partial class Emitter
             _ = builder.AppendLine();
             _ = builder.AppendLine("[JsonSourceGenerationOptions(");
             _ = builder.AppendLine("    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,");
-            _ = builder.AppendLine("    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault)]");
+            _ = builder.AppendLine("    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]");
 
             // Fixed protocol wrapper and payload types.
             _ = builder.AppendLine("[JsonSerializable(typeof(OutgoingMessage<RequestPayload>))]");

--- a/ObsWebSocket.Core/Generated/Serialization/ObsWebSocketJsonContext.g.cs
+++ b/ObsWebSocket.Core/Generated/Serialization/ObsWebSocketJsonContext.g.cs
@@ -15,7 +15,7 @@ namespace ObsWebSocket.Core.Serialization;
 
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
-    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault)]
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(OutgoingMessage<RequestPayload>))]
 [JsonSerializable(typeof(OutgoingMessage<IdentifyPayload>))]
 [JsonSerializable(typeof(OutgoingMessage<ReidentifyPayload>))]

--- a/ObsWebSocket.Core/Serialization/ObsWebSocketJsonContext.Settings.cs
+++ b/ObsWebSocket.Core/Serialization/ObsWebSocketJsonContext.Settings.cs
@@ -56,5 +56,5 @@ namespace ObsWebSocket.Core.Serialization;
 [JsonSerializable(typeof(RtmpCustomStreamServiceSettings))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
-    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault)]
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 internal sealed partial class ObsWebSocketSettingsJsonContext : JsonSerializerContext { }

--- a/ObsWebSocket.Tests/FalsyRequestFieldTests.cs
+++ b/ObsWebSocket.Tests/FalsyRequestFieldTests.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+using MessagePack;
+using Microsoft.Extensions.Logging.Abstractions;
+using ObsWebSocket.Core.Protocol;
+using ObsWebSocket.Core.Protocol.Generated;
+using ObsWebSocket.Core.Protocol.Requests;
+using ObsWebSocket.Core.Serialization;
+
+namespace ObsWebSocket.Tests;
+
+/// <summary>
+/// Guards against required request fields being dropped when their value equals the CLR
+/// default. The serializer context previously used <c>WhenWritingDefault</c>, which silently
+/// removed <c>false</c> and <c>0</c> from outgoing payloads and made OBS reject the request
+/// with code 300 ("missing field").
+/// </summary>
+[TestClass]
+public sealed class FalsyRequestFieldTests
+{
+    private static string Json(object data) =>
+        JsonSerializer.SerializeToElement(
+            data,
+            ObsWebSocketJsonContext.Default.Options.GetTypeInfo(data.GetType())
+        ).GetRawText();
+
+    [TestMethod]
+    public void Serialize_RequiredFalseBool_KeepsField()
+    {
+        string json = Json(new SetStudioModeEnabledRequestData(false));
+        Assert.AreEqual("{\"studioModeEnabled\":false}", json);
+    }
+
+    [TestMethod]
+    public void Serialize_RequiredZeroNumber_KeepsField()
+    {
+        string json = Json(
+            new SetSceneItemEnabledRequestData
+            {
+                SceneName = "Scene",
+                SceneItemId = 0,
+                SceneItemEnabled = false,
+            }
+        );
+        StringAssert.Contains(json, "\"sceneItemId\":0");
+        StringAssert.Contains(json, "\"sceneItemEnabled\":false");
+    }
+
+    [TestMethod]
+    public void Serialize_UnsetOptionalField_IsStillOmitted()
+    {
+        // Optional protocol fields are generated as nullable, so they must stay absent
+        // rather than being sent as explicit nulls — OBS applies its own defaults for
+        // fields that are not present.
+        string json = Json(new CreateSceneItemRequestData(sceneName: "Scene", sourceName: "Src"));
+        Assert.IsFalse(json.Contains("null", StringComparison.Ordinal), json);
+        Assert.IsFalse(json.Contains("sceneItemEnabled", StringComparison.Ordinal), json);
+    }
+
+    [TestMethod]
+    public async Task SerializeMsgPack_RequiredFalseBool_KeepsField()
+    {
+        // The MessagePack transport funnels request data through the JSON context first
+        // (RequestPayload.RequestData is a JsonElement), so it shares the same failure mode.
+        JsonElement element = JsonSerializer.SerializeToElement(
+            new SetStudioModeEnabledRequestData(false),
+            ObsWebSocketJsonContext.Default.Options.GetTypeInfo(
+                typeof(SetStudioModeEnabledRequestData)
+            )
+        );
+        MsgPackMessageSerializer serializer = new(NullLogger<MsgPackMessageSerializer>.Instance);
+        byte[] bytes = await serializer.SerializeAsync(
+            new OutgoingMessage<RequestPayload>(
+                WebSocketOpCode.Request,
+                new RequestPayload("SetStudioModeEnabled", "req-1", element)
+            )
+        );
+
+        string json = MessagePackSerializer.ConvertToJson(
+            bytes,
+            MsgPackMessageSerializer.s_msgPackOptions
+        );
+        StringAssert.Contains(json, "\"studioModeEnabled\":false");
+    }
+
+    [TestMethod]
+    public void Serialize_IdentifyWithNoSubscriptions_KeepsZeroField()
+    {
+        // EventSubscription.None is 0. Dropping the field makes OBS fall back to its own
+        // default subscription set, silently subscribing to everything.
+        string json = JsonSerializer.Serialize(
+            new OutgoingMessage<IdentifyPayload>(
+                WebSocketOpCode.Identify,
+                new IdentifyPayload(1, null, (uint)EventSubscription.None)
+            ),
+            ObsWebSocketJsonContext.Default.Options.GetTypeInfo(
+                typeof(OutgoingMessage<IdentifyPayload>)
+            )
+        );
+        StringAssert.Contains(json, "\"eventSubscriptions\":0");
+    }
+
+    [TestMethod]
+    public void Serialize_JsonNullValue_IsStillWritten()
+    {
+        // A JsonElement whose ValueKind is Null is not a CLR null, so WhenWritingNull keeps
+        // it. Storing a JSON null in a persistent-data slot must reach OBS as an explicit null.
+        string json = Json(
+            new SetPersistentDataRequestData
+            {
+                Realm = "OBS_WEBSOCKET_DATA_REALM_PROFILE",
+                SlotName = "slot",
+                SlotValue = JsonSerializer.SerializeToElement<object?>(null),
+            }
+        );
+        StringAssert.Contains(json, "\"slotValue\":null");
+    }
+}


### PR DESCRIPTION
Fixes #10

The JSON serializer context used `WhenWritingDefault`, so any request field whose value matched the CLR default was dropped from the payload. `SetStudioModeEnabled(false)` serialized to `{}` and OBS answered with code 300, "Your request is missing the `studioModeEnabled` field."

Not specific to that one call. Anything falsy was affected, for example `SetInputMute(name, false)` and `SetSceneItemEnabled(scene, 0, false)`, the latter losing both `sceneItemId` and `sceneItemEnabled`. Identifying with `EventSubscription.None` also dropped `eventSubscriptions`, so OBS silently fell back to its default subscription set.

Introduced in the AOT pass (5fd1757), first shipped in v0.2.0-alpha1. Before that the client serialized with plain web defaults and had no ignore condition, which is why 0.1.x worked.

## Fix

`WhenWritingDefault` to `WhenWritingNull` in the emitted context, the regenerated output, and the typed settings context. Every optional protocol field is generated as nullable and no optional field is a non-nullable value type, so `WhenWritingNull` omits exactly the unset ones while keeping `false`, `0` and `""`.

MsgPack was broken too and is fixed by the same change, since `RequestPayload.RequestData` is a `JsonElement` built through the JSON context before the envelope is packed.

## Verified

Reverting the fix reproduces the reported error verbatim, same message and same stack frames.

Against OBS 32.2.2, restoring each original value afterwards:

- `SetStudioModeEnabled(false)`, `SetInputMute(false)`, `SetInputVolume(0dB)`, `SetSceneItemEnabled(false)`, `SetSceneItemIndex(0)`, `SetSourceFilterEnabled(false)`, `SetSourceFilterIndex(0)`, `SetPersistentData(false)`, `Identify(eventSubscriptions=0)`. All pass, all fail without the fix.
- The example's `run-transport-tests` suite passes on both JSON and MsgPack, including all six settings modes.

New tests in `FalsyRequestFieldTests` cover required false, required zero, the MsgPack envelope, identify with no subscriptions, and two guards that unset optional fields stay absent and that a JSON null value is still written.