### PR TITLE
docs: fix broken README examples and add net11

### DIFF
--- a/ObsWebSocket.Tests/ReadmeCompileCheck.cs
+++ b/ObsWebSocket.Tests/ReadmeCompileCheck.cs
@@ -1,0 +1,130 @@
+using System.Text.Json.Serialization;
+using ObsWebSocket.Core;
+using ObsWebSocket.Core.Events.Generated;
+using ObsWebSocket.Core.Protocol.Common.InputSettings;
+using ObsWebSocket.Core.Protocol;
+using ObsWebSocket.Core.Protocol.Generated;
+using ObsWebSocket.Core.Protocol.Requests;
+using ObsWebSocket.Core.Protocol.Responses;
+
+namespace ObsWebSocket.Tests;
+
+[JsonSerializable(typeof(OverlaySettings))]
+internal partial class MyContext : JsonSerializerContext { }
+
+internal sealed record OverlaySettings(
+    [property: JsonPropertyName("url")] string? Url = null,
+    [property: JsonPropertyName("css")] string? Css = null
+);
+
+// Compile-only check that the call shapes printed in README.md are real.
+// Never executed; if this file compiles, the README examples compile.
+internal static class ReadmeCompileCheck
+{
+    internal static async Task TextSourceAsync(ObsWebSocketClient client, CancellationToken ct)
+    {
+        await client.SetInputTextAsync("NewsTicker", "Breaking: Live now!", ct);
+
+        var settings = new TextGdiPlusInputSettings(Text: "Breaking: Live now!", WordWrap: true);
+        await client.SetInputSettingsAsync("NewsTicker", settings, cancellationToken: ct);
+    }
+
+    internal static async Task ReplayBufferAsync(ObsWebSocketClient client, CancellationToken ct)
+    {
+        var status = await client.GetReplayBufferStatusAsync(cancellationToken: ct);
+        if (status?.OutputActive == true)
+        {
+            await client.SaveReplayBufferAsync(cancellationToken: ct);
+        }
+    }
+
+    internal static async Task BrowserSourceAsync(ObsWebSocketClient client, CancellationToken ct)
+    {
+        var current = await client.GetInputSettingsAsync<BrowserSourceSettings>("StreamOverlay", ct);
+        _ = current?.Url;
+
+        await client.SetInputSettingsAsync(
+            "StreamOverlay",
+            new BrowserSourceSettings(Url: "https://myoverlay.example.com", Width: 1920, Height: 1080),
+            cancellationToken: ct
+        );
+
+        await client.SetInputSettingsAsync(
+            "StreamOverlay",
+            new OverlaySettings(Url: "https://myoverlay.example.com"),
+            MyContext.Default.OverlaySettings,
+            cancellationToken: ct
+        );
+    }
+
+    internal static async Task UtilitiesAsync(ObsWebSocketClient client, CancellationToken ct)
+    {
+        await client.SwitchSceneAndWaitAsync("Scene", cancellationToken: ct);
+        _ = await client.SourceExistsAsync("Source", ct);
+        await client.CreateSourceFilterAsync(
+            "Source",
+            "MyFilter",
+            "gain_filter",
+            new OverlaySettings(),
+            MyContext.Default.OverlaySettings,
+            ct
+        );
+        _ = await client.WaitForEventAsync<CurrentProgramSceneChangedEventArgs>(
+            e => e.EventData.SceneName == "Scene",
+            TimeSpan.FromSeconds(5),
+            ct
+        );
+    }
+
+    internal static async Task VersionAsync(ObsWebSocketClient client, CancellationToken ct)
+    {
+        GetVersionResponseData? version = await client.GetVersionAsync(cancellationToken: ct);
+        _ = version?.ObsVersion;
+    }
+
+    internal static async Task BatchAsync(ObsWebSocketClient client, CancellationToken ct)
+    {
+        List<BatchRequestItem> items =
+        [
+            new("GetVersion", null),
+            new("SetCurrentProgramScene", new SetCurrentProgramSceneRequestData(sceneName: "Intro")),
+            new("Sleep", new SleepRequestData(sleepMillis: 100)),
+            new("SetInputMute", new SetInputMuteRequestData { InputName = "Mic", InputMuted = false }),
+        ];
+
+        var results = await client.CallBatchAsync(
+            items,
+            executionType: RequestBatchExecutionType.SerialRealtime,
+            haltOnFailure: false,
+            cancellationToken: ct
+        );
+
+        foreach (var result in results)
+        {
+            _ = $"{result.RequestType}: {result.RequestStatus.Result}";
+        }
+    }
+
+    internal static async Task UtilitiesExtendedAsync(ObsWebSocketClient client, CancellationToken ct)
+    {
+        await client.SwitchSceneAsync("Scene", cancellationToken: ct);
+        _ = await client.SetSceneItemEnabledAsync("Scene", "Source", null, ct);
+        _ = await client.TryGetSceneItemIdAsync("Scene", "Source", ct);
+        await client.SetInputMutesAsync([("Mic", false), ("Desktop Audio", true)], ct);
+        _ = await client.GetSourceScreenshotBytesAsync("Source", cancellationToken: ct);
+        _ = await client.GetSourceScreenshotOnCanvasBytesAsync("Source", cancellationToken: ct);
+        await client.SaveSourceScreenshotToFileAsync("Source", "shot.png", cancellationToken: ct);
+        _ = await client.EnsureProfileActiveAsync("Profile", ct);
+        _ = await client.EnsureSceneCollectionActiveAsync("Collection", ct);
+        _ = await client.IsVirtualCamActiveAsync(ct);
+        _ = await client.SetVirtualCamActiveAndWaitAsync(true, cancellationToken: ct);
+        await client.TriggerHotkeyAsync("OBSBasic.StartRecording", ct);
+        _ = await client.CreateInputAsync(
+            "browser_source",
+            "NewOverlay",
+            new OverlaySettings(),
+            MyContext.Default.OverlaySettings,
+            cancellationToken: ct
+        );
+    }
+}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Modern .NET client for OBS Studio WebSocket v5, with generated protocol types an
 
 ## Targets
 
+- `net11.0`
 - `net10.0`
 - `net9.0`
 
@@ -25,7 +26,7 @@ dotnet add package ObsWebSocket.Core
 - DI helpers via `AddObsWebSocketClient()`
 - JSON and MessagePack transports (configurable per environment)
 - Reconnect, timeout, and event subscription options
-- Typed settings helpers for inputs, filters, transitions, outputs, and stream service — works with built-in library types or your own AOT-safe source-generated types
+- Typed settings helpers for inputs, filters, transitions, outputs, and stream service, working with built-in library types or your own AOT-safe source-generated types
 
 > **OBS WebSocket v5 only** (OBS Studio 28+). Enable the server via *Tools → WebSocket Server Settings* in OBS.
 
@@ -94,16 +95,16 @@ await client.SetInputTextAsync("NewsTicker", "Breaking: Live now!", ct);
 
 // Or use a typed settings object to update multiple properties at once
 var settings = new TextGdiPlusInputSettings(Text: "Breaking: Live now!", WordWrap: true);
-await client.SetInputSettingsAsync("NewsTicker", settings, ct);
+await client.SetInputSettingsAsync("NewsTicker", settings, cancellationToken: ct);
 ```
 
-`TextGdiPlusInputSettings` is a built-in library type. The same pattern applies to `TextFreetype2InputSettings`, `BrowserSourceSettings`, and filter settings types — all live in `ObsWebSocket.Core.Protocol.Common.InputSettings` and `ObsWebSocket.Core.Protocol.Common.FilterSettings`.
+`TextGdiPlusInputSettings` is a built-in library type. The same pattern applies to `TextFreetype2InputSettings`, `BrowserSourceSettings`, and the filter settings types, which live in `ObsWebSocket.Core.Protocol.Common.InputSettings` and `ObsWebSocket.Core.Protocol.Common.FilterSettings`.
 
 ### Check and save the replay buffer
 
 ```csharp
 var status = await client.GetReplayBufferStatusAsync(cancellationToken: ct);
-if (status.OutputActive == true)
+if (status?.OutputActive == true)
 {
     await client.SaveReplayBufferAsync(cancellationToken: ct);
     Console.WriteLine("Replay saved.");
@@ -115,19 +116,19 @@ if (status.OutputActive == true)
 Use a library type for common properties, or define your own type to target exactly what you need:
 
 ```csharp
-// Library type — covers the standard browser source properties
+// Library type, covers the standard browser source properties
 var current = await client.GetInputSettingsAsync<BrowserSourceSettings>("StreamOverlay", ct);
 Console.WriteLine($"Current URL: {current?.Url}");
 
 await client.SetInputSettingsAsync(
     "StreamOverlay",
     new BrowserSourceSettings(Url: "https://myoverlay.example.com", Width: 1920, Height: 1080),
-    ct
+    cancellationToken: ct
 );
 ```
 
 ```csharp
-// Consumer type — define only the properties you care about, fully AOT-safe
+// Consumer type, define only the properties you care about, fully AOT-safe
 [JsonSerializable(typeof(OverlaySettings))]
 internal partial class MyContext : JsonSerializerContext { }
 
@@ -140,15 +141,17 @@ await client.SetInputSettingsAsync(
     "StreamOverlay",
     new OverlaySettings(Url: "https://myoverlay.example.com"),
     MyContext.Default.OverlaySettings,
-    ct
+    cancellationToken: ct
 );
 ```
 
-> Raw `JsonElement` access is also available — all settings helpers have counterparts in the generated types under `ObsWebSocket.Core.Protocol.Requests` if you need full control.
+Both `Set` overloads take `overlay` before the cancellation token. It defaults to `true`, which merges your values onto the existing settings. Pass `overlay: false` to replace them outright.
+
+> Raw `JsonElement` access is also available. All settings helpers have counterparts in the generated types under `ObsWebSocket.Core.Protocol.Requests` if you need full control.
 
 ## Helper API
 
-All typed settings helpers have two overloads: an implicit one for library-registered types, and an explicit one accepting a `JsonTypeInfo<T>` for consumer-provided types. All are AOT-safe when using the explicit overload.
+Every typed settings helper has two overloads: an implicit one for library-registered types, and an explicit one taking a `JsonTypeInfo<T>` for consumer-provided types. Use the explicit overload to stay AOT-safe.
 
 **Settings read/write:**
 
@@ -162,13 +165,35 @@ All typed settings helpers have two overloads: an implicit one for library-regis
 | `GetOutputSettingsAsync<T>` / `SetOutputSettingsAsync<T>` | Output settings |
 | `GetStreamServiceSettingsAsync<T>` / `SetStreamServiceSettingsAsync<T>` | Stream service settings |
 
-**Scene / source utilities:**
+Most of these take optional parameters ahead of the cancellation token, so pass it as `cancellationToken: ct`.
 
-- `SwitchSceneAndWaitAsync(scene, ct)` — switch scene and wait for the event to confirm
-- `SetInputTextAsync(name, text, ct)` — shorthand for updating text source content
-- `CreateSourceFilterAsync<T>(source, filterName, kind, settings, ct)` — add a typed filter
-- `SourceExistsAsync(name, ct)` — check whether a source exists
-- `WaitForEventAsync<TEventArgs>(ct)` — await the next occurrence of any typed OBS event
+**Scenes and scene items:**
+
+- `SwitchSceneAsync(scene, cancellationToken: ct)` switches the Program scene, or Preview with `switchToProgram: false`. Optional `transitionName` and `transitionDurationMs` apply to that switch only.
+- `SwitchSceneAndWaitAsync(scene, cancellationToken: ct)` does the same and waits for the event confirming it.
+- `SetSceneItemEnabledAsync(scene, sourceName, isEnabled, ct)` returns the resulting state. Leave `isEnabled` null to toggle. There is an overload taking a numeric `sceneItemId`.
+- `TryGetSceneItemIdAsync(scene, sourceName, ct)` returns null instead of throwing when the item is not in the scene.
+- `SourceExistsAsync(name, ct)` checks whether a source exists.
+
+**Inputs and filters:**
+
+- `SetInputTextAsync(name, text, ct)` is shorthand for updating text source content.
+- `SetInputMutesAsync(inputMutes, ct)` sets many mute states in one batch, taking `IEnumerable<(string InputName, bool IsMuted)>`.
+- `CreateInputAsync<T>(kind, name, settings, ...)` creates an input with typed settings, optionally placing it in a scene.
+- `CreateSourceFilterAsync<T>(source, filterName, kind, settings, ct)` adds a typed filter.
+
+**Screenshots:**
+
+- `GetSourceScreenshotBytesAsync(source, ...)` returns the decoded image bytes rather than a base64 data URI.
+- `GetSourceScreenshotOnCanvasBytesAsync(source, ...)` does the same at full canvas dimensions.
+- `SaveSourceScreenshotToFileAsync(source, filePath, ...)` writes straight to disk.
+
+**Application state:**
+
+- `EnsureProfileActiveAsync(name, ct)` and `EnsureSceneCollectionActiveAsync(name, ct)` switch only if needed, returning whether the target is active afterwards rather than throwing when it does not exist.
+- `IsVirtualCamActiveAsync(ct)` and `SetVirtualCamActiveAndWaitAsync(activate, timeout, ct)` read and drive the virtual camera.
+- `TriggerHotkeyAsync(hotkeyName, ct)` fires a hotkey by name.
+- `WaitForEventAsync<TEventArgs>(predicate, timeout, ct)` awaits the next matching occurrence of a typed OBS event.
 
 For direct low-level access, all generated request/response types are in:
 - `ObsWebSocket.Core.Protocol.Requests`
@@ -177,26 +202,46 @@ For direct low-level access, all generated request/response types are in:
 
 ### Batch API
 
-`CallBatchAsync` accepts a `List<BatchRequestItem>`. Each item's `RequestData` should be `null`, a `JsonElement` built with `Utf8JsonWriter`, or a generated `*RequestData` DTO — anonymous types and reflection-based serialization are not AOT-safe here.
+Send several requests in one round trip, with OBS executing them back to back:
+
+```csharp
+List<BatchRequestItem> items =
+[
+    new("GetVersion", null),
+    new("SetCurrentProgramScene", new SetCurrentProgramSceneRequestData(sceneName: "Intro")),
+    new("Sleep", new SleepRequestData(sleepMillis: 100)),
+    new("SetInputMute", new SetInputMuteRequestData { InputName = "Mic", InputMuted = false }),
+];
+
+var results = await client.CallBatchAsync(
+    items,
+    executionType: RequestBatchExecutionType.SerialRealtime,
+    haltOnFailure: false,
+    cancellationToken: ct
+);
+
+foreach (var result in results)
+{
+    Console.WriteLine($"{result.RequestType}: {result.RequestStatus.Result}");
+}
+```
+
+`Sleep` is only valid inside a batch, and pairs with `SerialRealtime` to pace a sequence.
+
+Each item's `RequestData` should be `null`, a generated `*RequestData` DTO, or a `JsonElement` built with `Utf8JsonWriter`. Anonymous types and reflection-based serialization are not AOT-safe here.
 
 ## Example App
 
 `ObsWebSocket.Example` is a host-based sample with configuration and DI.
 
-- **Interactive mode** — command loop (`help`, `version`, `scene`, `batch-example`, `get-all-settings-types`, etc.)
-- **Transport validation mode** — exercises JSON and MsgPack across scene/input/filter/settings APIs, then enters the interactive loop
-- **One-shot mode** — pass a command as a process argument for CI/automation:
-  `ObsWebSocket.Example run-transport-tests`
+- **Interactive mode**: command loop (`help`, `version`, `scene`, `batch-example`, `get-all-settings-types`, etc.)
+- **Transport validation mode**: exercises JSON and MsgPack across scene/input/filter/settings APIs, then enters the interactive loop
+- **One-shot mode**: pass a command as a process argument for CI/automation, `ObsWebSocket.Example run-transport-tests`
 
-`appsettings.json`:
+It reads the same `Obs` section as above, plus:
 
 ```json
 {
-  "Obs": {
-    "ServerUri": "ws://localhost:4455",
-    "Password": "",
-    "Format": "Json"
-  },
   "ExampleValidation": {
     "RunValidationOnStartup": false,
     "ValidationIterations": 1


### PR DESCRIPTION
README was last touched in May, so it had drifted.

## Examples that did not compile

Four of them. `SetInputSettingsAsync` and `SwitchSceneAndWaitAsync` both take optional parameters ahead of the cancellation token, so passing `ct` positionally bound it to `overlay` / `transitionName` instead:

```csharp
// was, does not compile
await client.SetInputSettingsAsync("NewsTicker", settings, ct);
await client.SwitchSceneAndWaitAsync(scene, ct);

// now
await client.SetInputSettingsAsync("NewsTicker", settings, cancellationToken: ct);
await client.SwitchSceneAndWaitAsync("Scene", cancellationToken: ct);
```

`WaitForEventAsync<T>` was documented as taking just a token. It needs a predicate and a timeout. The replay buffer snippet dereferenced a nullable response, `status.OutputActive` on a `GetReplayBufferStatusResponseData?`.

Added a short note that `overlay` sits before the token and defaults to `true`, since that is what makes the named argument necessary.

## Other

- Targets listed `net10.0` and `net9.0` only. `net11.0` has been there since df11cff.
- The full `appsettings.json` block was repeated for the example app when only `ExampleValidation` differs.
- Dropped the em dashes.

## Guard

`ReadmeCompileCheck.cs` is a compile-only file holding every call shape the README prints. Nothing runs it. If an example stops compiling, the build breaks. Reverting the fixes above reproduces `CS1503` on it.