### PR TITLE
0.4.1: finish the grouping, type the protocol's numbers, and chain client options

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,11 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore ObsWebSocket.sln
 
+    - name: Check formatting
+      run: |
+        dotnet tool restore
+        dotnet csharpier check .
+
     - name: Build Solution
       run: dotnet build ObsWebSocket.sln --configuration Release --no-restore
 

--- a/ObsWebSocket.Codegen.Tasks/GenerateObsWebSocketSourcesTask.cs
+++ b/ObsWebSocket.Codegen.Tasks/GenerateObsWebSocketSourcesTask.cs
@@ -14,7 +14,8 @@ public sealed class GenerateObsWebSocketSourcesTask : Microsoft.Build.Utilities.
 
     public override bool Execute()
     {
-        int exitCode = ProtocolCodegenRunner.GenerateAsync(
+        int exitCode = ProtocolCodegenRunner
+            .GenerateAsync(
                 protocolPath: ProtocolPath,
                 outputDirectory: OutputDirectory,
                 downloadIfMissing: DownloadIfMissing,

--- a/ObsWebSocket.Codegen.Tasks/Generation/Diagnostics.cs
+++ b/ObsWebSocket.Codegen.Tasks/Generation/Diagnostics.cs
@@ -114,6 +114,20 @@ internal static class Diagnostics
     );
 
     /// <summary>
+    /// Reported when the protocol defines a <c>Number</c> field the numeric table does not
+    /// classify. The field still maps to <c>double</c>, which is the safe fallback, but a whole
+    /// number field left unclassified reaches callers as a floating point value.
+    /// </summary>
+    public static readonly DiagnosticDescriptor UnclassifiedNumberField = new(
+        id: "OBSWSGEN012",
+        title: "Unclassified Number field",
+        messageFormat: "Number field '{0}' in '{1}' is not listed in NumericFieldTable. Mapping to 'double'. Add it to the table if it holds whole numbers.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true
+    );
+
+    /// <summary>
     /// Informational diagnostic reported when an optional field that is a value type (struct) is generated as a nullable value type.
     /// </summary>
     public static readonly DiagnosticDescriptor OptionalValueTypeWarning = new(

--- a/ObsWebSocket.Codegen.Tasks/Generation/Emitter.DtoGeneration.cs
+++ b/ObsWebSocket.Codegen.Tasks/Generation/Emitter.DtoGeneration.cs
@@ -729,6 +729,7 @@ internal static partial class Emitter
             || f.ValueName.EndsWith("." + objectNode.Name)
         );
     }
+
     /// <summary>
     /// Reports whether a field's description says it can be null, which the protocol states in
     /// prose for fields it does not otherwise mark optional.
@@ -736,5 +737,4 @@ internal static partial class Emitter
     private static bool DescriptionAllowsNull(string? description) =>
         !string.IsNullOrEmpty(description)
         && description.IndexOf("null", StringComparison.OrdinalIgnoreCase) >= 0;
-
 }

--- a/ObsWebSocket.Codegen.Tasks/Generation/Emitter.EventStreams.cs
+++ b/ObsWebSocket.Codegen.Tasks/Generation/Emitter.EventStreams.cs
@@ -60,9 +60,7 @@ internal static partial class Emitter
             builder.AppendLine(
                 "/// Each accessor subscribes for the lifetime of the enumeration and unsubscribes"
             );
-            builder.AppendLine(
-                "/// when it ends, so the caller never manages handlers."
-            );
+            builder.AppendLine("/// when it ends, so the caller never manages handlers.");
             builder.AppendLine("/// </summary>");
 
             // A category with events but no requests has no group declared elsewhere, so this
@@ -93,10 +91,13 @@ internal static partial class Emitter
                         continue;
                     }
 
-                    string eventArgsTypeName = $"{GeneratedEventArgsNamespace}.{eventName}EventArgs";
+                    string eventArgsTypeName =
+                        $"{GeneratedEventArgsNamespace}.{eventName}EventArgs";
 
                     builder.AppendLine("    /// <summary>");
-                    builder.AppendLine($"    /// Streams <c>{eventName}</c> events as they arrive.");
+                    builder.AppendLine(
+                        $"    /// Streams <c>{eventName}</c> events as they arrive."
+                    );
                     if (!string.IsNullOrWhiteSpace(eventDef.Description))
                     {
                         builder.AppendLine(

--- a/ObsWebSocket.Codegen.Tasks/Generation/Emitter.EventStreams.cs
+++ b/ObsWebSocket.Codegen.Tasks/Generation/Emitter.EventStreams.cs
@@ -12,7 +12,9 @@ internal static partial class Emitter
 {
     /// <summary>
     /// Generates one stream accessor per protocol event, each wrapping the corresponding
-    /// classic event so it can be consumed with <c>await foreach</c>.
+    /// classic event so it can be consumed with <c>await foreach</c>. The accessors go onto the
+    /// same category group as that category's requests, because the protocol documents requests
+    /// and events under one set of category headings.
     /// </summary>
     /// <param name="context">The source production context.</param>
     /// <param name="protocol">The parsed protocol definition.</param>
@@ -26,6 +28,12 @@ internal static partial class Emitter
             return;
         }
 
+        HashSet<string> requestCategories = new(StringComparer.OrdinalIgnoreCase);
+        foreach (RequestDefinition request in protocol.Requests ?? [])
+        {
+            _ = requestCategories.Add(request.Category ?? "general");
+        }
+
         StringBuilder builder = BuildSourceHeader("// Helper: per-event IAsyncEnumerable streams");
         builder.AppendLine("using System;");
         builder.AppendLine("using System.Collections.Generic;");
@@ -36,86 +44,112 @@ internal static partial class Emitter
         builder.AppendLine();
         builder.AppendLine($"namespace {ExtensionsNamespace};");
         builder.AppendLine();
-        builder.AppendLine("/// <summary>");
-        builder.AppendLine(
-            "/// Observes OBS events as async sequences. Each accessor subscribes for the lifetime"
-        );
-        builder.AppendLine(
-            "/// of the enumeration and unsubscribes when it ends, so the caller never manages handlers."
-        );
-        builder.AppendLine("/// </summary>");
-        builder.AppendLine("public static class ObsWebSocketClientEventStreams");
-        builder.AppendLine("{");
 
-        foreach (OBSEvent? eventDef in protocol.Events)
+        foreach (
+            IGrouping<string, OBSEvent> group in protocol
+                .Events.GroupBy(e => e.Category ?? "general", StringComparer.OrdinalIgnoreCase)
+                .OrderBy(g => g.Key, StringComparer.Ordinal)
+        )
         {
-            try
+            string groupName = ToGroupName(group.Key);
+
+            builder.AppendLine("/// <summary>");
+            builder.AppendLine(
+                $"/// Events in the <c>{System.Security.SecurityElement.Escape(group.Key)}</c> category, as async sequences."
+            );
+            builder.AppendLine(
+                "/// Each accessor subscribes for the lifetime of the enumeration and unsubscribes"
+            );
+            builder.AppendLine(
+                "/// when it ends, so the caller never manages handlers."
+            );
+            builder.AppendLine("/// </summary>");
+
+            // A category with events but no requests has no group declared elsewhere, so this
+            // part has to carry the primary constructor.
+            if (requestCategories.Contains(group.Key))
             {
-                string eventName = SanitizeIdentifier(eventDef.EventType);
-                if (string.IsNullOrEmpty(eventName))
-                {
-                    continue;
-                }
-
-                string eventArgsTypeName = $"{GeneratedEventArgsNamespace}.{eventName}EventArgs";
-
-                builder.AppendLine("    /// <summary>");
-                builder.AppendLine(
-                    $"    /// Streams <c>{eventName}</c> events as they arrive."
-                );
-                if (!string.IsNullOrWhiteSpace(eventDef.Description))
-                {
-                    builder.AppendLine(
-                        $"    /// <para>{FlattenDescription(eventDef.Description)}</para>"
-                    );
-                }
-
-                builder.AppendLine("    /// </summary>");
-                builder.AppendLine("    /// <param name=\"client\">The ObsWebSocketClient instance.</param>");
-                builder.AppendLine(
-                    "    /// <param name=\"capacity\">Events buffered before the oldest is dropped.</param>"
-                );
-                builder.AppendLine(
-                    "    /// <param name=\"cancellationToken\">Ends the enumeration and unsubscribes.</param>"
-                );
-                if (!string.IsNullOrWhiteSpace(eventDef.EventSubscription))
-                {
-                    builder.AppendLine(
-                        $"    /// <remarks>Requires the <c>{System.Security.SecurityElement.Escape(eventDef.EventSubscription)}</c> subscription.</remarks>"
-                    );
-                }
-
-                builder.AppendLine(
-                    $"    public static IAsyncEnumerable<{eventArgsTypeName}> {eventName}Stream("
-                );
-                builder.AppendLine("        this ObsWebSocketClient client,");
-                builder.AppendLine("        int capacity = EventStream.DefaultCapacity,");
-                builder.AppendLine("        CancellationToken cancellationToken = default)");
-                builder.AppendLine("    {");
-                builder.AppendLine("        ArgumentNullException.ThrowIfNull(client);");
-                builder.AppendLine($"        return EventStream.Create<{eventArgsTypeName}>(");
-                builder.AppendLine($"            handler => client.{eventName} += handler,");
-                builder.AppendLine($"            handler => client.{eventName} -= handler,");
-                builder.AppendLine("            capacity,");
-                builder.AppendLine("            cancellationToken);");
-                builder.AppendLine("    }");
-                builder.AppendLine();
+                builder.AppendLine($"public readonly partial struct {groupName}Group");
             }
-            catch (Exception ex)
+            else
             {
-                context.ReportDiagnostic(
-                    Diagnostic.Create(
-                        Diagnostics.IdentifierGenerationError,
-                        Location.None,
-                        eventDef.EventType,
-                        $"Generating event stream for {eventDef.EventType}",
-                        ex.Message
-                    )
+                builder.AppendLine(
+                    "/// <param name=\"client\">The client these events are observed on.</param>"
+                );
+                builder.AppendLine(
+                    $"public readonly partial struct {groupName}Group(ObsWebSocketClient client)"
                 );
             }
+
+            builder.AppendLine("{");
+
+            foreach (OBSEvent eventDef in group)
+            {
+                try
+                {
+                    string eventName = SanitizeIdentifier(eventDef.EventType);
+                    if (string.IsNullOrEmpty(eventName))
+                    {
+                        continue;
+                    }
+
+                    string eventArgsTypeName = $"{GeneratedEventArgsNamespace}.{eventName}EventArgs";
+
+                    builder.AppendLine("    /// <summary>");
+                    builder.AppendLine($"    /// Streams <c>{eventName}</c> events as they arrive.");
+                    if (!string.IsNullOrWhiteSpace(eventDef.Description))
+                    {
+                        builder.AppendLine(
+                            $"    /// <para>{FlattenDescription(eventDef.Description)}</para>"
+                        );
+                    }
+
+                    builder.AppendLine("    /// </summary>");
+                    builder.AppendLine(
+                        "    /// <param name=\"capacity\">Events buffered before the oldest is dropped.</param>"
+                    );
+                    builder.AppendLine(
+                        "    /// <param name=\"cancellationToken\">Ends the enumeration and unsubscribes.</param>"
+                    );
+                    if (!string.IsNullOrWhiteSpace(eventDef.EventSubscription))
+                    {
+                        builder.AppendLine(
+                            $"    /// <remarks>Requires the <c>{System.Security.SecurityElement.Escape(eventDef.EventSubscription)}</c> subscription.</remarks>"
+                        );
+                    }
+
+                    builder.AppendLine(
+                        $"    public IAsyncEnumerable<{eventArgsTypeName}> {eventName}Stream("
+                    );
+                    builder.AppendLine("        int capacity = EventStream.DefaultCapacity,");
+                    builder.AppendLine("        CancellationToken cancellationToken = default)");
+                    builder.AppendLine("    {");
+                    builder.AppendLine("        ObsWebSocketClient source = client;");
+                    builder.AppendLine($"        return EventStream.Create<{eventArgsTypeName}>(");
+                    builder.AppendLine($"            handler => source.{eventName} += handler,");
+                    builder.AppendLine($"            handler => source.{eventName} -= handler,");
+                    builder.AppendLine("            capacity,");
+                    builder.AppendLine("            cancellationToken);");
+                    builder.AppendLine("    }");
+                    builder.AppendLine();
+                }
+                catch (Exception ex)
+                {
+                    context.ReportDiagnostic(
+                        Diagnostic.Create(
+                            Diagnostics.IdentifierGenerationError,
+                            Location.None,
+                            eventDef.EventType,
+                            $"Generating event stream for {eventDef.EventType}",
+                            ex.Message
+                        )
+                    );
+                }
+            }
+
+            builder.AppendLine("}");
+            builder.AppendLine();
         }
-
-        builder.AppendLine("}");
 
         context.AddSource(
             "ObsWebSocketClient.EventStreams.g.cs",

--- a/ObsWebSocket.Codegen.Tasks/Generation/Emitter.Helpers.cs
+++ b/ObsWebSocket.Codegen.Tasks/Generation/Emitter.Helpers.cs
@@ -238,7 +238,7 @@ internal static partial class Emitter
                     // Map specifically named 'Object' field to Stub record
                     // Use the fully qualified name to avoid potential namespace conflicts
                     return ($"{GeneratedCommonNamespace}.SceneItemTransformStub?", false);
-                    // Add other specific 'Object' mappings here if needed in the future
+                // Add other specific 'Object' mappings here if needed in the future
             }
             // If not handled above, it falls through to the general 'Object'/'Any' handling below
         }

--- a/ObsWebSocket.Codegen.Tasks/Generation/Emitter.Helpers.cs
+++ b/ObsWebSocket.Codegen.Tasks/Generation/Emitter.Helpers.cs
@@ -244,10 +244,27 @@ internal static partial class Emitter
         }
 
         // --- Basic Type Mapping ---
+        string? numberType = null;
+        if (obsType == "Number")
+        {
+            numberType = NumericFieldTable.MapNumber(fieldName, out bool classified);
+            if (!classified)
+            {
+                context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        Diagnostics.UnclassifiedNumberField,
+                        Location.None,
+                        fieldName,
+                        parentDtoName
+                    )
+                );
+            }
+        }
+
         string? mappedType = obsType switch
         {
             "String" => "string",
-            "Number" => "double",
+            "Number" => numberType,
             "Boolean" => "bool",
             "Uuid" => "string",
             "Object" or "Any" => "System.Text.Json.JsonElement?", // Fallback for unhandled Object/Any

--- a/ObsWebSocket.Codegen.Tasks/Generation/Emitter.Hierarchy.cs
+++ b/ObsWebSocket.Codegen.Tasks/Generation/Emitter.Hierarchy.cs
@@ -88,7 +88,7 @@ internal static partial class Emitter
                     currentNode = newNode;
                 }
             }
-        NextFieldPass1:
+            NextFieldPass1:
             ;
         }
 

--- a/ObsWebSocket.Codegen.Tasks/Generation/Emitter.JsonContext.cs
+++ b/ObsWebSocket.Codegen.Tasks/Generation/Emitter.JsonContext.cs
@@ -19,7 +19,9 @@ internal static partial class Emitter
     {
         try
         {
-            StringBuilder builder = BuildSourceHeader("// Serialization Context: ObsWebSocketJsonContext");
+            StringBuilder builder = BuildSourceHeader(
+                "// Serialization Context: ObsWebSocketJsonContext"
+            );
 
             _ = builder.AppendLine("using System.Collections.Generic;");
             _ = builder.AppendLine("using System.Text.Json;");
@@ -34,16 +36,26 @@ internal static partial class Emitter
             _ = builder.AppendLine();
             _ = builder.AppendLine("[JsonSourceGenerationOptions(");
             _ = builder.AppendLine("    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,");
-            _ = builder.AppendLine("    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]");
+            _ = builder.AppendLine(
+                "    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]"
+            );
 
             // Fixed protocol wrapper and payload types.
             _ = builder.AppendLine("[JsonSerializable(typeof(OutgoingMessage<RequestPayload>))]");
             _ = builder.AppendLine("[JsonSerializable(typeof(OutgoingMessage<IdentifyPayload>))]");
-            _ = builder.AppendLine("[JsonSerializable(typeof(OutgoingMessage<ReidentifyPayload>))]");
-            _ = builder.AppendLine("[JsonSerializable(typeof(OutgoingMessage<RequestBatchPayload>))]");
+            _ = builder.AppendLine(
+                "[JsonSerializable(typeof(OutgoingMessage<ReidentifyPayload>))]"
+            );
+            _ = builder.AppendLine(
+                "[JsonSerializable(typeof(OutgoingMessage<RequestBatchPayload>))]"
+            );
             _ = builder.AppendLine("[JsonSerializable(typeof(IncomingMessage<JsonElement>))]");
-            _ = builder.AppendLine("[JsonSerializable(typeof(RequestResponsePayload<JsonElement>))]");
-            _ = builder.AppendLine("[JsonSerializable(typeof(RequestBatchResponsePayload<JsonElement>))]");
+            _ = builder.AppendLine(
+                "[JsonSerializable(typeof(RequestResponsePayload<JsonElement>))]"
+            );
+            _ = builder.AppendLine(
+                "[JsonSerializable(typeof(RequestBatchResponsePayload<JsonElement>))]"
+            );
             _ = builder.AppendLine("[JsonSerializable(typeof(EventPayloadBase<JsonElement>))]");
             _ = builder.AppendLine("[JsonSerializable(typeof(HelloPayload))]");
             _ = builder.AppendLine("[JsonSerializable(typeof(IdentifiedPayload))]");
@@ -111,7 +123,9 @@ internal static partial class Emitter
                 );
             }
 
-            _ = builder.AppendLine("internal sealed partial class ObsWebSocketJsonContext : JsonSerializerContext");
+            _ = builder.AppendLine(
+                "internal sealed partial class ObsWebSocketJsonContext : JsonSerializerContext"
+            );
             _ = builder.AppendLine("{");
             _ = builder.AppendLine("}");
 

--- a/ObsWebSocket.Codegen.Tasks/Generation/Emitter.MsgPackResolver.cs
+++ b/ObsWebSocket.Codegen.Tasks/Generation/Emitter.MsgPackResolver.cs
@@ -105,12 +105,18 @@ internal static partial class Emitter
 
             context.AddSource(
                 "ObsWebSocketMsgPackResolver.RequestTypes.g.cs",
-                SourceText.From(BuildKnownTypeSource("IsRequestType", requestTypeNames), Encoding.UTF8)
+                SourceText.From(
+                    BuildKnownTypeSource("IsRequestType", requestTypeNames),
+                    Encoding.UTF8
+                )
             );
 
             context.AddSource(
                 "ObsWebSocketMsgPackResolver.ResponseTypes.g.cs",
-                SourceText.From(BuildKnownTypeSource("IsResponseType", responseTypeNames), Encoding.UTF8)
+                SourceText.From(
+                    BuildKnownTypeSource("IsResponseType", responseTypeNames),
+                    Encoding.UTF8
+                )
             );
 
             context.AddSource(
@@ -120,7 +126,10 @@ internal static partial class Emitter
 
             context.AddSource(
                 "ObsWebSocketMsgPackResolver.NestedTypes.g.cs",
-                SourceText.From(BuildKnownTypeSource("IsNestedType", nestedTypeNames), Encoding.UTF8)
+                SourceText.From(
+                    BuildKnownTypeSource("IsNestedType", nestedTypeNames),
+                    Encoding.UTF8
+                )
             );
         }
         catch (Exception ex)
@@ -139,7 +148,9 @@ internal static partial class Emitter
 
     private static string BuildResolverRootSource()
     {
-        StringBuilder builder = BuildSourceHeader("// Serialization Resolver: ObsWebSocketMsgPackResolver");
+        StringBuilder builder = BuildSourceHeader(
+            "// Serialization Resolver: ObsWebSocketMsgPackResolver"
+        );
         builder.AppendLine("using System;");
         builder.AppendLine("using MessagePack;");
         builder.AppendLine("using MessagePack.Formatters;");
@@ -162,7 +173,9 @@ internal static partial class Emitter
         builder.AppendLine("    private ObsWebSocketMsgPackResolver() { }");
         builder.AppendLine();
         builder.AppendLine("    /// <summary>");
-        builder.AppendLine("    /// Gets a formatter for <typeparamref name=\"T\"/> when this resolver supports it.");
+        builder.AppendLine(
+            "    /// Gets a formatter for <typeparamref name=\"T\"/> when this resolver supports it."
+        );
         builder.AppendLine("    /// </summary>");
         builder.AppendLine(
             "    public IMessagePackFormatter<T>? GetFormatter<T>() => ObsWebSocketMsgPackResolverCore.GetFormatter<T>();"
@@ -179,7 +192,9 @@ internal static partial class Emitter
         builder.AppendLine("            return null;");
         builder.AppendLine("        }");
         builder.AppendLine();
-        builder.AppendLine("        return SourceGeneratedFormatterResolver.Instance.GetFormatter<T>();");
+        builder.AppendLine(
+            "        return SourceGeneratedFormatterResolver.Instance.GetFormatter<T>();"
+        );
         builder.AppendLine("    }");
         builder.AppendLine();
         builder.AppendLine("    private static bool IsKnownType(Type type)");

--- a/ObsWebSocket.Codegen.Tasks/Generation/Emitter.cs
+++ b/ObsWebSocket.Codegen.Tasks/Generation/Emitter.cs
@@ -248,7 +248,11 @@ internal static partial class Emitter
         {
             string[] parts = identifier.Split('_');
             int i = 0;
-            while (i < shared && i < parts.Length && string.Equals(parts[i], first[i], StringComparison.Ordinal))
+            while (
+                i < shared
+                && i < parts.Length
+                && string.Equals(parts[i], first[i], StringComparison.Ordinal)
+            )
             {
                 i++;
             }
@@ -317,7 +321,9 @@ internal static partial class Emitter
 
         string prefix = FindCommonMemberPrefix([.. members.Select(m => m.Member)]);
 
-        StringBuilder builder = BuildSourceHeader("// Type: Typed Enum for a string-valued protocol enum");
+        StringBuilder builder = BuildSourceHeader(
+            "// Type: Typed Enum for a string-valued protocol enum"
+        );
         builder.AppendLine("using System;");
         builder.AppendLine("using System.Text.Json.Serialization;");
         builder.AppendLine();
@@ -328,7 +334,9 @@ internal static partial class Emitter
             $"Typed form of the {constantsClass} protocol enum. Use <see cref=\"{enumName}Extensions.ToWireValue\"/> to obtain the string OBS expects.",
             0
         );
-        builder.AppendLine("/// <remarks>Generated from OBS WebSocket Protocol definition.</remarks>");
+        builder.AppendLine(
+            "/// <remarks>Generated from OBS WebSocket Protocol definition.</remarks>"
+        );
         builder.AppendLine($"public enum {enumName}");
         builder.AppendLine("{");
         foreach ((string memberIdentifier, string wire) in members)
@@ -340,7 +348,9 @@ internal static partial class Emitter
             }
 
             string memberName = SnakeToPascalCase(shortName);
-            builder.AppendLine($"    /// <summary>Maps to <c>{System.Security.SecurityElement.Escape(wire)}</c>.</summary>");
+            builder.AppendLine(
+                $"    /// <summary>Maps to <c>{System.Security.SecurityElement.Escape(wire)}</c>.</summary>"
+            );
             builder.AppendLine($"    [JsonStringEnumMemberName(\"{wire}\")]");
             builder.AppendLine($"    {memberName},");
             builder.AppendLine();
@@ -352,8 +362,12 @@ internal static partial class Emitter
         AppendXmlDocSummary(builder, $"Wire-value conversions for <see cref=\"{enumName}\"/>.", 0);
         builder.AppendLine($"public static class {enumName}Extensions");
         builder.AppendLine("{");
-        builder.AppendLine($"    /// <summary>Returns the protocol string OBS expects for this value.</summary>");
-        builder.AppendLine($"    public static string ToWireValue(this {enumName} value) => value switch");
+        builder.AppendLine(
+            $"    /// <summary>Returns the protocol string OBS expects for this value.</summary>"
+        );
+        builder.AppendLine(
+            $"    public static string ToWireValue(this {enumName} value) => value switch"
+        );
         builder.AppendLine("    {");
         foreach ((string memberIdentifier, string wire) in members)
         {
@@ -363,14 +377,22 @@ internal static partial class Emitter
                 shortName = shortName.Substring(prefix.Length);
             }
 
-            builder.AppendLine($"        {enumName}.{SnakeToPascalCase(shortName)} => {constantsClass}.{memberIdentifier},");
+            builder.AppendLine(
+                $"        {enumName}.{SnakeToPascalCase(shortName)} => {constantsClass}.{memberIdentifier},"
+            );
         }
 
-        builder.AppendLine($"        _ => throw new ArgumentOutOfRangeException(nameof(value), value, null),");
+        builder.AppendLine(
+            $"        _ => throw new ArgumentOutOfRangeException(nameof(value), value, null),"
+        );
         builder.AppendLine("    };");
         builder.AppendLine();
-        builder.AppendLine($"    /// <summary>Parses a protocol string into a <see cref=\"{enumName}\"/>, returning null when unrecognised.</summary>");
-        builder.AppendLine($"    public static {enumName}? FromWireValue(string? value) => value switch");
+        builder.AppendLine(
+            $"    /// <summary>Parses a protocol string into a <see cref=\"{enumName}\"/>, returning null when unrecognised.</summary>"
+        );
+        builder.AppendLine(
+            $"    public static {enumName}? FromWireValue(string? value) => value switch"
+        );
         builder.AppendLine("    {");
         foreach ((string memberIdentifier, string wire) in members)
         {
@@ -380,7 +402,9 @@ internal static partial class Emitter
                 shortName = shortName.Substring(prefix.Length);
             }
 
-            builder.AppendLine($"        {constantsClass}.{memberIdentifier} => {enumName}.{SnakeToPascalCase(shortName)},");
+            builder.AppendLine(
+                $"        {constantsClass}.{memberIdentifier} => {enumName}.{SnakeToPascalCase(shortName)},"
+            );
         }
 
         builder.AppendLine("        _ => null,");
@@ -712,7 +736,9 @@ internal static partial class Emitter
                 $"/// Requests in the <c>{System.Security.SecurityElement.Escape(group.Key)}</c> category."
             );
             builder.AppendLine("/// </summary>");
-            builder.AppendLine("/// <param name=\"client\">The client these requests are sent on.</param>");
+            builder.AppendLine(
+                "/// <param name=\"client\">The client these requests are sent on.</param>"
+            );
             builder.AppendLine(
                 $"public readonly partial struct {groupName}Group(ObsWebSocketClient client)"
             );
@@ -744,7 +770,9 @@ internal static partial class Emitter
         }
 
         builder.AppendLine("/// <summary>");
-        builder.AppendLine("/// Exposes the request categories defined by the OBS WebSocket protocol.");
+        builder.AppendLine(
+            "/// Exposes the request categories defined by the OBS WebSocket protocol."
+        );
         builder.AppendLine("/// </summary>");
         builder.AppendLine("public static class ObsWebSocketClientExtensions");
         builder.AppendLine("{");
@@ -757,9 +785,7 @@ internal static partial class Emitter
                 $"        /// Requests in the <c>{System.Security.SecurityElement.Escape(category)}</c> category."
             );
             builder.AppendLine("        /// </summary>");
-            builder.AppendLine(
-                $"        public {groupName}Group {groupName} => new(client);"
-            );
+            builder.AppendLine($"        public {groupName}Group {groupName} => new(client);");
             builder.AppendLine("    }");
             builder.AppendLine();
         }
@@ -828,15 +854,11 @@ internal static partial class Emitter
         {
             if (baseCallMethod == "CallAsyncValue")
             {
-                builder.Append(
-                    $"Yields the <see cref=\"{responseDtoType}\"/> response data."
-                );
+                builder.Append($"Yields the <see cref=\"{responseDtoType}\"/> response data.");
             }
             else // Assumed CallAsync (reference type)
             {
-                builder.Append(
-                    $"Yields the <see cref=\"{responseDtoType}\"/> response data."
-                );
+                builder.Append($"Yields the <see cref=\"{responseDtoType}\"/> response data.");
             }
         }
         else // No response data
@@ -876,9 +898,7 @@ internal static partial class Emitter
             );
         }
 
-        builder.AppendLine(
-            $"    public async {returnType} {methodName}({parameterList})"
-        );
+        builder.AppendLine($"    public async {returnType} {methodName}({parameterList})");
         builder.AppendLine("    {");
         // Method Body
         string callParams = hasRequestData ? requestParamName : "null";

--- a/ObsWebSocket.Codegen.Tasks/Generation/Emitter.cs
+++ b/ObsWebSocket.Codegen.Tasks/Generation/Emitter.cs
@@ -714,7 +714,7 @@ internal static partial class Emitter
             builder.AppendLine("/// </summary>");
             builder.AppendLine("/// <param name=\"client\">The client these requests are sent on.</param>");
             builder.AppendLine(
-                $"public readonly partial struct {groupName}RequestGroup(ObsWebSocketClient client)"
+                $"public readonly partial struct {groupName}Group(ObsWebSocketClient client)"
             );
             builder.AppendLine("{");
 
@@ -758,7 +758,7 @@ internal static partial class Emitter
             );
             builder.AppendLine("        /// </summary>");
             builder.AppendLine(
-                $"        public {groupName}RequestGroup {groupName} => new(client);"
+                $"        public {groupName}Group {groupName} => new(client);"
             );
             builder.AppendLine("    }");
             builder.AppendLine();

--- a/ObsWebSocket.Codegen.Tasks/Generation/Emitter.cs
+++ b/ObsWebSocket.Codegen.Tasks/Generation/Emitter.cs
@@ -48,8 +48,12 @@ internal static partial class Emitter
                 {
                     string suffix =
                         valueKind == EnumValueKind.Numeric ? ".Enum.g.cs" : ".Class.g.cs";
+                    string fileStem =
+                        valueKind == EnumValueKind.Numeric
+                            ? MapEnumTypeName(SanitizeIdentifier(enumDef.EnumType))
+                            : SanitizeIdentifier(enumDef.EnumType);
                     context.AddSource(
-                        $"{SanitizeIdentifier(enumDef.EnumType)}{suffix}",
+                        $"{fileStem}{suffix}",
                         SourceText.From(source, Encoding.UTF8)
                     );
                 }
@@ -88,7 +92,7 @@ internal static partial class Emitter
     /// </summary>
     private static string? GenerateNumericEnumSource(EnumDefinition enumDef, string underlyingType)
     {
-        string enumName = SanitizeIdentifier(enumDef.EnumType);
+        string enumName = MapEnumTypeName(SanitizeIdentifier(enumDef.EnumType));
         StringBuilder builder = BuildSourceHeader($"// Type: Numeric Enum ({underlyingType})");
         builder.AppendLine($"namespace {GeneratedEnumsNamespace};");
         builder.AppendLine();
@@ -221,6 +225,19 @@ internal static partial class Emitter
         builder.AppendLine("}");
         return builder.ToString();
     }
+
+    /// <summary>
+    /// Renames protocol enums whose name already belongs to a message type, so a caller writing a
+    /// catch filter does not have to disambiguate two types called <c>RequestStatus</c> in
+    /// neighbouring namespaces.
+    /// </summary>
+    private static string MapEnumTypeName(string enumTypeName) =>
+        enumTypeName switch
+        {
+            // Protocol.RequestStatus is the record carried on a response; this is the code on it.
+            "RequestStatus" => "RequestStatusCode",
+            _ => enumTypeName,
+        };
 
     /// <summary>
     /// Drops the leading <c>Obs</c> from a protocol enum type name, so <c>ObsMediaInputAction</c>

--- a/ObsWebSocket.Codegen.Tasks/Generation/GenerationContext.cs
+++ b/ObsWebSocket.Codegen.Tasks/Generation/GenerationContext.cs
@@ -26,13 +26,19 @@ internal sealed class GenerationContext
     private static string ResolveOutputPath(string hintName, string source)
     {
         string fileName = Path.GetFileName(hintName);
-        string namespaceLine = source
-            .Split('\n')
-            .Select(line => line.Trim())
-            .FirstOrDefault(line => line.StartsWith("namespace ", StringComparison.Ordinal))
+        string namespaceLine =
+            source
+                .Split('\n')
+                .Select(line => line.Trim())
+                .FirstOrDefault(line => line.StartsWith("namespace ", StringComparison.Ordinal))
             ?? string.Empty;
 
-        if (namespaceLine.Contains("ObsWebSocket.Core.Protocol.Common.NestedTypes", StringComparison.Ordinal))
+        if (
+            namespaceLine.Contains(
+                "ObsWebSocket.Core.Protocol.Common.NestedTypes",
+                StringComparison.Ordinal
+            )
+        )
         {
             return Path.Combine("Protocol", "Common", "NestedTypes", fileName);
         }
@@ -42,7 +48,9 @@ internal sealed class GenerationContext
             return Path.Combine("Protocol", "Requests", fileName);
         }
 
-        if (namespaceLine.Contains("ObsWebSocket.Core.Protocol.Responses", StringComparison.Ordinal))
+        if (
+            namespaceLine.Contains("ObsWebSocket.Core.Protocol.Responses", StringComparison.Ordinal)
+        )
         {
             return Path.Combine("Protocol", "Responses", fileName);
         }
@@ -52,15 +60,20 @@ internal sealed class GenerationContext
             return Path.Combine("Protocol", "Events", fileName);
         }
 
-        if (namespaceLine.Contains("ObsWebSocket.Core.Protocol.Generated", StringComparison.Ordinal))
+        if (
+            namespaceLine.Contains("ObsWebSocket.Core.Protocol.Generated", StringComparison.Ordinal)
+        )
         {
             return Path.Combine("Protocol", "Generated", fileName);
         }
 
-        return namespaceLine.Contains("ObsWebSocket.Core.Events.Generated", StringComparison.Ordinal)
-            ? Path.Combine("Events", "Generated", fileName)
+        return namespaceLine.Contains(
+                "ObsWebSocket.Core.Events.Generated",
+                StringComparison.Ordinal
+            )
+                ? Path.Combine("Events", "Generated", fileName)
             : namespaceLine.Contains("ObsWebSocket.Core.Serialization", StringComparison.Ordinal)
-            ? Path.Combine("Serialization", fileName)
+                ? Path.Combine("Serialization", fileName)
             : Path.Combine("Client", fileName);
     }
 }

--- a/ObsWebSocket.Codegen.Tasks/Generation/NumericFieldTable.cs
+++ b/ObsWebSocket.Codegen.Tasks/Generation/NumericFieldTable.cs
@@ -1,0 +1,112 @@
+// ObsWebSocket.Codegen.Tasks/Generation/NumericFieldTable.cs
+namespace ObsWebSocket.Codegen.Tasks.Generation;
+
+/// <summary>
+/// Decides which of the protocol's <c>Number</c> fields are whole numbers.
+/// </summary>
+/// <remarks>
+/// The protocol has one numeric type because JSON has one numeric type, so <c>sceneItemId</c> and
+/// <c>inputVolumeMul</c> are indistinguishable in the definition: both are <c>Number</c> with a
+/// <c>&gt;= 0</c> restriction. This table is written out by hand rather than inferred from the
+/// field name, because a rule that guesses wrong on a volume field truncates it silently, while a
+/// field missing from the table only stays <c>double</c>, which is what it would have been anyway.
+/// A refresh that introduces an unlisted <c>Number</c> field reports OBSWSGEN012 so it gets
+/// classified deliberately instead of drifting in.
+/// </remarks>
+internal static class NumericFieldTable
+{
+    /// <summary>Whole-number fields whose values fit comfortably in 32 bits.</summary>
+    private static readonly HashSet<string> s_int32Fields = new(StringComparer.Ordinal)
+    {
+        // Identity and ordering.
+        "sceneItemId",
+        "sceneItemIndex",
+        "filterIndex",
+        "monitorIndex",
+        "position",
+        "searchOffset",
+        // Resolutions, in pixels.
+        "baseWidth",
+        "baseHeight",
+        "outputWidth",
+        "outputHeight",
+        "imageWidth",
+        "imageHeight",
+        "imageCompressionQuality",
+        // Frame rate, expressed as a fraction.
+        "fpsNumerator",
+        "fpsDenominator",
+        // Durations and offsets that OBS reports in whole milliseconds or frames.
+        "inputAudioSyncOffset",
+        "transitionDuration",
+        "sleepFrames",
+        "sleepMillis",
+        // Counters.
+        "renderSkippedFrames",
+        "renderTotalFrames",
+        "outputSkippedFrames",
+        "outputTotalFrames",
+        "webSocketSessionIncomingMessages",
+        "webSocketSessionOutgoingMessages",
+        // Protocol version.
+        "rpcVersion",
+    };
+
+    /// <summary>
+    /// Whole-number fields that can exceed 32 bits: byte counts, millisecond durations over a long
+    /// session, and the input capability bitflag, which OBS defines as an unsigned 32 bit mask.
+    /// </summary>
+    private static readonly HashSet<string> s_int64Fields = new(StringComparer.Ordinal)
+    {
+        "outputBytes",
+        "outputDuration",
+        "mediaCursor",
+        "mediaCursorOffset",
+        "mediaDuration",
+        "inputKindCaps",
+    };
+
+    /// <summary>
+    /// Fields deliberately left fractional, listed so an unclassified field is distinguishable
+    /// from one that was considered and left alone.
+    /// </summary>
+    private static readonly HashSet<string> s_doubleFields = new(StringComparer.Ordinal)
+    {
+        "inputVolumeMul",
+        "inputVolumeDb",
+        "inputAudioBalance",
+        "transitionCursor",
+        "outputCongestion",
+        "cpuUsage",
+        "memoryUsage",
+        "availableDiskSpace",
+        "activeFps",
+        "averageFrameRenderTime",
+    };
+
+    /// <summary>
+    /// Returns the C# type for a protocol <c>Number</c> field.
+    /// </summary>
+    /// <param name="fieldName">The protocol field name, matched case sensitively.</param>
+    /// <param name="classified">
+    /// Whether the field appears in the table at all. An unclassified field still maps to
+    /// <c>double</c>; the flag lets the caller report it.
+    /// </param>
+    public static string MapNumber(string fieldName, out bool classified)
+    {
+        if (s_int32Fields.Contains(fieldName))
+        {
+            classified = true;
+            return "int";
+        }
+
+        if (s_int64Fields.Contains(fieldName))
+        {
+            classified = true;
+            return "long";
+        }
+
+        classified = s_doubleFields.Contains(fieldName);
+        return "double";
+    }
+}

--- a/ObsWebSocket.Codegen.Tasks/Generation/ProtocolCodeGenerator.cs
+++ b/ObsWebSocket.Codegen.Tasks/Generation/ProtocolCodeGenerator.cs
@@ -12,15 +12,27 @@ internal static class ProtocolCodeGenerator
         NumberHandling = JsonNumberHandling.AllowReadingFromString,
     };
 
-    public static (IReadOnlyDictionary<string, string> Sources, IReadOnlyList<Diagnostic> Diagnostics) Generate(string protocolJson)
+    public static (
+        IReadOnlyDictionary<string, string> Sources,
+        IReadOnlyList<Diagnostic> Diagnostics
+    ) Generate(string protocolJson)
     {
         ArgumentException.ThrowIfNullOrEmpty(protocolJson);
 
         GenerationContext context = new();
-        ProtocolDefinition? protocol = JsonSerializer.Deserialize<ProtocolDefinition>(protocolJson, s_jsonOptions);
+        ProtocolDefinition? protocol = JsonSerializer.Deserialize<ProtocolDefinition>(
+            protocolJson,
+            s_jsonOptions
+        );
         if (protocol is null)
         {
-            context.ReportDiagnostic(Diagnostic.Create(Diagnostics.ProtocolJsonParseError, Location.None, "Deserialization returned null."));
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    Diagnostics.ProtocolJsonParseError,
+                    Location.None,
+                    "Deserialization returned null."
+                )
+            );
             return (context.Sources, context.Diagnostics);
         }
 

--- a/ObsWebSocket.Codegen.Tasks/ObsWebSocket.Codegen.Tasks.csproj
+++ b/ObsWebSocket.Codegen.Tasks/ObsWebSocket.Codegen.Tasks.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -12,5 +11,4 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.3.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.6.0" />
   </ItemGroup>
-
 </Project>

--- a/ObsWebSocket.Codegen.Tasks/ProtocolCodegenRunner.cs
+++ b/ObsWebSocket.Codegen.Tasks/ProtocolCodegenRunner.cs
@@ -6,7 +6,8 @@ namespace ObsWebSocket.Codegen.Tasks;
 
 internal static class ProtocolCodegenRunner
 {
-    private const string ProtocolUrl = "https://raw.githubusercontent.com/obsproject/obs-websocket/master/docs/generated/protocol.json";
+    private const string ProtocolUrl =
+        "https://raw.githubusercontent.com/obsproject/obs-websocket/master/docs/generated/protocol.json";
 
     public static async Task<int> GenerateAsync(
         string protocolPath,
@@ -34,15 +35,24 @@ internal static class ProtocolCodegenRunner
                     return 2;
                 }
 
-                await DownloadProtocolAsync(fullProtocolPath, cancellationToken).ConfigureAwait(false);
+                await DownloadProtocolAsync(fullProtocolPath, cancellationToken)
+                    .ConfigureAwait(false);
                 logInfo?.Invoke($"Downloaded protocol.json to '{fullProtocolPath}'.");
             }
 
-            string protocolJson = await File.ReadAllTextAsync(fullProtocolPath, cancellationToken).ConfigureAwait(false);
-            (IReadOnlyDictionary<string, string> sources, IReadOnlyList<Diagnostic> diagnostics) = ProtocolCodeGenerator.Generate(protocolJson);
+            string protocolJson = await File.ReadAllTextAsync(fullProtocolPath, cancellationToken)
+                .ConfigureAwait(false);
+            (IReadOnlyDictionary<string, string> sources, IReadOnlyList<Diagnostic> diagnostics) =
+                ProtocolCodeGenerator.Generate(protocolJson);
 
-            Diagnostic[] errors = [.. diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)];
-            Diagnostic[] warnings = [.. diagnostics.Where(d => d.Severity == DiagnosticSeverity.Warning)];
+            Diagnostic[] errors =
+            [
+                .. diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error),
+            ];
+            Diagnostic[] warnings =
+            [
+                .. diagnostics.Where(d => d.Severity == DiagnosticSeverity.Warning),
+            ];
             Diagnostic[] infos = [.. diagnostics.Where(d => d.Severity == DiagnosticSeverity.Info)];
             if (errors.Length > 0)
             {
@@ -79,27 +89,50 @@ internal static class ProtocolCodegenRunner
         }
     }
 
-    private static async Task DownloadProtocolAsync(string protocolPath, CancellationToken cancellationToken)
+    private static async Task DownloadProtocolAsync(
+        string protocolPath,
+        CancellationToken cancellationToken
+    )
     {
         _ = Directory.CreateDirectory(Path.GetDirectoryName(protocolPath)!);
         using HttpClient http = new();
-        using HttpResponseMessage response = await http.GetAsync(ProtocolUrl, cancellationToken).ConfigureAwait(false);
+        using HttpResponseMessage response = await http.GetAsync(ProtocolUrl, cancellationToken)
+            .ConfigureAwait(false);
         _ = response.EnsureSuccessStatusCode();
-        string protocolJson = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await File.WriteAllTextAsync(protocolPath, protocolJson, new UTF8Encoding(false), cancellationToken).ConfigureAwait(false);
+        string protocolJson = await response
+            .Content.ReadAsStringAsync(cancellationToken)
+            .ConfigureAwait(false);
+        await File.WriteAllTextAsync(
+                protocolPath,
+                protocolJson,
+                new UTF8Encoding(false),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
     }
 
-    private static void WriteSources(string outputDirectory, IReadOnlyDictionary<string, string> sources)
+    private static void WriteSources(
+        string outputDirectory,
+        IReadOnlyDictionary<string, string> sources
+    )
     {
         _ = Directory.CreateDirectory(outputDirectory);
 
-        HashSet<string> generatedRelativePaths = sources.Keys
-            .Select(NormalizeRelativePath)
+        HashSet<string> generatedRelativePaths = sources
+            .Keys.Select(NormalizeRelativePath)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        foreach (string existingFile in Directory.GetFiles(outputDirectory, "*.g.cs", SearchOption.AllDirectories))
+        foreach (
+            string existingFile in Directory.GetFiles(
+                outputDirectory,
+                "*.g.cs",
+                SearchOption.AllDirectories
+            )
+        )
         {
-            string relativePath = NormalizeRelativePath(Path.GetRelativePath(outputDirectory, existingFile));
+            string relativePath = NormalizeRelativePath(
+                Path.GetRelativePath(outputDirectory, existingFile)
+            );
             if (!generatedRelativePaths.Contains(relativePath))
             {
                 File.Delete(existingFile);
@@ -115,7 +148,7 @@ internal static class ProtocolCodegenRunner
         }
     }
 
-    private static string NormalizeRelativePath(string path) => path
-            .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
+    private static string NormalizeRelativePath(string path) =>
+        path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
             .TrimStart(Path.DirectorySeparatorChar);
 }

--- a/ObsWebSocket.Core/AuthenticationFailureException.cs
+++ b/ObsWebSocket.Core/AuthenticationFailureException.cs
@@ -31,5 +31,11 @@ public sealed class AuthenticationFailureException : ObsWebSocketException
     /// a specified error message and a reference to the inner exception that caused this one.
     /// </summary>
     public AuthenticationFailureException(string message, Exception? innerException)
-        : base(message, innerException ?? new InvalidOperationException("OBS authentication failed without a more specific cause.")) { }
+        : base(
+            message,
+            innerException
+                ?? new InvalidOperationException(
+                    "OBS authentication failed without a more specific cause."
+                )
+        ) { }
 }

--- a/ObsWebSocket.Core/BatchRef.cs
+++ b/ObsWebSocket.Core/BatchRef.cs
@@ -18,8 +18,7 @@ public readonly record struct BatchRef<TResponse>(int Index)
 {
     /// <summary>Drops the response type, leaving a plain reference.</summary>
     /// <param name="reference">The reference to convert.</param>
-    public static implicit operator BatchRef(BatchRef<TResponse> reference) =>
-        new(reference.Index);
+    public static implicit operator BatchRef(BatchRef<TResponse> reference) => new(reference.Index);
 
     /// <summary>Drops the response type, leaving a plain reference.</summary>
     public BatchRef ToBatchRef() => new(Index);

--- a/ObsWebSocket.Core/BatchResultExtensions.cs
+++ b/ObsWebSocket.Core/BatchResultExtensions.cs
@@ -11,6 +11,13 @@ namespace ObsWebSocket.Core;
 /// <see cref="ObsWebSocketClient.CallBatchAsync(IEnumerable{BatchRequestItem}, Protocol.Generated.RequestBatchExecutionType?, bool?, int?, CancellationToken)"/>
 /// returns results whose payloads are transport-shaped, because a batch may mix request types.
 /// These helpers turn a result into the response record for its request.
+/// <para>
+/// They exist for that low level path. A batch built with <see cref="ObsBatchBuilder"/> comes back
+/// as <see cref="BatchResults"/>, which addresses results by the reference the builder handed out
+/// and carries its own <c>AllSucceeded</c> and <c>GetFailures</c>. Those members win over the
+/// extensions of the same name here, so reaching for a builder-built batch gets the typed path
+/// either way; prefer it, and use these when holding a raw result list.
+/// </para>
 /// </remarks>
 public static class BatchResultExtensions
 {

--- a/ObsWebSocket.Core/BatchResultExtensions.cs
+++ b/ObsWebSocket.Core/BatchResultExtensions.cs
@@ -84,7 +84,8 @@ public static class BatchResultExtensions
             );
 #endif
         }
-        catch (Exception ex) when (ex is JsonException or InvalidOperationException or NotSupportedException)
+        catch (Exception ex)
+            when (ex is JsonException or InvalidOperationException or NotSupportedException)
         {
             throw new ObsWebSocketSerializationException(
                 $"Failed to read batch result for '{result.RequestType}' as {typeof(TResponse).Name}.",

--- a/ObsWebSocket.Core/ConnectionAttemptFailedException.cs
+++ b/ObsWebSocket.Core/ConnectionAttemptFailedException.cs
@@ -26,5 +26,11 @@ public sealed class ConnectionAttemptFailedException : ObsWebSocketException
     /// with a specified error message and a reference to the inner exception that caused this one.
     /// </summary>
     public ConnectionAttemptFailedException(string message, Exception? innerException)
-        : base(message, innerException ?? new InvalidOperationException("OBS connection attempt failed without a more specific cause.")) { }
+        : base(
+            message,
+            innerException
+                ?? new InvalidOperationException(
+                    "OBS connection attempt failed without a more specific cause."
+                )
+        ) { }
 }

--- a/ObsWebSocket.Core/Generated/Client/ObsWebSocketClient.EventStreams.g.cs
+++ b/ObsWebSocket.Core/Generated/Client/ObsWebSocketClient.EventStreams.g.cs
@@ -12,28 +12,27 @@ using ObsWebSocket.Core.Events.Generated;
 namespace ObsWebSocket.Core;
 
 /// <summary>
-/// Observes OBS events as async sequences. Each accessor subscribes for the lifetime
-/// of the enumeration and unsubscribes when it ends, so the caller never manages handlers.
+/// Events in the <c>canvases</c> category, as async sequences.
+/// Each accessor subscribes for the lifetime of the enumeration and unsubscribes
+/// when it ends, so the caller never manages handlers.
 /// </summary>
-public static class ObsWebSocketClientEventStreams
+public readonly partial struct CanvasesGroup
 {
     /// <summary>
     /// Streams <c>CanvasCreated</c> events as they arrive.
     /// <para>A new canvas has been created.</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>Canvases</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CanvasCreatedEventArgs> CanvasCreatedStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CanvasCreatedEventArgs> CanvasCreatedStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.CanvasCreatedEventArgs>(
-            handler => client.CanvasCreated += handler,
-            handler => client.CanvasCreated -= handler,
+            handler => source.CanvasCreated += handler,
+            handler => source.CanvasCreated -= handler,
             capacity,
             cancellationToken);
     }
@@ -42,19 +41,17 @@ public static class ObsWebSocketClientEventStreams
     /// Streams <c>CanvasRemoved</c> events as they arrive.
     /// <para>A canvas has been removed.</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>Canvases</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CanvasRemovedEventArgs> CanvasRemovedStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CanvasRemovedEventArgs> CanvasRemovedStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.CanvasRemovedEventArgs>(
-            handler => client.CanvasRemoved += handler,
-            handler => client.CanvasRemoved -= handler,
+            handler => source.CanvasRemoved += handler,
+            handler => source.CanvasRemoved -= handler,
             capacity,
             cancellationToken);
     }
@@ -63,40 +60,45 @@ public static class ObsWebSocketClientEventStreams
     /// Streams <c>CanvasNameChanged</c> events as they arrive.
     /// <para>The name of a canvas has changed.</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>Canvases</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CanvasNameChangedEventArgs> CanvasNameChangedStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CanvasNameChangedEventArgs> CanvasNameChangedStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.CanvasNameChangedEventArgs>(
-            handler => client.CanvasNameChanged += handler,
-            handler => client.CanvasNameChanged -= handler,
+            handler => source.CanvasNameChanged += handler,
+            handler => source.CanvasNameChanged -= handler,
             capacity,
             cancellationToken);
     }
 
+}
+
+/// <summary>
+/// Events in the <c>config</c> category, as async sequences.
+/// Each accessor subscribes for the lifetime of the enumeration and unsubscribes
+/// when it ends, so the caller never manages handlers.
+/// </summary>
+public readonly partial struct ConfigGroup
+{
     /// <summary>
     /// Streams <c>CurrentSceneCollectionChanging</c> events as they arrive.
     /// <para>The current scene collection has begun changing. Note: We recommend using this event to trigger a pause of all polling requests, as performing any requests during a scene collection change is considered undefined behavior and can cause crashes!</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>Config</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CurrentSceneCollectionChangingEventArgs> CurrentSceneCollectionChangingStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CurrentSceneCollectionChangingEventArgs> CurrentSceneCollectionChangingStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.CurrentSceneCollectionChangingEventArgs>(
-            handler => client.CurrentSceneCollectionChanging += handler,
-            handler => client.CurrentSceneCollectionChanging -= handler,
+            handler => source.CurrentSceneCollectionChanging += handler,
+            handler => source.CurrentSceneCollectionChanging -= handler,
             capacity,
             cancellationToken);
     }
@@ -105,19 +107,17 @@ public static class ObsWebSocketClientEventStreams
     /// Streams <c>CurrentSceneCollectionChanged</c> events as they arrive.
     /// <para>The current scene collection has changed. Note: If polling has been paused during `CurrentSceneCollectionChanging`, this is the que to restart polling.</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>Config</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CurrentSceneCollectionChangedEventArgs> CurrentSceneCollectionChangedStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CurrentSceneCollectionChangedEventArgs> CurrentSceneCollectionChangedStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.CurrentSceneCollectionChangedEventArgs>(
-            handler => client.CurrentSceneCollectionChanged += handler,
-            handler => client.CurrentSceneCollectionChanged -= handler,
+            handler => source.CurrentSceneCollectionChanged += handler,
+            handler => source.CurrentSceneCollectionChanged -= handler,
             capacity,
             cancellationToken);
     }
@@ -126,19 +126,17 @@ public static class ObsWebSocketClientEventStreams
     /// Streams <c>SceneCollectionListChanged</c> events as they arrive.
     /// <para>The scene collection list has changed.</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>Config</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneCollectionListChangedEventArgs> SceneCollectionListChangedStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneCollectionListChangedEventArgs> SceneCollectionListChangedStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneCollectionListChangedEventArgs>(
-            handler => client.SceneCollectionListChanged += handler,
-            handler => client.SceneCollectionListChanged -= handler,
+            handler => source.SceneCollectionListChanged += handler,
+            handler => source.SceneCollectionListChanged -= handler,
             capacity,
             cancellationToken);
     }
@@ -147,19 +145,17 @@ public static class ObsWebSocketClientEventStreams
     /// Streams <c>CurrentProfileChanging</c> events as they arrive.
     /// <para>The current profile has begun changing.</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>Config</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CurrentProfileChangingEventArgs> CurrentProfileChangingStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CurrentProfileChangingEventArgs> CurrentProfileChangingStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.CurrentProfileChangingEventArgs>(
-            handler => client.CurrentProfileChanging += handler,
-            handler => client.CurrentProfileChanging -= handler,
+            handler => source.CurrentProfileChanging += handler,
+            handler => source.CurrentProfileChanging -= handler,
             capacity,
             cancellationToken);
     }
@@ -168,19 +164,17 @@ public static class ObsWebSocketClientEventStreams
     /// Streams <c>CurrentProfileChanged</c> events as they arrive.
     /// <para>The current profile has changed.</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>Config</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CurrentProfileChangedEventArgs> CurrentProfileChangedStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CurrentProfileChangedEventArgs> CurrentProfileChangedStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.CurrentProfileChangedEventArgs>(
-            handler => client.CurrentProfileChanged += handler,
-            handler => client.CurrentProfileChanged -= handler,
+            handler => source.CurrentProfileChanged += handler,
+            handler => source.CurrentProfileChanged -= handler,
             capacity,
             cancellationToken);
     }
@@ -189,40 +183,45 @@ public static class ObsWebSocketClientEventStreams
     /// Streams <c>ProfileListChanged</c> events as they arrive.
     /// <para>The profile list has changed.</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>Config</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.ProfileListChangedEventArgs> ProfileListChangedStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.ProfileListChangedEventArgs> ProfileListChangedStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.ProfileListChangedEventArgs>(
-            handler => client.ProfileListChanged += handler,
-            handler => client.ProfileListChanged -= handler,
+            handler => source.ProfileListChanged += handler,
+            handler => source.ProfileListChanged -= handler,
             capacity,
             cancellationToken);
     }
 
+}
+
+/// <summary>
+/// Events in the <c>filters</c> category, as async sequences.
+/// Each accessor subscribes for the lifetime of the enumeration and unsubscribes
+/// when it ends, so the caller never manages handlers.
+/// </summary>
+public readonly partial struct FiltersGroup
+{
     /// <summary>
     /// Streams <c>SourceFilterListReindexed</c> events as they arrive.
     /// <para>A source&apos;s filter list has been reindexed.</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>Filters</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SourceFilterListReindexedEventArgs> SourceFilterListReindexedStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SourceFilterListReindexedEventArgs> SourceFilterListReindexedStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.SourceFilterListReindexedEventArgs>(
-            handler => client.SourceFilterListReindexed += handler,
-            handler => client.SourceFilterListReindexed -= handler,
+            handler => source.SourceFilterListReindexed += handler,
+            handler => source.SourceFilterListReindexed -= handler,
             capacity,
             cancellationToken);
     }
@@ -231,19 +230,17 @@ public static class ObsWebSocketClientEventStreams
     /// Streams <c>SourceFilterCreated</c> events as they arrive.
     /// <para>A filter has been added to a source.</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>Filters</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SourceFilterCreatedEventArgs> SourceFilterCreatedStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SourceFilterCreatedEventArgs> SourceFilterCreatedStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.SourceFilterCreatedEventArgs>(
-            handler => client.SourceFilterCreated += handler,
-            handler => client.SourceFilterCreated -= handler,
+            handler => source.SourceFilterCreated += handler,
+            handler => source.SourceFilterCreated -= handler,
             capacity,
             cancellationToken);
     }
@@ -252,19 +249,17 @@ public static class ObsWebSocketClientEventStreams
     /// Streams <c>SourceFilterRemoved</c> events as they arrive.
     /// <para>A filter has been removed from a source.</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>Filters</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SourceFilterRemovedEventArgs> SourceFilterRemovedStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SourceFilterRemovedEventArgs> SourceFilterRemovedStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.SourceFilterRemovedEventArgs>(
-            handler => client.SourceFilterRemoved += handler,
-            handler => client.SourceFilterRemoved -= handler,
+            handler => source.SourceFilterRemoved += handler,
+            handler => source.SourceFilterRemoved -= handler,
             capacity,
             cancellationToken);
     }
@@ -273,19 +268,17 @@ public static class ObsWebSocketClientEventStreams
     /// Streams <c>SourceFilterNameChanged</c> events as they arrive.
     /// <para>The name of a source filter has changed.</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>Filters</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SourceFilterNameChangedEventArgs> SourceFilterNameChangedStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SourceFilterNameChangedEventArgs> SourceFilterNameChangedStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.SourceFilterNameChangedEventArgs>(
-            handler => client.SourceFilterNameChanged += handler,
-            handler => client.SourceFilterNameChanged -= handler,
+            handler => source.SourceFilterNameChanged += handler,
+            handler => source.SourceFilterNameChanged -= handler,
             capacity,
             cancellationToken);
     }
@@ -294,19 +287,17 @@ public static class ObsWebSocketClientEventStreams
     /// Streams <c>SourceFilterSettingsChanged</c> events as they arrive.
     /// <para>An source filter&apos;s settings have changed (been updated).</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>Filters</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SourceFilterSettingsChangedEventArgs> SourceFilterSettingsChangedStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SourceFilterSettingsChangedEventArgs> SourceFilterSettingsChangedStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.SourceFilterSettingsChangedEventArgs>(
-            handler => client.SourceFilterSettingsChanged += handler,
-            handler => client.SourceFilterSettingsChanged -= handler,
+            handler => source.SourceFilterSettingsChanged += handler,
+            handler => source.SourceFilterSettingsChanged -= handler,
             capacity,
             cancellationToken);
     }
@@ -315,922 +306,45 @@ public static class ObsWebSocketClientEventStreams
     /// Streams <c>SourceFilterEnableStateChanged</c> events as they arrive.
     /// <para>A source filter&apos;s enable state has changed.</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>Filters</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SourceFilterEnableStateChangedEventArgs> SourceFilterEnableStateChangedStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SourceFilterEnableStateChangedEventArgs> SourceFilterEnableStateChangedStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.SourceFilterEnableStateChangedEventArgs>(
-            handler => client.SourceFilterEnableStateChanged += handler,
-            handler => client.SourceFilterEnableStateChanged -= handler,
+            handler => source.SourceFilterEnableStateChanged += handler,
+            handler => source.SourceFilterEnableStateChanged -= handler,
             capacity,
             cancellationToken);
     }
 
+}
+
+/// <summary>
+/// Events in the <c>general</c> category, as async sequences.
+/// Each accessor subscribes for the lifetime of the enumeration and unsubscribes
+/// when it ends, so the caller never manages handlers.
+/// </summary>
+public readonly partial struct GeneralGroup
+{
     /// <summary>
     /// Streams <c>ExitStarted</c> events as they arrive.
     /// <para>OBS has begun the shutdown process.</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>General</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.ExitStartedEventArgs> ExitStartedStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.ExitStartedEventArgs> ExitStartedStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.ExitStartedEventArgs>(
-            handler => client.ExitStarted += handler,
-            handler => client.ExitStarted -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>InputCreated</c> events as they arrive.
-    /// <para>An input has been created.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputCreatedEventArgs> InputCreatedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputCreatedEventArgs>(
-            handler => client.InputCreated += handler,
-            handler => client.InputCreated -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>InputRemoved</c> events as they arrive.
-    /// <para>An input has been removed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputRemovedEventArgs> InputRemovedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputRemovedEventArgs>(
-            handler => client.InputRemoved += handler,
-            handler => client.InputRemoved -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>InputNameChanged</c> events as they arrive.
-    /// <para>The name of an input has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputNameChangedEventArgs> InputNameChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputNameChangedEventArgs>(
-            handler => client.InputNameChanged += handler,
-            handler => client.InputNameChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>InputSettingsChanged</c> events as they arrive.
-    /// <para>An input&apos;s settings have changed (been updated). Note: On some inputs, changing values in the properties dialog will cause an immediate update. Pressing the &quot;Cancel&quot; button will revert the settings, resulting in another event being fired.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputSettingsChangedEventArgs> InputSettingsChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputSettingsChangedEventArgs>(
-            handler => client.InputSettingsChanged += handler,
-            handler => client.InputSettingsChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>InputActiveStateChanged</c> events as they arrive.
-    /// <para>An input&apos;s active state has changed. When an input is active, it means it&apos;s being shown by the program feed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>InputActiveStateChanged</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputActiveStateChangedEventArgs> InputActiveStateChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputActiveStateChangedEventArgs>(
-            handler => client.InputActiveStateChanged += handler,
-            handler => client.InputActiveStateChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>InputShowStateChanged</c> events as they arrive.
-    /// <para>An input&apos;s show state has changed. When an input is showing, it means it&apos;s being shown by the preview or a dialog.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>InputShowStateChanged</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputShowStateChangedEventArgs> InputShowStateChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputShowStateChangedEventArgs>(
-            handler => client.InputShowStateChanged += handler,
-            handler => client.InputShowStateChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>InputMuteStateChanged</c> events as they arrive.
-    /// <para>An input&apos;s mute state has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputMuteStateChangedEventArgs> InputMuteStateChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputMuteStateChangedEventArgs>(
-            handler => client.InputMuteStateChanged += handler,
-            handler => client.InputMuteStateChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>InputVolumeChanged</c> events as they arrive.
-    /// <para>An input&apos;s volume level has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputVolumeChangedEventArgs> InputVolumeChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputVolumeChangedEventArgs>(
-            handler => client.InputVolumeChanged += handler,
-            handler => client.InputVolumeChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>InputAudioBalanceChanged</c> events as they arrive.
-    /// <para>The audio balance value of an input has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputAudioBalanceChangedEventArgs> InputAudioBalanceChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputAudioBalanceChangedEventArgs>(
-            handler => client.InputAudioBalanceChanged += handler,
-            handler => client.InputAudioBalanceChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>InputAudioSyncOffsetChanged</c> events as they arrive.
-    /// <para>The sync offset of an input has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputAudioSyncOffsetChangedEventArgs> InputAudioSyncOffsetChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputAudioSyncOffsetChangedEventArgs>(
-            handler => client.InputAudioSyncOffsetChanged += handler,
-            handler => client.InputAudioSyncOffsetChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>InputAudioTracksChanged</c> events as they arrive.
-    /// <para>The audio tracks of an input have changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputAudioTracksChangedEventArgs> InputAudioTracksChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputAudioTracksChangedEventArgs>(
-            handler => client.InputAudioTracksChanged += handler,
-            handler => client.InputAudioTracksChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>InputAudioMonitorTypeChanged</c> events as they arrive.
-    /// <para>The monitor type of an input has changed. Available types are: - `OBS_MONITORING_TYPE_NONE` - `OBS_MONITORING_TYPE_MONITOR_ONLY` - `OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT`</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputAudioMonitorTypeChangedEventArgs> InputAudioMonitorTypeChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputAudioMonitorTypeChangedEventArgs>(
-            handler => client.InputAudioMonitorTypeChanged += handler,
-            handler => client.InputAudioMonitorTypeChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>InputVolumeMeters</c> events as they arrive.
-    /// <para>A high-volume event providing volume levels of all active inputs every 50 milliseconds.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>InputVolumeMeters</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputVolumeMetersEventArgs> InputVolumeMetersStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputVolumeMetersEventArgs>(
-            handler => client.InputVolumeMeters += handler,
-            handler => client.InputVolumeMeters -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>MediaInputPlaybackStarted</c> events as they arrive.
-    /// <para>A media input has started playing.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>MediaInputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.MediaInputPlaybackStartedEventArgs> MediaInputPlaybackStartedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.MediaInputPlaybackStartedEventArgs>(
-            handler => client.MediaInputPlaybackStarted += handler,
-            handler => client.MediaInputPlaybackStarted -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>MediaInputPlaybackEnded</c> events as they arrive.
-    /// <para>A media input has finished playing.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>MediaInputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.MediaInputPlaybackEndedEventArgs> MediaInputPlaybackEndedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.MediaInputPlaybackEndedEventArgs>(
-            handler => client.MediaInputPlaybackEnded += handler,
-            handler => client.MediaInputPlaybackEnded -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>MediaInputActionTriggered</c> events as they arrive.
-    /// <para>An action has been performed on an input.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>MediaInputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.MediaInputActionTriggeredEventArgs> MediaInputActionTriggeredStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.MediaInputActionTriggeredEventArgs>(
-            handler => client.MediaInputActionTriggered += handler,
-            handler => client.MediaInputActionTriggered -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>StreamStateChanged</c> events as they arrive.
-    /// <para>The state of the stream output has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Outputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.StreamStateChangedEventArgs> StreamStateChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.StreamStateChangedEventArgs>(
-            handler => client.StreamStateChanged += handler,
-            handler => client.StreamStateChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>RecordStateChanged</c> events as they arrive.
-    /// <para>The state of the record output has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Outputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.RecordStateChangedEventArgs> RecordStateChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.RecordStateChangedEventArgs>(
-            handler => client.RecordStateChanged += handler,
-            handler => client.RecordStateChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>RecordFileChanged</c> events as they arrive.
-    /// <para>The record output has started writing to a new file. For example, when a file split happens.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Outputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.RecordFileChangedEventArgs> RecordFileChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.RecordFileChangedEventArgs>(
-            handler => client.RecordFileChanged += handler,
-            handler => client.RecordFileChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>ReplayBufferStateChanged</c> events as they arrive.
-    /// <para>The state of the replay buffer output has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Outputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.ReplayBufferStateChangedEventArgs> ReplayBufferStateChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.ReplayBufferStateChangedEventArgs>(
-            handler => client.ReplayBufferStateChanged += handler,
-            handler => client.ReplayBufferStateChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>VirtualcamStateChanged</c> events as they arrive.
-    /// <para>The state of the virtualcam output has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Outputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.VirtualcamStateChangedEventArgs> VirtualcamStateChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.VirtualcamStateChangedEventArgs>(
-            handler => client.VirtualcamStateChanged += handler,
-            handler => client.VirtualcamStateChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>ReplayBufferSaved</c> events as they arrive.
-    /// <para>The replay buffer has been saved.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Outputs</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.ReplayBufferSavedEventArgs> ReplayBufferSavedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.ReplayBufferSavedEventArgs>(
-            handler => client.ReplayBufferSaved += handler,
-            handler => client.ReplayBufferSaved -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>SceneItemCreated</c> events as they arrive.
-    /// <para>A scene item has been created.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>SceneItems</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneItemCreatedEventArgs> SceneItemCreatedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneItemCreatedEventArgs>(
-            handler => client.SceneItemCreated += handler,
-            handler => client.SceneItemCreated -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>SceneItemRemoved</c> events as they arrive.
-    /// <para>A scene item has been removed. This event is not emitted when the scene the item is in is removed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>SceneItems</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneItemRemovedEventArgs> SceneItemRemovedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneItemRemovedEventArgs>(
-            handler => client.SceneItemRemoved += handler,
-            handler => client.SceneItemRemoved -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>SceneItemListReindexed</c> events as they arrive.
-    /// <para>A scene&apos;s item list has been reindexed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>SceneItems</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneItemListReindexedEventArgs> SceneItemListReindexedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneItemListReindexedEventArgs>(
-            handler => client.SceneItemListReindexed += handler,
-            handler => client.SceneItemListReindexed -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>SceneItemEnableStateChanged</c> events as they arrive.
-    /// <para>A scene item&apos;s enable state has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>SceneItems</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneItemEnableStateChangedEventArgs> SceneItemEnableStateChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneItemEnableStateChangedEventArgs>(
-            handler => client.SceneItemEnableStateChanged += handler,
-            handler => client.SceneItemEnableStateChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>SceneItemLockStateChanged</c> events as they arrive.
-    /// <para>A scene item&apos;s lock state has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>SceneItems</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneItemLockStateChangedEventArgs> SceneItemLockStateChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneItemLockStateChangedEventArgs>(
-            handler => client.SceneItemLockStateChanged += handler,
-            handler => client.SceneItemLockStateChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>SceneItemSelected</c> events as they arrive.
-    /// <para>A scene item has been selected in the Ui.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>SceneItems</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneItemSelectedEventArgs> SceneItemSelectedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneItemSelectedEventArgs>(
-            handler => client.SceneItemSelected += handler,
-            handler => client.SceneItemSelected -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>SceneItemTransformChanged</c> events as they arrive.
-    /// <para>The transform/crop of a scene item has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>SceneItemTransformChanged</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneItemTransformChangedEventArgs> SceneItemTransformChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneItemTransformChangedEventArgs>(
-            handler => client.SceneItemTransformChanged += handler,
-            handler => client.SceneItemTransformChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>SceneCreated</c> events as they arrive.
-    /// <para>A new scene has been created.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Scenes</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneCreatedEventArgs> SceneCreatedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneCreatedEventArgs>(
-            handler => client.SceneCreated += handler,
-            handler => client.SceneCreated -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>SceneRemoved</c> events as they arrive.
-    /// <para>A scene has been removed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Scenes</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneRemovedEventArgs> SceneRemovedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneRemovedEventArgs>(
-            handler => client.SceneRemoved += handler,
-            handler => client.SceneRemoved -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>SceneNameChanged</c> events as they arrive.
-    /// <para>The name of a scene has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Scenes</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneNameChangedEventArgs> SceneNameChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneNameChangedEventArgs>(
-            handler => client.SceneNameChanged += handler,
-            handler => client.SceneNameChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>CurrentProgramSceneChanged</c> events as they arrive.
-    /// <para>The current program scene has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Scenes</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CurrentProgramSceneChangedEventArgs> CurrentProgramSceneChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.CurrentProgramSceneChangedEventArgs>(
-            handler => client.CurrentProgramSceneChanged += handler,
-            handler => client.CurrentProgramSceneChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>CurrentPreviewSceneChanged</c> events as they arrive.
-    /// <para>The current preview scene has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Scenes</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CurrentPreviewSceneChangedEventArgs> CurrentPreviewSceneChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.CurrentPreviewSceneChangedEventArgs>(
-            handler => client.CurrentPreviewSceneChanged += handler,
-            handler => client.CurrentPreviewSceneChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>SceneListChanged</c> events as they arrive.
-    /// <para>The list of scenes has changed. TODO: Make OBS fire this event when scenes are reordered.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Scenes</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneListChangedEventArgs> SceneListChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneListChangedEventArgs>(
-            handler => client.SceneListChanged += handler,
-            handler => client.SceneListChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>CurrentSceneTransitionChanged</c> events as they arrive.
-    /// <para>The current scene transition has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Transitions</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CurrentSceneTransitionChangedEventArgs> CurrentSceneTransitionChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.CurrentSceneTransitionChangedEventArgs>(
-            handler => client.CurrentSceneTransitionChanged += handler,
-            handler => client.CurrentSceneTransitionChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>CurrentSceneTransitionDurationChanged</c> events as they arrive.
-    /// <para>The current scene transition duration has changed.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Transitions</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CurrentSceneTransitionDurationChangedEventArgs> CurrentSceneTransitionDurationChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.CurrentSceneTransitionDurationChangedEventArgs>(
-            handler => client.CurrentSceneTransitionDurationChanged += handler,
-            handler => client.CurrentSceneTransitionDurationChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>SceneTransitionStarted</c> events as they arrive.
-    /// <para>A scene transition has started.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Transitions</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneTransitionStartedEventArgs> SceneTransitionStartedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneTransitionStartedEventArgs>(
-            handler => client.SceneTransitionStarted += handler,
-            handler => client.SceneTransitionStarted -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>SceneTransitionEnded</c> events as they arrive.
-    /// <para>A scene transition has completed fully. Note: Does not appear to trigger when the transition is interrupted by the user.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Transitions</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneTransitionEndedEventArgs> SceneTransitionEndedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneTransitionEndedEventArgs>(
-            handler => client.SceneTransitionEnded += handler,
-            handler => client.SceneTransitionEnded -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>SceneTransitionVideoEnded</c> events as they arrive.
-    /// <para>A scene transition&apos;s video has completed fully. Useful for stinger transitions to tell when the video *actually* ends. `SceneTransitionEnded` only signifies the cut point, not the completion of transition playback. Note: Appears to be called by every transition, regardless of relevance.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Transitions</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneTransitionVideoEndedEventArgs> SceneTransitionVideoEndedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneTransitionVideoEndedEventArgs>(
-            handler => client.SceneTransitionVideoEnded += handler,
-            handler => client.SceneTransitionVideoEnded -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>StudioModeStateChanged</c> events as they arrive.
-    /// <para>Studio mode has been enabled or disabled.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Ui</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.StudioModeStateChangedEventArgs> StudioModeStateChangedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.StudioModeStateChangedEventArgs>(
-            handler => client.StudioModeStateChanged += handler,
-            handler => client.StudioModeStateChanged -= handler,
-            capacity,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// Streams <c>ScreenshotSaved</c> events as they arrive.
-    /// <para>A screenshot has been saved. Note: Triggered for the screenshot feature available in `Settings -&gt; Hotkeys -&gt; Screenshot Output` ONLY. Applications using `Get/SaveSourceScreenshot` should implement a `CustomEvent` if this kind of inter-client communication is desired.</para>
-    /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
-    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
-    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
-    /// <remarks>Requires the <c>Ui</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.ScreenshotSavedEventArgs> ScreenshotSavedStream(
-        this ObsWebSocketClient client,
-        int capacity = EventStream.DefaultCapacity,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(client);
-        return EventStream.Create<ObsWebSocket.Core.Events.Generated.ScreenshotSavedEventArgs>(
-            handler => client.ScreenshotSaved += handler,
-            handler => client.ScreenshotSaved -= handler,
+            handler => source.ExitStarted += handler,
+            handler => source.ExitStarted -= handler,
             capacity,
             cancellationToken);
     }
@@ -1239,19 +353,17 @@ public static class ObsWebSocketClientEventStreams
     /// Streams <c>VendorEvent</c> events as they arrive.
     /// <para>An event has been emitted from a vendor. A vendor is a unique name registered by a third-party plugin or script, which allows for custom requests and events to be added to obs-websocket. If a plugin or script implements vendor requests or events, documentation is expected to be provided with them.</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>Vendors</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.VendorEventEventArgs> VendorEventStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.VendorEventEventArgs> VendorEventStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.VendorEventEventArgs>(
-            handler => client.VendorEvent += handler,
-            handler => client.VendorEvent -= handler,
+            handler => source.VendorEvent += handler,
+            handler => source.VendorEvent -= handler,
             capacity,
             cancellationToken);
     }
@@ -1260,21 +372,881 @@ public static class ObsWebSocketClientEventStreams
     /// Streams <c>CustomEvent</c> events as they arrive.
     /// <para>Custom event emitted by `BroadcastCustomEvent`.</para>
     /// </summary>
-    /// <param name="client">The ObsWebSocketClient instance.</param>
     /// <param name="capacity">Events buffered before the oldest is dropped.</param>
     /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
     /// <remarks>Requires the <c>General</c> subscription.</remarks>
-    public static IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CustomEventEventArgs> CustomEventStream(
-        this ObsWebSocketClient client,
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CustomEventEventArgs> CustomEventStream(
         int capacity = EventStream.DefaultCapacity,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ObsWebSocketClient source = client;
         return EventStream.Create<ObsWebSocket.Core.Events.Generated.CustomEventEventArgs>(
-            handler => client.CustomEvent += handler,
-            handler => client.CustomEvent -= handler,
+            handler => source.CustomEvent += handler,
+            handler => source.CustomEvent -= handler,
             capacity,
             cancellationToken);
     }
 
 }
+
+/// <summary>
+/// Events in the <c>inputs</c> category, as async sequences.
+/// Each accessor subscribes for the lifetime of the enumeration and unsubscribes
+/// when it ends, so the caller never manages handlers.
+/// </summary>
+public readonly partial struct InputsGroup
+{
+    /// <summary>
+    /// Streams <c>InputCreated</c> events as they arrive.
+    /// <para>An input has been created.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputCreatedEventArgs> InputCreatedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputCreatedEventArgs>(
+            handler => source.InputCreated += handler,
+            handler => source.InputCreated -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>InputRemoved</c> events as they arrive.
+    /// <para>An input has been removed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputRemovedEventArgs> InputRemovedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputRemovedEventArgs>(
+            handler => source.InputRemoved += handler,
+            handler => source.InputRemoved -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>InputNameChanged</c> events as they arrive.
+    /// <para>The name of an input has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputNameChangedEventArgs> InputNameChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputNameChangedEventArgs>(
+            handler => source.InputNameChanged += handler,
+            handler => source.InputNameChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>InputSettingsChanged</c> events as they arrive.
+    /// <para>An input&apos;s settings have changed (been updated). Note: On some inputs, changing values in the properties dialog will cause an immediate update. Pressing the &quot;Cancel&quot; button will revert the settings, resulting in another event being fired.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputSettingsChangedEventArgs> InputSettingsChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputSettingsChangedEventArgs>(
+            handler => source.InputSettingsChanged += handler,
+            handler => source.InputSettingsChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>InputActiveStateChanged</c> events as they arrive.
+    /// <para>An input&apos;s active state has changed. When an input is active, it means it&apos;s being shown by the program feed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>InputActiveStateChanged</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputActiveStateChangedEventArgs> InputActiveStateChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputActiveStateChangedEventArgs>(
+            handler => source.InputActiveStateChanged += handler,
+            handler => source.InputActiveStateChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>InputShowStateChanged</c> events as they arrive.
+    /// <para>An input&apos;s show state has changed. When an input is showing, it means it&apos;s being shown by the preview or a dialog.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>InputShowStateChanged</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputShowStateChangedEventArgs> InputShowStateChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputShowStateChangedEventArgs>(
+            handler => source.InputShowStateChanged += handler,
+            handler => source.InputShowStateChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>InputMuteStateChanged</c> events as they arrive.
+    /// <para>An input&apos;s mute state has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputMuteStateChangedEventArgs> InputMuteStateChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputMuteStateChangedEventArgs>(
+            handler => source.InputMuteStateChanged += handler,
+            handler => source.InputMuteStateChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>InputVolumeChanged</c> events as they arrive.
+    /// <para>An input&apos;s volume level has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputVolumeChangedEventArgs> InputVolumeChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputVolumeChangedEventArgs>(
+            handler => source.InputVolumeChanged += handler,
+            handler => source.InputVolumeChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>InputAudioBalanceChanged</c> events as they arrive.
+    /// <para>The audio balance value of an input has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputAudioBalanceChangedEventArgs> InputAudioBalanceChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputAudioBalanceChangedEventArgs>(
+            handler => source.InputAudioBalanceChanged += handler,
+            handler => source.InputAudioBalanceChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>InputAudioSyncOffsetChanged</c> events as they arrive.
+    /// <para>The sync offset of an input has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputAudioSyncOffsetChangedEventArgs> InputAudioSyncOffsetChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputAudioSyncOffsetChangedEventArgs>(
+            handler => source.InputAudioSyncOffsetChanged += handler,
+            handler => source.InputAudioSyncOffsetChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>InputAudioTracksChanged</c> events as they arrive.
+    /// <para>The audio tracks of an input have changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputAudioTracksChangedEventArgs> InputAudioTracksChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputAudioTracksChangedEventArgs>(
+            handler => source.InputAudioTracksChanged += handler,
+            handler => source.InputAudioTracksChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>InputAudioMonitorTypeChanged</c> events as they arrive.
+    /// <para>The monitor type of an input has changed. Available types are: - `OBS_MONITORING_TYPE_NONE` - `OBS_MONITORING_TYPE_MONITOR_ONLY` - `OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT`</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Inputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputAudioMonitorTypeChangedEventArgs> InputAudioMonitorTypeChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputAudioMonitorTypeChangedEventArgs>(
+            handler => source.InputAudioMonitorTypeChanged += handler,
+            handler => source.InputAudioMonitorTypeChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>InputVolumeMeters</c> events as they arrive.
+    /// <para>A high-volume event providing volume levels of all active inputs every 50 milliseconds.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>InputVolumeMeters</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.InputVolumeMetersEventArgs> InputVolumeMetersStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.InputVolumeMetersEventArgs>(
+            handler => source.InputVolumeMeters += handler,
+            handler => source.InputVolumeMeters -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+}
+
+/// <summary>
+/// Events in the <c>media inputs</c> category, as async sequences.
+/// Each accessor subscribes for the lifetime of the enumeration and unsubscribes
+/// when it ends, so the caller never manages handlers.
+/// </summary>
+public readonly partial struct MediaInputsGroup
+{
+    /// <summary>
+    /// Streams <c>MediaInputPlaybackStarted</c> events as they arrive.
+    /// <para>A media input has started playing.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>MediaInputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.MediaInputPlaybackStartedEventArgs> MediaInputPlaybackStartedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.MediaInputPlaybackStartedEventArgs>(
+            handler => source.MediaInputPlaybackStarted += handler,
+            handler => source.MediaInputPlaybackStarted -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>MediaInputPlaybackEnded</c> events as they arrive.
+    /// <para>A media input has finished playing.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>MediaInputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.MediaInputPlaybackEndedEventArgs> MediaInputPlaybackEndedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.MediaInputPlaybackEndedEventArgs>(
+            handler => source.MediaInputPlaybackEnded += handler,
+            handler => source.MediaInputPlaybackEnded -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>MediaInputActionTriggered</c> events as they arrive.
+    /// <para>An action has been performed on an input.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>MediaInputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.MediaInputActionTriggeredEventArgs> MediaInputActionTriggeredStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.MediaInputActionTriggeredEventArgs>(
+            handler => source.MediaInputActionTriggered += handler,
+            handler => source.MediaInputActionTriggered -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+}
+
+/// <summary>
+/// Events in the <c>outputs</c> category, as async sequences.
+/// Each accessor subscribes for the lifetime of the enumeration and unsubscribes
+/// when it ends, so the caller never manages handlers.
+/// </summary>
+public readonly partial struct OutputsGroup
+{
+    /// <summary>
+    /// Streams <c>StreamStateChanged</c> events as they arrive.
+    /// <para>The state of the stream output has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Outputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.StreamStateChangedEventArgs> StreamStateChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.StreamStateChangedEventArgs>(
+            handler => source.StreamStateChanged += handler,
+            handler => source.StreamStateChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>RecordStateChanged</c> events as they arrive.
+    /// <para>The state of the record output has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Outputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.RecordStateChangedEventArgs> RecordStateChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.RecordStateChangedEventArgs>(
+            handler => source.RecordStateChanged += handler,
+            handler => source.RecordStateChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>RecordFileChanged</c> events as they arrive.
+    /// <para>The record output has started writing to a new file. For example, when a file split happens.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Outputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.RecordFileChangedEventArgs> RecordFileChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.RecordFileChangedEventArgs>(
+            handler => source.RecordFileChanged += handler,
+            handler => source.RecordFileChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>ReplayBufferStateChanged</c> events as they arrive.
+    /// <para>The state of the replay buffer output has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Outputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.ReplayBufferStateChangedEventArgs> ReplayBufferStateChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.ReplayBufferStateChangedEventArgs>(
+            handler => source.ReplayBufferStateChanged += handler,
+            handler => source.ReplayBufferStateChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>VirtualcamStateChanged</c> events as they arrive.
+    /// <para>The state of the virtualcam output has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Outputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.VirtualcamStateChangedEventArgs> VirtualcamStateChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.VirtualcamStateChangedEventArgs>(
+            handler => source.VirtualcamStateChanged += handler,
+            handler => source.VirtualcamStateChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>ReplayBufferSaved</c> events as they arrive.
+    /// <para>The replay buffer has been saved.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Outputs</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.ReplayBufferSavedEventArgs> ReplayBufferSavedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.ReplayBufferSavedEventArgs>(
+            handler => source.ReplayBufferSaved += handler,
+            handler => source.ReplayBufferSaved -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+}
+
+/// <summary>
+/// Events in the <c>scene items</c> category, as async sequences.
+/// Each accessor subscribes for the lifetime of the enumeration and unsubscribes
+/// when it ends, so the caller never manages handlers.
+/// </summary>
+public readonly partial struct SceneItemsGroup
+{
+    /// <summary>
+    /// Streams <c>SceneItemCreated</c> events as they arrive.
+    /// <para>A scene item has been created.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>SceneItems</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneItemCreatedEventArgs> SceneItemCreatedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneItemCreatedEventArgs>(
+            handler => source.SceneItemCreated += handler,
+            handler => source.SceneItemCreated -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>SceneItemRemoved</c> events as they arrive.
+    /// <para>A scene item has been removed. This event is not emitted when the scene the item is in is removed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>SceneItems</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneItemRemovedEventArgs> SceneItemRemovedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneItemRemovedEventArgs>(
+            handler => source.SceneItemRemoved += handler,
+            handler => source.SceneItemRemoved -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>SceneItemListReindexed</c> events as they arrive.
+    /// <para>A scene&apos;s item list has been reindexed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>SceneItems</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneItemListReindexedEventArgs> SceneItemListReindexedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneItemListReindexedEventArgs>(
+            handler => source.SceneItemListReindexed += handler,
+            handler => source.SceneItemListReindexed -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>SceneItemEnableStateChanged</c> events as they arrive.
+    /// <para>A scene item&apos;s enable state has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>SceneItems</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneItemEnableStateChangedEventArgs> SceneItemEnableStateChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneItemEnableStateChangedEventArgs>(
+            handler => source.SceneItemEnableStateChanged += handler,
+            handler => source.SceneItemEnableStateChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>SceneItemLockStateChanged</c> events as they arrive.
+    /// <para>A scene item&apos;s lock state has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>SceneItems</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneItemLockStateChangedEventArgs> SceneItemLockStateChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneItemLockStateChangedEventArgs>(
+            handler => source.SceneItemLockStateChanged += handler,
+            handler => source.SceneItemLockStateChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>SceneItemSelected</c> events as they arrive.
+    /// <para>A scene item has been selected in the Ui.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>SceneItems</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneItemSelectedEventArgs> SceneItemSelectedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneItemSelectedEventArgs>(
+            handler => source.SceneItemSelected += handler,
+            handler => source.SceneItemSelected -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>SceneItemTransformChanged</c> events as they arrive.
+    /// <para>The transform/crop of a scene item has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>SceneItemTransformChanged</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneItemTransformChangedEventArgs> SceneItemTransformChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneItemTransformChangedEventArgs>(
+            handler => source.SceneItemTransformChanged += handler,
+            handler => source.SceneItemTransformChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+}
+
+/// <summary>
+/// Events in the <c>scenes</c> category, as async sequences.
+/// Each accessor subscribes for the lifetime of the enumeration and unsubscribes
+/// when it ends, so the caller never manages handlers.
+/// </summary>
+public readonly partial struct ScenesGroup
+{
+    /// <summary>
+    /// Streams <c>SceneCreated</c> events as they arrive.
+    /// <para>A new scene has been created.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Scenes</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneCreatedEventArgs> SceneCreatedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneCreatedEventArgs>(
+            handler => source.SceneCreated += handler,
+            handler => source.SceneCreated -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>SceneRemoved</c> events as they arrive.
+    /// <para>A scene has been removed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Scenes</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneRemovedEventArgs> SceneRemovedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneRemovedEventArgs>(
+            handler => source.SceneRemoved += handler,
+            handler => source.SceneRemoved -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>SceneNameChanged</c> events as they arrive.
+    /// <para>The name of a scene has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Scenes</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneNameChangedEventArgs> SceneNameChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneNameChangedEventArgs>(
+            handler => source.SceneNameChanged += handler,
+            handler => source.SceneNameChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>CurrentProgramSceneChanged</c> events as they arrive.
+    /// <para>The current program scene has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Scenes</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CurrentProgramSceneChangedEventArgs> CurrentProgramSceneChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.CurrentProgramSceneChangedEventArgs>(
+            handler => source.CurrentProgramSceneChanged += handler,
+            handler => source.CurrentProgramSceneChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>CurrentPreviewSceneChanged</c> events as they arrive.
+    /// <para>The current preview scene has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Scenes</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CurrentPreviewSceneChangedEventArgs> CurrentPreviewSceneChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.CurrentPreviewSceneChangedEventArgs>(
+            handler => source.CurrentPreviewSceneChanged += handler,
+            handler => source.CurrentPreviewSceneChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>SceneListChanged</c> events as they arrive.
+    /// <para>The list of scenes has changed. TODO: Make OBS fire this event when scenes are reordered.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Scenes</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneListChangedEventArgs> SceneListChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneListChangedEventArgs>(
+            handler => source.SceneListChanged += handler,
+            handler => source.SceneListChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+}
+
+/// <summary>
+/// Events in the <c>transitions</c> category, as async sequences.
+/// Each accessor subscribes for the lifetime of the enumeration and unsubscribes
+/// when it ends, so the caller never manages handlers.
+/// </summary>
+public readonly partial struct TransitionsGroup
+{
+    /// <summary>
+    /// Streams <c>CurrentSceneTransitionChanged</c> events as they arrive.
+    /// <para>The current scene transition has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Transitions</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CurrentSceneTransitionChangedEventArgs> CurrentSceneTransitionChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.CurrentSceneTransitionChangedEventArgs>(
+            handler => source.CurrentSceneTransitionChanged += handler,
+            handler => source.CurrentSceneTransitionChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>CurrentSceneTransitionDurationChanged</c> events as they arrive.
+    /// <para>The current scene transition duration has changed.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Transitions</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.CurrentSceneTransitionDurationChangedEventArgs> CurrentSceneTransitionDurationChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.CurrentSceneTransitionDurationChangedEventArgs>(
+            handler => source.CurrentSceneTransitionDurationChanged += handler,
+            handler => source.CurrentSceneTransitionDurationChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>SceneTransitionStarted</c> events as they arrive.
+    /// <para>A scene transition has started.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Transitions</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneTransitionStartedEventArgs> SceneTransitionStartedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneTransitionStartedEventArgs>(
+            handler => source.SceneTransitionStarted += handler,
+            handler => source.SceneTransitionStarted -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>SceneTransitionEnded</c> events as they arrive.
+    /// <para>A scene transition has completed fully. Note: Does not appear to trigger when the transition is interrupted by the user.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Transitions</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneTransitionEndedEventArgs> SceneTransitionEndedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneTransitionEndedEventArgs>(
+            handler => source.SceneTransitionEnded += handler,
+            handler => source.SceneTransitionEnded -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>SceneTransitionVideoEnded</c> events as they arrive.
+    /// <para>A scene transition&apos;s video has completed fully. Useful for stinger transitions to tell when the video *actually* ends. `SceneTransitionEnded` only signifies the cut point, not the completion of transition playback. Note: Appears to be called by every transition, regardless of relevance.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Transitions</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.SceneTransitionVideoEndedEventArgs> SceneTransitionVideoEndedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.SceneTransitionVideoEndedEventArgs>(
+            handler => source.SceneTransitionVideoEnded += handler,
+            handler => source.SceneTransitionVideoEnded -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+}
+
+/// <summary>
+/// Events in the <c>ui</c> category, as async sequences.
+/// Each accessor subscribes for the lifetime of the enumeration and unsubscribes
+/// when it ends, so the caller never manages handlers.
+/// </summary>
+public readonly partial struct UiGroup
+{
+    /// <summary>
+    /// Streams <c>StudioModeStateChanged</c> events as they arrive.
+    /// <para>Studio mode has been enabled or disabled.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Ui</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.StudioModeStateChangedEventArgs> StudioModeStateChangedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.StudioModeStateChangedEventArgs>(
+            handler => source.StudioModeStateChanged += handler,
+            handler => source.StudioModeStateChanged -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams <c>ScreenshotSaved</c> events as they arrive.
+    /// <para>A screenshot has been saved. Note: Triggered for the screenshot feature available in `Settings -&gt; Hotkeys -&gt; Screenshot Output` ONLY. Applications using `Get/SaveSourceScreenshot` should implement a `CustomEvent` if this kind of inter-client communication is desired.</para>
+    /// </summary>
+    /// <param name="capacity">Events buffered before the oldest is dropped.</param>
+    /// <param name="cancellationToken">Ends the enumeration and unsubscribes.</param>
+    /// <remarks>Requires the <c>Ui</c> subscription.</remarks>
+    public IAsyncEnumerable<ObsWebSocket.Core.Events.Generated.ScreenshotSavedEventArgs> ScreenshotSavedStream(
+        int capacity = EventStream.DefaultCapacity,
+        CancellationToken cancellationToken = default)
+    {
+        ObsWebSocketClient source = client;
+        return EventStream.Create<ObsWebSocket.Core.Events.Generated.ScreenshotSavedEventArgs>(
+            handler => source.ScreenshotSaved += handler,
+            handler => source.ScreenshotSaved -= handler,
+            capacity,
+            cancellationToken);
+    }
+
+}
+

--- a/ObsWebSocket.Core/Generated/Client/ObsWebSocketClient.Extensions.g.cs
+++ b/ObsWebSocket.Core/Generated/Client/ObsWebSocketClient.Extensions.g.cs
@@ -17,7 +17,7 @@ namespace ObsWebSocket.Core;
 /// Requests in the <c>canvases</c> category.
 /// </summary>
 /// <param name="client">The client these requests are sent on.</param>
-public readonly partial struct CanvasesRequestGroup(ObsWebSocketClient client)
+public readonly partial struct CanvasesGroup(ObsWebSocketClient client)
 {
     /// <summary>
     /// Gets an array of canvases in OBS.
@@ -43,7 +43,7 @@ public readonly partial struct CanvasesRequestGroup(ObsWebSocketClient client)
 /// Requests in the <c>config</c> category.
 /// </summary>
 /// <param name="client">The client these requests are sent on.</param>
-public readonly partial struct ConfigRequestGroup(ObsWebSocketClient client)
+public readonly partial struct ConfigGroup(ObsWebSocketClient client)
 {
     /// <summary>
     /// Gets the value of a &quot;slot&quot; from the selected persistent data realm.
@@ -379,7 +379,7 @@ public readonly partial struct ConfigRequestGroup(ObsWebSocketClient client)
 /// Requests in the <c>filters</c> category.
 /// </summary>
 /// <param name="client">The client these requests are sent on.</param>
-public readonly partial struct FiltersRequestGroup(ObsWebSocketClient client)
+public readonly partial struct FiltersGroup(ObsWebSocketClient client)
 {
     /// <summary>
     /// Gets an array of all available source filter kinds.
@@ -578,7 +578,7 @@ public readonly partial struct FiltersRequestGroup(ObsWebSocketClient client)
 /// Requests in the <c>general</c> category.
 /// </summary>
 /// <param name="client">The client these requests are sent on.</param>
-public readonly partial struct GeneralRequestGroup(ObsWebSocketClient client)
+public readonly partial struct GeneralGroup(ObsWebSocketClient client)
 {
     /// <summary>
     /// Gets data about the current plugin and RPC version.
@@ -744,7 +744,7 @@ public readonly partial struct GeneralRequestGroup(ObsWebSocketClient client)
 /// Requests in the <c>inputs</c> category.
 /// </summary>
 /// <param name="client">The client these requests are sent on.</param>
-public readonly partial struct InputsRequestGroup(ObsWebSocketClient client)
+public readonly partial struct InputsGroup(ObsWebSocketClient client)
 {
     /// <summary>
     /// Gets an array of all inputs in OBS.
@@ -1328,7 +1328,7 @@ public readonly partial struct InputsRequestGroup(ObsWebSocketClient client)
 /// Requests in the <c>media inputs</c> category.
 /// </summary>
 /// <param name="client">The client these requests are sent on.</param>
-public readonly partial struct MediaInputsRequestGroup(ObsWebSocketClient client)
+public readonly partial struct MediaInputsGroup(ObsWebSocketClient client)
 {
     /// <summary>
     /// Gets the status of a media input.
@@ -1427,7 +1427,7 @@ public readonly partial struct MediaInputsRequestGroup(ObsWebSocketClient client
 /// Requests in the <c>outputs</c> category.
 /// </summary>
 /// <param name="client">The client these requests are sent on.</param>
-public readonly partial struct OutputsRequestGroup(ObsWebSocketClient client)
+public readonly partial struct OutputsGroup(ObsWebSocketClient client)
 {
     /// <summary>
     /// Gets the status of the virtualcam output.
@@ -1747,7 +1747,7 @@ public readonly partial struct OutputsRequestGroup(ObsWebSocketClient client)
 /// Requests in the <c>record</c> category.
 /// </summary>
 /// <param name="client">The client these requests are sent on.</param>
-public readonly partial struct RecordRequestGroup(ObsWebSocketClient client)
+public readonly partial struct RecordGroup(ObsWebSocketClient client)
 {
     /// <summary>
     /// Gets the status of the record output.
@@ -1920,7 +1920,7 @@ public readonly partial struct RecordRequestGroup(ObsWebSocketClient client)
 /// Requests in the <c>scene items</c> category.
 /// </summary>
 /// <param name="client">The client these requests are sent on.</param>
-public readonly partial struct SceneItemsRequestGroup(ObsWebSocketClient client)
+public readonly partial struct SceneItemsGroup(ObsWebSocketClient client)
 {
     /// <summary>
     /// Gets a list of all scene items in a scene.
@@ -2295,7 +2295,7 @@ public readonly partial struct SceneItemsRequestGroup(ObsWebSocketClient client)
 /// Requests in the <c>scenes</c> category.
 /// </summary>
 /// <param name="client">The client these requests are sent on.</param>
-public readonly partial struct ScenesRequestGroup(ObsWebSocketClient client)
+public readonly partial struct ScenesGroup(ObsWebSocketClient client)
 {
     /// <summary>
     /// Gets an array of scenes in OBS.
@@ -2523,7 +2523,7 @@ public readonly partial struct ScenesRequestGroup(ObsWebSocketClient client)
 /// Requests in the <c>sources</c> category.
 /// </summary>
 /// <param name="client">The client these requests are sent on.</param>
-public readonly partial struct SourcesRequestGroup(ObsWebSocketClient client)
+public readonly partial struct SourcesGroup(ObsWebSocketClient client)
 {
     /// <summary>
     /// Gets the active and show state of a source.
@@ -2600,7 +2600,7 @@ public readonly partial struct SourcesRequestGroup(ObsWebSocketClient client)
 /// Requests in the <c>stream</c> category.
 /// </summary>
 /// <param name="client">The client these requests are sent on.</param>
-public readonly partial struct StreamRequestGroup(ObsWebSocketClient client)
+public readonly partial struct StreamGroup(ObsWebSocketClient client)
 {
     /// <summary>
     /// Gets the status of the stream output.
@@ -2699,7 +2699,7 @@ public readonly partial struct StreamRequestGroup(ObsWebSocketClient client)
 /// Requests in the <c>transitions</c> category.
 /// </summary>
 /// <param name="client">The client these requests are sent on.</param>
-public readonly partial struct TransitionsRequestGroup(ObsWebSocketClient client)
+public readonly partial struct TransitionsGroup(ObsWebSocketClient client)
 {
     /// <summary>
     /// Gets an array of all available transition kinds.
@@ -2881,7 +2881,7 @@ public readonly partial struct TransitionsRequestGroup(ObsWebSocketClient client
 /// Requests in the <c>ui</c> category.
 /// </summary>
 /// <param name="client">The client these requests are sent on.</param>
-public readonly partial struct UiRequestGroup(ObsWebSocketClient client)
+public readonly partial struct UiGroup(ObsWebSocketClient client)
 {
     /// <summary>
     /// Gets whether studio is enabled.
@@ -3055,7 +3055,7 @@ public static class ObsWebSocketClientExtensions
         /// <summary>
         /// Requests in the <c>canvases</c> category.
         /// </summary>
-        public CanvasesRequestGroup Canvases => new(client);
+        public CanvasesGroup Canvases => new(client);
     }
 
     extension(ObsWebSocketClient client)
@@ -3063,7 +3063,7 @@ public static class ObsWebSocketClientExtensions
         /// <summary>
         /// Requests in the <c>config</c> category.
         /// </summary>
-        public ConfigRequestGroup Config => new(client);
+        public ConfigGroup Config => new(client);
     }
 
     extension(ObsWebSocketClient client)
@@ -3071,7 +3071,7 @@ public static class ObsWebSocketClientExtensions
         /// <summary>
         /// Requests in the <c>filters</c> category.
         /// </summary>
-        public FiltersRequestGroup Filters => new(client);
+        public FiltersGroup Filters => new(client);
     }
 
     extension(ObsWebSocketClient client)
@@ -3079,7 +3079,7 @@ public static class ObsWebSocketClientExtensions
         /// <summary>
         /// Requests in the <c>general</c> category.
         /// </summary>
-        public GeneralRequestGroup General => new(client);
+        public GeneralGroup General => new(client);
     }
 
     extension(ObsWebSocketClient client)
@@ -3087,7 +3087,7 @@ public static class ObsWebSocketClientExtensions
         /// <summary>
         /// Requests in the <c>inputs</c> category.
         /// </summary>
-        public InputsRequestGroup Inputs => new(client);
+        public InputsGroup Inputs => new(client);
     }
 
     extension(ObsWebSocketClient client)
@@ -3095,7 +3095,7 @@ public static class ObsWebSocketClientExtensions
         /// <summary>
         /// Requests in the <c>media inputs</c> category.
         /// </summary>
-        public MediaInputsRequestGroup MediaInputs => new(client);
+        public MediaInputsGroup MediaInputs => new(client);
     }
 
     extension(ObsWebSocketClient client)
@@ -3103,7 +3103,7 @@ public static class ObsWebSocketClientExtensions
         /// <summary>
         /// Requests in the <c>outputs</c> category.
         /// </summary>
-        public OutputsRequestGroup Outputs => new(client);
+        public OutputsGroup Outputs => new(client);
     }
 
     extension(ObsWebSocketClient client)
@@ -3111,7 +3111,7 @@ public static class ObsWebSocketClientExtensions
         /// <summary>
         /// Requests in the <c>record</c> category.
         /// </summary>
-        public RecordRequestGroup Record => new(client);
+        public RecordGroup Record => new(client);
     }
 
     extension(ObsWebSocketClient client)
@@ -3119,7 +3119,7 @@ public static class ObsWebSocketClientExtensions
         /// <summary>
         /// Requests in the <c>scene items</c> category.
         /// </summary>
-        public SceneItemsRequestGroup SceneItems => new(client);
+        public SceneItemsGroup SceneItems => new(client);
     }
 
     extension(ObsWebSocketClient client)
@@ -3127,7 +3127,7 @@ public static class ObsWebSocketClientExtensions
         /// <summary>
         /// Requests in the <c>scenes</c> category.
         /// </summary>
-        public ScenesRequestGroup Scenes => new(client);
+        public ScenesGroup Scenes => new(client);
     }
 
     extension(ObsWebSocketClient client)
@@ -3135,7 +3135,7 @@ public static class ObsWebSocketClientExtensions
         /// <summary>
         /// Requests in the <c>sources</c> category.
         /// </summary>
-        public SourcesRequestGroup Sources => new(client);
+        public SourcesGroup Sources => new(client);
     }
 
     extension(ObsWebSocketClient client)
@@ -3143,7 +3143,7 @@ public static class ObsWebSocketClientExtensions
         /// <summary>
         /// Requests in the <c>stream</c> category.
         /// </summary>
-        public StreamRequestGroup Stream => new(client);
+        public StreamGroup Stream => new(client);
     }
 
     extension(ObsWebSocketClient client)
@@ -3151,7 +3151,7 @@ public static class ObsWebSocketClientExtensions
         /// <summary>
         /// Requests in the <c>transitions</c> category.
         /// </summary>
-        public TransitionsRequestGroup Transitions => new(client);
+        public TransitionsGroup Transitions => new(client);
     }
 
     extension(ObsWebSocketClient client)
@@ -3159,7 +3159,7 @@ public static class ObsWebSocketClientExtensions
         /// <summary>
         /// Requests in the <c>ui</c> category.
         /// </summary>
-        public UiRequestGroup Ui => new(client);
+        public UiGroup Ui => new(client);
     }
 
 }

--- a/ObsWebSocket.Core/Generated/Protocol/Events/CurrentSceneTransitionDurationChanged.EventPayload.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Events/CurrentSceneTransitionDurationChanged.EventPayload.g.cs
@@ -29,7 +29,7 @@ public sealed partial record CurrentSceneTransitionDurationChangedPayload
     /// </summary>
     [JsonPropertyName("transitionDuration")]
     [Key("transitionDuration")]
-    public required double TransitionDuration { get; init; }
+    public required int TransitionDuration { get; init; }
 
     /// <summary>Initializes a new instance for deserialization via <see cref="JsonConstructorAttribute"/>.</summary>
     [JsonConstructor]
@@ -40,7 +40,7 @@ public sealed partial record CurrentSceneTransitionDurationChangedPayload
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public CurrentSceneTransitionDurationChangedPayload(double transitionDuration)
+    public CurrentSceneTransitionDurationChangedPayload(int transitionDuration)
     {
         this.TransitionDuration = transitionDuration;
     }

--- a/ObsWebSocket.Core/Generated/Protocol/Events/InputAudioSyncOffsetChanged.EventPayload.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Events/InputAudioSyncOffsetChanged.EventPayload.g.cs
@@ -29,7 +29,7 @@ public sealed partial record InputAudioSyncOffsetChangedPayload
     /// </summary>
     [JsonPropertyName("inputAudioSyncOffset")]
     [Key("inputAudioSyncOffset")]
-    public required double InputAudioSyncOffset { get; init; }
+    public required int InputAudioSyncOffset { get; init; }
 
     /// <summary>
     /// Name of the input
@@ -54,7 +54,7 @@ public sealed partial record InputAudioSyncOffsetChangedPayload
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public InputAudioSyncOffsetChangedPayload(double inputAudioSyncOffset, string? inputName = null, string? inputUuid = null)
+    public InputAudioSyncOffsetChangedPayload(int inputAudioSyncOffset, string? inputName = null, string? inputUuid = null)
     {
         this.InputName = inputName;
         this.InputUuid = inputUuid;

--- a/ObsWebSocket.Core/Generated/Protocol/Events/InputCreated.EventPayload.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Events/InputCreated.EventPayload.g.cs
@@ -43,7 +43,7 @@ public sealed partial record InputCreatedPayload
     /// </summary>
     [JsonPropertyName("inputKindCaps")]
     [Key("inputKindCaps")]
-    public required double InputKindCaps { get; init; }
+    public required long InputKindCaps { get; init; }
 
     /// <summary>
     /// Name of the input
@@ -82,7 +82,7 @@ public sealed partial record InputCreatedPayload
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public InputCreatedPayload(double inputKindCaps, string? inputName = null, string? inputUuid = null, string? inputKind = null, string? unversionedInputKind = null, System.Text.Json.JsonElement? inputSettings = null, System.Text.Json.JsonElement? defaultInputSettings = null)
+    public InputCreatedPayload(long inputKindCaps, string? inputName = null, string? inputUuid = null, string? inputKind = null, string? unversionedInputKind = null, System.Text.Json.JsonElement? inputSettings = null, System.Text.Json.JsonElement? defaultInputSettings = null)
     {
         this.InputName = inputName;
         this.InputUuid = inputUuid;

--- a/ObsWebSocket.Core/Generated/Protocol/Events/SceneItemCreated.EventPayload.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Events/SceneItemCreated.EventPayload.g.cs
@@ -29,14 +29,14 @@ public sealed partial record SceneItemCreatedPayload
     /// </summary>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// Index position of the item
     /// </summary>
     [JsonPropertyName("sceneItemIndex")]
     [Key("sceneItemIndex")]
-    public required double SceneItemIndex { get; init; }
+    public required int SceneItemIndex { get; init; }
 
     /// <summary>
     /// Name of the scene the item was added to
@@ -75,7 +75,7 @@ public sealed partial record SceneItemCreatedPayload
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SceneItemCreatedPayload(double sceneItemId, double sceneItemIndex, string? sceneName = null, string? sceneUuid = null, string? sourceName = null, string? sourceUuid = null)
+    public SceneItemCreatedPayload(int sceneItemId, int sceneItemIndex, string? sceneName = null, string? sceneUuid = null, string? sourceName = null, string? sourceUuid = null)
     {
         this.SceneName = sceneName;
         this.SceneUuid = sceneUuid;

--- a/ObsWebSocket.Core/Generated/Protocol/Events/SceneItemEnableStateChanged.EventPayload.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Events/SceneItemEnableStateChanged.EventPayload.g.cs
@@ -36,7 +36,7 @@ public sealed partial record SceneItemEnableStateChangedPayload
     /// </summary>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// Name of the scene the item is in
@@ -61,7 +61,7 @@ public sealed partial record SceneItemEnableStateChangedPayload
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SceneItemEnableStateChangedPayload(double sceneItemId, bool sceneItemEnabled, string? sceneName = null, string? sceneUuid = null)
+    public SceneItemEnableStateChangedPayload(int sceneItemId, bool sceneItemEnabled, string? sceneName = null, string? sceneUuid = null)
     {
         this.SceneName = sceneName;
         this.SceneUuid = sceneUuid;

--- a/ObsWebSocket.Core/Generated/Protocol/Events/SceneItemLockStateChanged.EventPayload.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Events/SceneItemLockStateChanged.EventPayload.g.cs
@@ -29,7 +29,7 @@ public sealed partial record SceneItemLockStateChangedPayload
     /// </summary>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// Whether the scene item is locked
@@ -61,7 +61,7 @@ public sealed partial record SceneItemLockStateChangedPayload
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SceneItemLockStateChangedPayload(double sceneItemId, bool sceneItemLocked, string? sceneName = null, string? sceneUuid = null)
+    public SceneItemLockStateChangedPayload(int sceneItemId, bool sceneItemLocked, string? sceneName = null, string? sceneUuid = null)
     {
         this.SceneName = sceneName;
         this.SceneUuid = sceneUuid;

--- a/ObsWebSocket.Core/Generated/Protocol/Events/SceneItemRemoved.EventPayload.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Events/SceneItemRemoved.EventPayload.g.cs
@@ -31,7 +31,7 @@ public sealed partial record SceneItemRemovedPayload
     /// </summary>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// Name of the scene the item was removed from
@@ -70,7 +70,7 @@ public sealed partial record SceneItemRemovedPayload
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SceneItemRemovedPayload(double sceneItemId, string? sceneName = null, string? sceneUuid = null, string? sourceName = null, string? sourceUuid = null)
+    public SceneItemRemovedPayload(int sceneItemId, string? sceneName = null, string? sceneUuid = null, string? sourceName = null, string? sourceUuid = null)
     {
         this.SceneName = sceneName;
         this.SceneUuid = sceneUuid;

--- a/ObsWebSocket.Core/Generated/Protocol/Events/SceneItemSelected.EventPayload.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Events/SceneItemSelected.EventPayload.g.cs
@@ -29,7 +29,7 @@ public sealed partial record SceneItemSelectedPayload
     /// </summary>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// Name of the scene the item is in
@@ -54,7 +54,7 @@ public sealed partial record SceneItemSelectedPayload
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SceneItemSelectedPayload(double sceneItemId, string? sceneName = null, string? sceneUuid = null)
+    public SceneItemSelectedPayload(int sceneItemId, string? sceneName = null, string? sceneUuid = null)
     {
         this.SceneName = sceneName;
         this.SceneUuid = sceneUuid;

--- a/ObsWebSocket.Core/Generated/Protocol/Events/SceneItemTransformChanged.EventPayload.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Events/SceneItemTransformChanged.EventPayload.g.cs
@@ -29,7 +29,7 @@ public sealed partial record SceneItemTransformChangedPayload
     /// </summary>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// New transform/crop info of the scene item
@@ -61,7 +61,7 @@ public sealed partial record SceneItemTransformChangedPayload
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SceneItemTransformChangedPayload(double sceneItemId, string? sceneName = null, string? sceneUuid = null, ObsWebSocket.Core.Protocol.Common.SceneItemTransformStub? sceneItemTransform = null)
+    public SceneItemTransformChangedPayload(int sceneItemId, string? sceneName = null, string? sceneUuid = null, ObsWebSocket.Core.Protocol.Common.SceneItemTransformStub? sceneItemTransform = null)
     {
         this.SceneName = sceneName;
         this.SceneUuid = sceneUuid;

--- a/ObsWebSocket.Core/Generated/Protocol/Events/SourceFilterCreated.EventPayload.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Events/SourceFilterCreated.EventPayload.g.cs
@@ -36,7 +36,7 @@ public sealed partial record SourceFilterCreatedPayload
     /// </summary>
     [JsonPropertyName("filterIndex")]
     [Key("filterIndex")]
-    public required double FilterIndex { get; init; }
+    public required int FilterIndex { get; init; }
 
     /// <summary>
     /// The kind of the filter
@@ -75,7 +75,7 @@ public sealed partial record SourceFilterCreatedPayload
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SourceFilterCreatedPayload(double filterIndex, string? sourceName = null, string? filterName = null, string? filterKind = null, System.Text.Json.JsonElement? filterSettings = null, System.Text.Json.JsonElement? defaultFilterSettings = null)
+    public SourceFilterCreatedPayload(int filterIndex, string? sourceName = null, string? filterName = null, string? filterKind = null, System.Text.Json.JsonElement? filterSettings = null, System.Text.Json.JsonElement? defaultFilterSettings = null)
     {
         this.SourceName = sourceName;
         this.FilterName = filterName;

--- a/ObsWebSocket.Core/Generated/Protocol/Generated/RequestStatusCode.Enum.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Generated/RequestStatusCode.Enum.g.cs
@@ -5,10 +5,10 @@
 namespace ObsWebSocket.Core.Protocol.Generated;
 
 /// <summary>
-/// Represents the RequestStatus options defined in the OBS WebSocket protocol.
+/// Represents the RequestStatusCode options defined in the OBS WebSocket protocol.
 /// </summary>
 /// <remarks>Generated from OBS WebSocket Protocol definition.</remarks>
-public enum RequestStatus : int
+public enum RequestStatusCode : int
 {
     /// <summary>
     /// Unknown status, should never be used.

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/DuplicateSceneItem.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/DuplicateSceneItem.Request.g.cs
@@ -68,7 +68,7 @@ public sealed partial record DuplicateSceneItemRequestData
     /// </remarks>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// Name of the scene the item is in
@@ -101,7 +101,7 @@ public sealed partial record DuplicateSceneItemRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public DuplicateSceneItemRequestData(double sceneItemId, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null, string? destinationSceneName = null, string? destinationSceneUuid = null)
+    public DuplicateSceneItemRequestData(int sceneItemId, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null, string? destinationSceneName = null, string? destinationSceneUuid = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SceneName = sceneName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/GetSceneItemBlendMode.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/GetSceneItemBlendMode.Request.g.cs
@@ -56,7 +56,7 @@ public sealed partial record GetSceneItemBlendModeRequestData
     /// </remarks>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// Name of the scene the item is in
@@ -89,7 +89,7 @@ public sealed partial record GetSceneItemBlendModeRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetSceneItemBlendModeRequestData(double sceneItemId, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
+    public GetSceneItemBlendModeRequestData(int sceneItemId, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SceneName = sceneName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/GetSceneItemEnabled.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/GetSceneItemEnabled.Request.g.cs
@@ -46,7 +46,7 @@ public sealed partial record GetSceneItemEnabledRequestData
     /// </remarks>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// Name of the scene the item is in
@@ -79,7 +79,7 @@ public sealed partial record GetSceneItemEnabledRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetSceneItemEnabledRequestData(double sceneItemId, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
+    public GetSceneItemEnabledRequestData(int sceneItemId, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SceneName = sceneName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/GetSceneItemId.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/GetSceneItemId.Request.g.cs
@@ -69,7 +69,7 @@ public sealed partial record GetSceneItemIdRequestData
     /// </remarks>
     [JsonPropertyName("searchOffset")]
     [Key("searchOffset")]
-    public double? SearchOffset { get; init; }
+    public int? SearchOffset { get; init; }
 
     /// <summary>
     /// Name of the source to find
@@ -90,7 +90,7 @@ public sealed partial record GetSceneItemIdRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetSceneItemIdRequestData(string sourceName, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null, double? searchOffset = null)
+    public GetSceneItemIdRequestData(string sourceName, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null, int? searchOffset = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SceneName = sceneName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/GetSceneItemIndex.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/GetSceneItemIndex.Request.g.cs
@@ -48,7 +48,7 @@ public sealed partial record GetSceneItemIndexRequestData
     /// </remarks>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// Name of the scene the item is in
@@ -81,7 +81,7 @@ public sealed partial record GetSceneItemIndexRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetSceneItemIndexRequestData(double sceneItemId, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
+    public GetSceneItemIndexRequestData(int sceneItemId, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SceneName = sceneName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/GetSceneItemLocked.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/GetSceneItemLocked.Request.g.cs
@@ -46,7 +46,7 @@ public sealed partial record GetSceneItemLockedRequestData
     /// </remarks>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// Name of the scene the item is in
@@ -79,7 +79,7 @@ public sealed partial record GetSceneItemLockedRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetSceneItemLockedRequestData(double sceneItemId, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
+    public GetSceneItemLockedRequestData(int sceneItemId, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SceneName = sceneName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/GetSceneItemSource.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/GetSceneItemSource.Request.g.cs
@@ -44,7 +44,7 @@ public sealed partial record GetSceneItemSourceRequestData
     /// </remarks>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// Name of the scene the item is in
@@ -77,7 +77,7 @@ public sealed partial record GetSceneItemSourceRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetSceneItemSourceRequestData(double sceneItemId, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
+    public GetSceneItemSourceRequestData(int sceneItemId, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SceneName = sceneName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/GetSceneItemTransform.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/GetSceneItemTransform.Request.g.cs
@@ -46,7 +46,7 @@ public sealed partial record GetSceneItemTransformRequestData
     /// </remarks>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// Name of the scene the item is in
@@ -79,7 +79,7 @@ public sealed partial record GetSceneItemTransformRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetSceneItemTransformRequestData(double sceneItemId, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
+    public GetSceneItemTransformRequestData(int sceneItemId, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SceneName = sceneName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/GetSourceScreenshot.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/GetSourceScreenshot.Request.g.cs
@@ -50,7 +50,7 @@ public sealed partial record GetSourceScreenshotRequestData
     /// </remarks>
     [JsonPropertyName("imageCompressionQuality")]
     [Key("imageCompressionQuality")]
-    public double? ImageCompressionQuality { get; init; }
+    public int? ImageCompressionQuality { get; init; }
 
     /// <summary>
     /// Image compression format to use. Use `GetVersion` to get compatible image formats
@@ -72,7 +72,7 @@ public sealed partial record GetSourceScreenshotRequestData
     /// </remarks>
     [JsonPropertyName("imageHeight")]
     [Key("imageHeight")]
-    public double? ImageHeight { get; init; }
+    public int? ImageHeight { get; init; }
 
     /// <summary>
     /// Width to scale the screenshot to
@@ -84,7 +84,7 @@ public sealed partial record GetSourceScreenshotRequestData
     /// </remarks>
     [JsonPropertyName("imageWidth")]
     [Key("imageWidth")]
-    public double? ImageWidth { get; init; }
+    public int? ImageWidth { get; init; }
 
     /// <summary>
     /// Name of the source to take a screenshot of
@@ -117,7 +117,7 @@ public sealed partial record GetSourceScreenshotRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetSourceScreenshotRequestData(string imageFormat, string? canvasUuid = null, string? sourceName = null, string? sourceUuid = null, double? imageWidth = null, double? imageHeight = null, double? imageCompressionQuality = null)
+    public GetSourceScreenshotRequestData(string imageFormat, string? canvasUuid = null, string? sourceName = null, string? sourceUuid = null, int? imageWidth = null, int? imageHeight = null, int? imageCompressionQuality = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SourceName = sourceName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/OffsetMediaInputCursor.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/OffsetMediaInputCursor.Request.g.cs
@@ -56,7 +56,7 @@ public sealed partial record OffsetMediaInputCursorRequestData
     /// </remarks>
     [JsonPropertyName("mediaCursorOffset")]
     [Key("mediaCursorOffset")]
-    public required double MediaCursorOffset { get; init; }
+    public required long MediaCursorOffset { get; init; }
 
     /// <summary>Initializes a new instance for deserialization via <see cref="JsonConstructorAttribute"/>.</summary>
     [JsonConstructor]
@@ -67,7 +67,7 @@ public sealed partial record OffsetMediaInputCursorRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public OffsetMediaInputCursorRequestData(double mediaCursorOffset, string? inputName = null, string? inputUuid = null)
+    public OffsetMediaInputCursorRequestData(long mediaCursorOffset, string? inputName = null, string? inputUuid = null)
     {
         this.InputName = inputName;
         this.InputUuid = inputUuid;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/OpenSourceProjector.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/OpenSourceProjector.Request.g.cs
@@ -46,7 +46,7 @@ public sealed partial record OpenSourceProjectorRequestData
     /// </remarks>
     [JsonPropertyName("monitorIndex")]
     [Key("monitorIndex")]
-    public double? MonitorIndex { get; init; }
+    public int? MonitorIndex { get; init; }
 
     /// <summary>
     /// Size/Position data for a windowed projector, in Qt Base64 encoded format. Mutually exclusive with `monitorIndex`
@@ -89,7 +89,7 @@ public sealed partial record OpenSourceProjectorRequestData
     /// Initializes a new instance with all properties specified.
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
-    public OpenSourceProjectorRequestData(string? canvasUuid = null, string? sourceName = null, string? sourceUuid = null, double? monitorIndex = null, string? projectorGeometry = null)
+    public OpenSourceProjectorRequestData(string? canvasUuid = null, string? sourceName = null, string? sourceUuid = null, int? monitorIndex = null, string? projectorGeometry = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SourceName = sourceName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/OpenVideoMixProjector.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/OpenVideoMixProjector.Request.g.cs
@@ -41,7 +41,7 @@ public sealed partial record OpenVideoMixProjectorRequestData
     /// </remarks>
     [JsonPropertyName("monitorIndex")]
     [Key("monitorIndex")]
-    public double? MonitorIndex { get; init; }
+    public int? MonitorIndex { get; init; }
 
     /// <summary>
     /// Size/Position data for a windowed projector, in Qt Base64 encoded format. Mutually exclusive with `monitorIndex`
@@ -73,7 +73,7 @@ public sealed partial record OpenVideoMixProjectorRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public OpenVideoMixProjectorRequestData(string videoMixType, double? monitorIndex = null, string? projectorGeometry = null)
+    public OpenVideoMixProjectorRequestData(string videoMixType, int? monitorIndex = null, string? projectorGeometry = null)
     {
         this.VideoMixType = videoMixType;
         this.MonitorIndex = monitorIndex;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/RemoveSceneItem.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/RemoveSceneItem.Request.g.cs
@@ -46,7 +46,7 @@ public sealed partial record RemoveSceneItemRequestData
     /// </remarks>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// Name of the scene the item is in
@@ -79,7 +79,7 @@ public sealed partial record RemoveSceneItemRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public RemoveSceneItemRequestData(double sceneItemId, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
+    public RemoveSceneItemRequestData(int sceneItemId, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SceneName = sceneName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/SaveSourceScreenshot.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/SaveSourceScreenshot.Request.g.cs
@@ -50,7 +50,7 @@ public sealed partial record SaveSourceScreenshotRequestData
     /// </remarks>
     [JsonPropertyName("imageCompressionQuality")]
     [Key("imageCompressionQuality")]
-    public double? ImageCompressionQuality { get; init; }
+    public int? ImageCompressionQuality { get; init; }
 
     /// <summary>
     /// Path to save the screenshot file to. Eg. `C:\Users\user\Desktop\screenshot.png`
@@ -82,7 +82,7 @@ public sealed partial record SaveSourceScreenshotRequestData
     /// </remarks>
     [JsonPropertyName("imageHeight")]
     [Key("imageHeight")]
-    public double? ImageHeight { get; init; }
+    public int? ImageHeight { get; init; }
 
     /// <summary>
     /// Width to scale the screenshot to
@@ -94,7 +94,7 @@ public sealed partial record SaveSourceScreenshotRequestData
     /// </remarks>
     [JsonPropertyName("imageWidth")]
     [Key("imageWidth")]
-    public double? ImageWidth { get; init; }
+    public int? ImageWidth { get; init; }
 
     /// <summary>
     /// Name of the source to take a screenshot of
@@ -127,7 +127,7 @@ public sealed partial record SaveSourceScreenshotRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SaveSourceScreenshotRequestData(string imageFormat, string imageFilePath, string? canvasUuid = null, string? sourceName = null, string? sourceUuid = null, double? imageWidth = null, double? imageHeight = null, double? imageCompressionQuality = null)
+    public SaveSourceScreenshotRequestData(string imageFormat, string imageFilePath, string? canvasUuid = null, string? sourceName = null, string? sourceUuid = null, int? imageWidth = null, int? imageHeight = null, int? imageCompressionQuality = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SourceName = sourceName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/SetCurrentSceneTransitionDuration.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/SetCurrentSceneTransitionDuration.Request.g.cs
@@ -33,7 +33,7 @@ public sealed partial record SetCurrentSceneTransitionDurationRequestData
     /// </remarks>
     [JsonPropertyName("transitionDuration")]
     [Key("transitionDuration")]
-    public required double TransitionDuration { get; init; }
+    public required int TransitionDuration { get; init; }
 
     /// <summary>Initializes a new instance for deserialization via <see cref="JsonConstructorAttribute"/>.</summary>
     [JsonConstructor]
@@ -44,7 +44,7 @@ public sealed partial record SetCurrentSceneTransitionDurationRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SetCurrentSceneTransitionDurationRequestData(double transitionDuration)
+    public SetCurrentSceneTransitionDurationRequestData(int transitionDuration)
     {
         this.TransitionDuration = transitionDuration;
     }

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/SetInputAudioSyncOffset.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/SetInputAudioSyncOffset.Request.g.cs
@@ -33,7 +33,7 @@ public sealed partial record SetInputAudioSyncOffsetRequestData
     /// </remarks>
     [JsonPropertyName("inputAudioSyncOffset")]
     [Key("inputAudioSyncOffset")]
-    public required double InputAudioSyncOffset { get; init; }
+    public required int InputAudioSyncOffset { get; init; }
 
     /// <summary>
     /// Name of the input to set the audio sync offset of
@@ -66,7 +66,7 @@ public sealed partial record SetInputAudioSyncOffsetRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SetInputAudioSyncOffsetRequestData(double inputAudioSyncOffset, string? inputName = null, string? inputUuid = null)
+    public SetInputAudioSyncOffsetRequestData(int inputAudioSyncOffset, string? inputName = null, string? inputUuid = null)
     {
         this.InputName = inputName;
         this.InputUuid = inputUuid;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/SetMediaInputCursor.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/SetMediaInputCursor.Request.g.cs
@@ -57,7 +57,7 @@ public sealed partial record SetMediaInputCursorRequestData
     /// </remarks>
     [JsonPropertyName("mediaCursor")]
     [Key("mediaCursor")]
-    public required double MediaCursor { get; init; }
+    public required long MediaCursor { get; init; }
 
     /// <summary>Initializes a new instance for deserialization via <see cref="JsonConstructorAttribute"/>.</summary>
     [JsonConstructor]
@@ -68,7 +68,7 @@ public sealed partial record SetMediaInputCursorRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SetMediaInputCursorRequestData(double mediaCursor, string? inputName = null, string? inputUuid = null)
+    public SetMediaInputCursorRequestData(long mediaCursor, string? inputName = null, string? inputUuid = null)
     {
         this.InputName = inputName;
         this.InputUuid = inputUuid;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/SetSceneItemBlendMode.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/SetSceneItemBlendMode.Request.g.cs
@@ -56,7 +56,7 @@ public sealed partial record SetSceneItemBlendModeRequestData
     /// </remarks>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// Name of the scene the item is in
@@ -89,7 +89,7 @@ public sealed partial record SetSceneItemBlendModeRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SetSceneItemBlendModeRequestData(double sceneItemId, string sceneItemBlendMode, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
+    public SetSceneItemBlendModeRequestData(int sceneItemId, string sceneItemBlendMode, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SceneName = sceneName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/SetSceneItemEnabled.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/SetSceneItemEnabled.Request.g.cs
@@ -56,7 +56,7 @@ public sealed partial record SetSceneItemEnabledRequestData
     /// </remarks>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// Name of the scene the item is in
@@ -89,7 +89,7 @@ public sealed partial record SetSceneItemEnabledRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SetSceneItemEnabledRequestData(double sceneItemId, bool sceneItemEnabled, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
+    public SetSceneItemEnabledRequestData(int sceneItemId, bool sceneItemEnabled, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SceneName = sceneName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/SetSceneItemIndex.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/SetSceneItemIndex.Request.g.cs
@@ -46,7 +46,7 @@ public sealed partial record SetSceneItemIndexRequestData
     /// </remarks>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// New index position of the scene item
@@ -57,7 +57,7 @@ public sealed partial record SetSceneItemIndexRequestData
     /// </remarks>
     [JsonPropertyName("sceneItemIndex")]
     [Key("sceneItemIndex")]
-    public required double SceneItemIndex { get; init; }
+    public required int SceneItemIndex { get; init; }
 
     /// <summary>
     /// Name of the scene the item is in
@@ -90,7 +90,7 @@ public sealed partial record SetSceneItemIndexRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SetSceneItemIndexRequestData(double sceneItemId, double sceneItemIndex, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
+    public SetSceneItemIndexRequestData(int sceneItemId, int sceneItemIndex, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SceneName = sceneName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/SetSceneItemLocked.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/SetSceneItemLocked.Request.g.cs
@@ -46,7 +46,7 @@ public sealed partial record SetSceneItemLockedRequestData
     /// </remarks>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// New lock state of the scene item
@@ -89,7 +89,7 @@ public sealed partial record SetSceneItemLockedRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SetSceneItemLockedRequestData(double sceneItemId, bool sceneItemLocked, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
+    public SetSceneItemLockedRequestData(int sceneItemId, bool sceneItemLocked, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SceneName = sceneName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/SetSceneItemTransform.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/SetSceneItemTransform.Request.g.cs
@@ -44,7 +44,7 @@ public sealed partial record SetSceneItemTransformRequestData
     /// </remarks>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>
     /// Object containing scene item transform info to update
@@ -87,7 +87,7 @@ public sealed partial record SetSceneItemTransformRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SetSceneItemTransformRequestData(double sceneItemId, ObsWebSocket.Core.Protocol.Common.SceneItemTransformStub? sceneItemTransform, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
+    public SetSceneItemTransformRequestData(int sceneItemId, ObsWebSocket.Core.Protocol.Common.SceneItemTransformStub? sceneItemTransform, string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SceneName = sceneName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/SetSceneSceneTransitionOverride.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/SetSceneSceneTransitionOverride.Request.g.cs
@@ -67,7 +67,7 @@ public sealed partial record SetSceneSceneTransitionOverrideRequestData
     /// </remarks>
     [JsonPropertyName("transitionDuration")]
     [Key("transitionDuration")]
-    public double? TransitionDuration { get; init; }
+    public int? TransitionDuration { get; init; }
 
     /// <summary>
     /// Name of the scene transition to use as override. Specify `null` to remove
@@ -88,7 +88,7 @@ public sealed partial record SetSceneSceneTransitionOverrideRequestData
     /// Initializes a new instance with all properties specified.
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
-    public SetSceneSceneTransitionOverrideRequestData(string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null, string? transitionName = null, double? transitionDuration = null)
+    public SetSceneSceneTransitionOverrideRequestData(string? canvasUuid = null, string? sceneName = null, string? sceneUuid = null, string? transitionName = null, int? transitionDuration = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SceneName = sceneName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/SetSourceFilterIndex.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/SetSourceFilterIndex.Request.g.cs
@@ -44,7 +44,7 @@ public sealed partial record SetSourceFilterIndexRequestData
     /// </remarks>
     [JsonPropertyName("filterIndex")]
     [Key("filterIndex")]
-    public required double FilterIndex { get; init; }
+    public required int FilterIndex { get; init; }
 
     /// <summary>
     /// Name of the filter
@@ -87,7 +87,7 @@ public sealed partial record SetSourceFilterIndexRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SetSourceFilterIndexRequestData(string filterName, double filterIndex, string? canvasUuid = null, string? sourceName = null, string? sourceUuid = null)
+    public SetSourceFilterIndexRequestData(string filterName, int filterIndex, string? canvasUuid = null, string? sourceName = null, string? sourceUuid = null)
     {
         this.CanvasUuid = canvasUuid;
         this.SourceName = sourceName;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/SetTBarPosition.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/SetTBarPosition.Request.g.cs
@@ -35,7 +35,7 @@ public sealed partial record SetTBarPositionRequestData
     /// </remarks>
     [JsonPropertyName("position")]
     [Key("position")]
-    public required double Position { get; init; }
+    public required int Position { get; init; }
 
     /// <summary>
     /// Whether to release the TBar. Only set `false` if you know that you will be sending another position update
@@ -57,7 +57,7 @@ public sealed partial record SetTBarPositionRequestData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public SetTBarPositionRequestData(double position, bool? release = null)
+    public SetTBarPositionRequestData(int position, bool? release = null)
     {
         this.Position = position;
         this.Release = release;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/SetVideoSettings.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/SetVideoSettings.Request.g.cs
@@ -36,7 +36,7 @@ public sealed partial record SetVideoSettingsRequestData
     /// </remarks>
     [JsonPropertyName("baseHeight")]
     [Key("baseHeight")]
-    public double? BaseHeight { get; init; }
+    public int? BaseHeight { get; init; }
 
     /// <summary>
     /// Width of the base (canvas) resolution in pixels
@@ -48,7 +48,7 @@ public sealed partial record SetVideoSettingsRequestData
     /// </remarks>
     [JsonPropertyName("baseWidth")]
     [Key("baseWidth")]
-    public double? BaseWidth { get; init; }
+    public int? BaseWidth { get; init; }
 
     /// <summary>
     /// Denominator of the fractional FPS value
@@ -60,7 +60,7 @@ public sealed partial record SetVideoSettingsRequestData
     /// </remarks>
     [JsonPropertyName("fpsDenominator")]
     [Key("fpsDenominator")]
-    public double? FpsDenominator { get; init; }
+    public int? FpsDenominator { get; init; }
 
     /// <summary>
     /// Numerator of the fractional FPS value
@@ -72,7 +72,7 @@ public sealed partial record SetVideoSettingsRequestData
     /// </remarks>
     [JsonPropertyName("fpsNumerator")]
     [Key("fpsNumerator")]
-    public double? FpsNumerator { get; init; }
+    public int? FpsNumerator { get; init; }
 
     /// <summary>
     /// Height of the output resolution in pixels
@@ -84,7 +84,7 @@ public sealed partial record SetVideoSettingsRequestData
     /// </remarks>
     [JsonPropertyName("outputHeight")]
     [Key("outputHeight")]
-    public double? OutputHeight { get; init; }
+    public int? OutputHeight { get; init; }
 
     /// <summary>
     /// Width of the output resolution in pixels
@@ -96,7 +96,7 @@ public sealed partial record SetVideoSettingsRequestData
     /// </remarks>
     [JsonPropertyName("outputWidth")]
     [Key("outputWidth")]
-    public double? OutputWidth { get; init; }
+    public int? OutputWidth { get; init; }
 
     /// <summary>Initializes a new instance for deserialization via <see cref="JsonConstructorAttribute"/>.</summary>
     [JsonConstructor]
@@ -106,7 +106,7 @@ public sealed partial record SetVideoSettingsRequestData
     /// Initializes a new instance with all properties specified.
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
-    public SetVideoSettingsRequestData(double? fpsNumerator = null, double? fpsDenominator = null, double? baseWidth = null, double? baseHeight = null, double? outputWidth = null, double? outputHeight = null)
+    public SetVideoSettingsRequestData(int? fpsNumerator = null, int? fpsDenominator = null, int? baseWidth = null, int? baseHeight = null, int? outputWidth = null, int? outputHeight = null)
     {
         this.FpsNumerator = fpsNumerator;
         this.FpsDenominator = fpsDenominator;

--- a/ObsWebSocket.Core/Generated/Protocol/Requests/Sleep.Request.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Requests/Sleep.Request.g.cs
@@ -34,7 +34,7 @@ public sealed partial record SleepRequestData
     /// </remarks>
     [JsonPropertyName("sleepFrames")]
     [Key("sleepFrames")]
-    public double? SleepFrames { get; init; }
+    public int? SleepFrames { get; init; }
 
     /// <summary>
     /// Number of milliseconds to sleep for (if `SERIAL_REALTIME` mode)
@@ -46,7 +46,7 @@ public sealed partial record SleepRequestData
     /// </remarks>
     [JsonPropertyName("sleepMillis")]
     [Key("sleepMillis")]
-    public double? SleepMillis { get; init; }
+    public int? SleepMillis { get; init; }
 
     /// <summary>Initializes a new instance for deserialization via <see cref="JsonConstructorAttribute"/>.</summary>
     [JsonConstructor]
@@ -56,7 +56,7 @@ public sealed partial record SleepRequestData
     /// Initializes a new instance with all properties specified.
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
-    public SleepRequestData(double? sleepMillis = null, double? sleepFrames = null)
+    public SleepRequestData(int? sleepMillis = null, int? sleepFrames = null)
     {
         this.SleepMillis = sleepMillis;
         this.SleepFrames = sleepFrames;

--- a/ObsWebSocket.Core/Generated/Protocol/Responses/CreateInput.Response.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Responses/CreateInput.Response.g.cs
@@ -36,7 +36,7 @@ public sealed partial record CreateInputResponseData
     /// </summary>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>Initializes a new instance for deserialization via <see cref="JsonConstructorAttribute"/>.</summary>
     [JsonConstructor]
@@ -47,7 +47,7 @@ public sealed partial record CreateInputResponseData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public CreateInputResponseData(double sceneItemId, string? inputUuid = null)
+    public CreateInputResponseData(int sceneItemId, string? inputUuid = null)
     {
         this.InputUuid = inputUuid;
         this.SceneItemId = sceneItemId;

--- a/ObsWebSocket.Core/Generated/Protocol/Responses/CreateSceneItem.Response.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Responses/CreateSceneItem.Response.g.cs
@@ -31,7 +31,7 @@ public sealed partial record CreateSceneItemResponseData
     /// </summary>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>Initializes a new instance for deserialization via <see cref="JsonConstructorAttribute"/>.</summary>
     [JsonConstructor]
@@ -42,7 +42,7 @@ public sealed partial record CreateSceneItemResponseData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public CreateSceneItemResponseData(double sceneItemId)
+    public CreateSceneItemResponseData(int sceneItemId)
     {
         this.SceneItemId = sceneItemId;
     }

--- a/ObsWebSocket.Core/Generated/Protocol/Responses/DuplicateSceneItem.Response.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Responses/DuplicateSceneItem.Response.g.cs
@@ -31,7 +31,7 @@ public sealed partial record DuplicateSceneItemResponseData
     /// </summary>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>Initializes a new instance for deserialization via <see cref="JsonConstructorAttribute"/>.</summary>
     [JsonConstructor]
@@ -42,7 +42,7 @@ public sealed partial record DuplicateSceneItemResponseData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public DuplicateSceneItemResponseData(double sceneItemId)
+    public DuplicateSceneItemResponseData(int sceneItemId)
     {
         this.SceneItemId = sceneItemId;
     }

--- a/ObsWebSocket.Core/Generated/Protocol/Responses/GetCurrentSceneTransition.Response.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Responses/GetCurrentSceneTransition.Response.g.cs
@@ -36,7 +36,7 @@ public sealed partial record GetCurrentSceneTransitionResponseData
     /// </summary>
     [JsonPropertyName("transitionDuration")]
     [Key("transitionDuration")]
-    public double? TransitionDuration { get; init; }
+    public int? TransitionDuration { get; init; }
 
     /// <summary>
     /// Whether the transition uses a fixed (unconfigurable) duration
@@ -82,7 +82,7 @@ public sealed partial record GetCurrentSceneTransitionResponseData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetCurrentSceneTransitionResponseData(bool transitionFixed, bool transitionConfigurable, string? transitionName = null, string? transitionUuid = null, string? transitionKind = null, double? transitionDuration = null, System.Text.Json.JsonElement? transitionSettings = null)
+    public GetCurrentSceneTransitionResponseData(bool transitionFixed, bool transitionConfigurable, string? transitionName = null, string? transitionUuid = null, string? transitionKind = null, int? transitionDuration = null, System.Text.Json.JsonElement? transitionSettings = null)
     {
         this.TransitionName = transitionName;
         this.TransitionUuid = transitionUuid;

--- a/ObsWebSocket.Core/Generated/Protocol/Responses/GetInputAudioSyncOffset.Response.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Responses/GetInputAudioSyncOffset.Response.g.cs
@@ -31,7 +31,7 @@ public sealed partial record GetInputAudioSyncOffsetResponseData
     /// </summary>
     [JsonPropertyName("inputAudioSyncOffset")]
     [Key("inputAudioSyncOffset")]
-    public required double InputAudioSyncOffset { get; init; }
+    public required int InputAudioSyncOffset { get; init; }
 
     /// <summary>Initializes a new instance for deserialization via <see cref="JsonConstructorAttribute"/>.</summary>
     [JsonConstructor]
@@ -42,7 +42,7 @@ public sealed partial record GetInputAudioSyncOffsetResponseData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetInputAudioSyncOffsetResponseData(double inputAudioSyncOffset)
+    public GetInputAudioSyncOffsetResponseData(int inputAudioSyncOffset)
     {
         this.InputAudioSyncOffset = inputAudioSyncOffset;
     }

--- a/ObsWebSocket.Core/Generated/Protocol/Responses/GetMediaInputStatus.Response.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Responses/GetMediaInputStatus.Response.g.cs
@@ -40,14 +40,14 @@ public sealed partial record GetMediaInputStatusResponseData
     /// </summary>
     [JsonPropertyName("mediaCursor")]
     [Key("mediaCursor")]
-    public double? MediaCursor { get; init; }
+    public long? MediaCursor { get; init; }
 
     /// <summary>
     /// Total duration of the playing media in milliseconds. `null` if not playing
     /// </summary>
     [JsonPropertyName("mediaDuration")]
     [Key("mediaDuration")]
-    public double? MediaDuration { get; init; }
+    public long? MediaDuration { get; init; }
 
     /// <summary>
     /// State of the media input
@@ -64,7 +64,7 @@ public sealed partial record GetMediaInputStatusResponseData
     /// Initializes a new instance with all properties specified.
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
-    public GetMediaInputStatusResponseData(string? mediaState = null, double? mediaDuration = null, double? mediaCursor = null)
+    public GetMediaInputStatusResponseData(string? mediaState = null, long? mediaDuration = null, long? mediaCursor = null)
     {
         this.MediaState = mediaState;
         this.MediaDuration = mediaDuration;

--- a/ObsWebSocket.Core/Generated/Protocol/Responses/GetOutputStatus.Response.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Responses/GetOutputStatus.Response.g.cs
@@ -36,7 +36,7 @@ public sealed partial record GetOutputStatusResponseData
     /// </summary>
     [JsonPropertyName("outputBytes")]
     [Key("outputBytes")]
-    public required double OutputBytes { get; init; }
+    public required long OutputBytes { get; init; }
 
     /// <summary>
     /// Congestion of the output
@@ -50,7 +50,7 @@ public sealed partial record GetOutputStatusResponseData
     /// </summary>
     [JsonPropertyName("outputDuration")]
     [Key("outputDuration")]
-    public required double OutputDuration { get; init; }
+    public required long OutputDuration { get; init; }
 
     /// <summary>
     /// Whether the output is reconnecting
@@ -64,7 +64,7 @@ public sealed partial record GetOutputStatusResponseData
     /// </summary>
     [JsonPropertyName("outputSkippedFrames")]
     [Key("outputSkippedFrames")]
-    public required double OutputSkippedFrames { get; init; }
+    public required int OutputSkippedFrames { get; init; }
 
     /// <summary>
     /// Current formatted timecode string for the output
@@ -78,7 +78,7 @@ public sealed partial record GetOutputStatusResponseData
     /// </summary>
     [JsonPropertyName("outputTotalFrames")]
     [Key("outputTotalFrames")]
-    public required double OutputTotalFrames { get; init; }
+    public required int OutputTotalFrames { get; init; }
 
     /// <summary>Initializes a new instance for deserialization via <see cref="JsonConstructorAttribute"/>.</summary>
     [JsonConstructor]
@@ -89,7 +89,7 @@ public sealed partial record GetOutputStatusResponseData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetOutputStatusResponseData(bool outputActive, bool outputReconnecting, double outputDuration, double outputCongestion, double outputBytes, double outputSkippedFrames, double outputTotalFrames, string? outputTimecode = null)
+    public GetOutputStatusResponseData(bool outputActive, bool outputReconnecting, long outputDuration, double outputCongestion, long outputBytes, int outputSkippedFrames, int outputTotalFrames, string? outputTimecode = null)
     {
         this.OutputActive = outputActive;
         this.OutputReconnecting = outputReconnecting;

--- a/ObsWebSocket.Core/Generated/Protocol/Responses/GetRecordStatus.Response.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Responses/GetRecordStatus.Response.g.cs
@@ -36,14 +36,14 @@ public sealed partial record GetRecordStatusResponseData
     /// </summary>
     [JsonPropertyName("outputBytes")]
     [Key("outputBytes")]
-    public required double OutputBytes { get; init; }
+    public required long OutputBytes { get; init; }
 
     /// <summary>
     /// Current duration in milliseconds for the output
     /// </summary>
     [JsonPropertyName("outputDuration")]
     [Key("outputDuration")]
-    public required double OutputDuration { get; init; }
+    public required long OutputDuration { get; init; }
 
     /// <summary>
     /// Whether the output is paused
@@ -68,7 +68,7 @@ public sealed partial record GetRecordStatusResponseData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetRecordStatusResponseData(bool outputActive, bool outputPaused, double outputDuration, double outputBytes, string? outputTimecode = null)
+    public GetRecordStatusResponseData(bool outputActive, bool outputPaused, long outputDuration, long outputBytes, string? outputTimecode = null)
     {
         this.OutputActive = outputActive;
         this.OutputPaused = outputPaused;

--- a/ObsWebSocket.Core/Generated/Protocol/Responses/GetSceneItemId.Response.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Responses/GetSceneItemId.Response.g.cs
@@ -31,7 +31,7 @@ public sealed partial record GetSceneItemIdResponseData
     /// </summary>
     [JsonPropertyName("sceneItemId")]
     [Key("sceneItemId")]
-    public required double SceneItemId { get; init; }
+    public required int SceneItemId { get; init; }
 
     /// <summary>Initializes a new instance for deserialization via <see cref="JsonConstructorAttribute"/>.</summary>
     [JsonConstructor]
@@ -42,7 +42,7 @@ public sealed partial record GetSceneItemIdResponseData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetSceneItemIdResponseData(double sceneItemId)
+    public GetSceneItemIdResponseData(int sceneItemId)
     {
         this.SceneItemId = sceneItemId;
     }

--- a/ObsWebSocket.Core/Generated/Protocol/Responses/GetSceneItemIndex.Response.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Responses/GetSceneItemIndex.Response.g.cs
@@ -33,7 +33,7 @@ public sealed partial record GetSceneItemIndexResponseData
     /// </summary>
     [JsonPropertyName("sceneItemIndex")]
     [Key("sceneItemIndex")]
-    public required double SceneItemIndex { get; init; }
+    public required int SceneItemIndex { get; init; }
 
     /// <summary>Initializes a new instance for deserialization via <see cref="JsonConstructorAttribute"/>.</summary>
     [JsonConstructor]
@@ -44,7 +44,7 @@ public sealed partial record GetSceneItemIndexResponseData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetSceneItemIndexResponseData(double sceneItemIndex)
+    public GetSceneItemIndexResponseData(int sceneItemIndex)
     {
         this.SceneItemIndex = sceneItemIndex;
     }

--- a/ObsWebSocket.Core/Generated/Protocol/Responses/GetSceneSceneTransitionOverride.Response.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Responses/GetSceneSceneTransitionOverride.Response.g.cs
@@ -31,7 +31,7 @@ public sealed partial record GetSceneSceneTransitionOverrideResponseData
     /// </summary>
     [JsonPropertyName("transitionDuration")]
     [Key("transitionDuration")]
-    public double? TransitionDuration { get; init; }
+    public int? TransitionDuration { get; init; }
 
     /// <summary>
     /// Name of the overridden scene transition, else `null`
@@ -48,7 +48,7 @@ public sealed partial record GetSceneSceneTransitionOverrideResponseData
     /// Initializes a new instance with all properties specified.
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
-    public GetSceneSceneTransitionOverrideResponseData(string? transitionName = null, double? transitionDuration = null)
+    public GetSceneSceneTransitionOverrideResponseData(string? transitionName = null, int? transitionDuration = null)
     {
         this.TransitionName = transitionName;
         this.TransitionDuration = transitionDuration;

--- a/ObsWebSocket.Core/Generated/Protocol/Responses/GetSourceFilter.Response.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Responses/GetSourceFilter.Response.g.cs
@@ -36,7 +36,7 @@ public sealed partial record GetSourceFilterResponseData
     /// </summary>
     [JsonPropertyName("filterIndex")]
     [Key("filterIndex")]
-    public required double FilterIndex { get; init; }
+    public required int FilterIndex { get; init; }
 
     /// <summary>
     /// The kind of filter
@@ -61,7 +61,7 @@ public sealed partial record GetSourceFilterResponseData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetSourceFilterResponseData(bool filterEnabled, double filterIndex, string? filterKind = null, System.Text.Json.JsonElement? filterSettings = null)
+    public GetSourceFilterResponseData(bool filterEnabled, int filterIndex, string? filterKind = null, System.Text.Json.JsonElement? filterSettings = null)
     {
         this.FilterEnabled = filterEnabled;
         this.FilterIndex = filterIndex;

--- a/ObsWebSocket.Core/Generated/Protocol/Responses/GetStats.Response.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Responses/GetStats.Response.g.cs
@@ -64,42 +64,42 @@ public sealed partial record GetStatsResponseData
     /// </summary>
     [JsonPropertyName("outputSkippedFrames")]
     [Key("outputSkippedFrames")]
-    public required double OutputSkippedFrames { get; init; }
+    public required int OutputSkippedFrames { get; init; }
 
     /// <summary>
     /// Total number of frames outputted by the output thread
     /// </summary>
     [JsonPropertyName("outputTotalFrames")]
     [Key("outputTotalFrames")]
-    public required double OutputTotalFrames { get; init; }
+    public required int OutputTotalFrames { get; init; }
 
     /// <summary>
     /// Number of frames skipped by OBS in the render thread
     /// </summary>
     [JsonPropertyName("renderSkippedFrames")]
     [Key("renderSkippedFrames")]
-    public required double RenderSkippedFrames { get; init; }
+    public required int RenderSkippedFrames { get; init; }
 
     /// <summary>
     /// Total number of frames outputted by the render thread
     /// </summary>
     [JsonPropertyName("renderTotalFrames")]
     [Key("renderTotalFrames")]
-    public required double RenderTotalFrames { get; init; }
+    public required int RenderTotalFrames { get; init; }
 
     /// <summary>
     /// Total number of messages received by obs-websocket from the client
     /// </summary>
     [JsonPropertyName("webSocketSessionIncomingMessages")]
     [Key("webSocketSessionIncomingMessages")]
-    public required double WebSocketSessionIncomingMessages { get; init; }
+    public required int WebSocketSessionIncomingMessages { get; init; }
 
     /// <summary>
     /// Total number of messages sent by obs-websocket to the client
     /// </summary>
     [JsonPropertyName("webSocketSessionOutgoingMessages")]
     [Key("webSocketSessionOutgoingMessages")]
-    public required double WebSocketSessionOutgoingMessages { get; init; }
+    public required int WebSocketSessionOutgoingMessages { get; init; }
 
     /// <summary>Initializes a new instance for deserialization via <see cref="JsonConstructorAttribute"/>.</summary>
     [JsonConstructor]
@@ -110,7 +110,7 @@ public sealed partial record GetStatsResponseData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetStatsResponseData(double cpuUsage, double memoryUsage, double availableDiskSpace, double activeFps, double averageFrameRenderTime, double renderSkippedFrames, double renderTotalFrames, double outputSkippedFrames, double outputTotalFrames, double webSocketSessionIncomingMessages, double webSocketSessionOutgoingMessages)
+    public GetStatsResponseData(double cpuUsage, double memoryUsage, double availableDiskSpace, double activeFps, double averageFrameRenderTime, int renderSkippedFrames, int renderTotalFrames, int outputSkippedFrames, int outputTotalFrames, int webSocketSessionIncomingMessages, int webSocketSessionOutgoingMessages)
     {
         this.CpuUsage = cpuUsage;
         this.MemoryUsage = memoryUsage;

--- a/ObsWebSocket.Core/Generated/Protocol/Responses/GetStreamStatus.Response.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Responses/GetStreamStatus.Response.g.cs
@@ -36,7 +36,7 @@ public sealed partial record GetStreamStatusResponseData
     /// </summary>
     [JsonPropertyName("outputBytes")]
     [Key("outputBytes")]
-    public required double OutputBytes { get; init; }
+    public required long OutputBytes { get; init; }
 
     /// <summary>
     /// Congestion of the output
@@ -50,7 +50,7 @@ public sealed partial record GetStreamStatusResponseData
     /// </summary>
     [JsonPropertyName("outputDuration")]
     [Key("outputDuration")]
-    public required double OutputDuration { get; init; }
+    public required long OutputDuration { get; init; }
 
     /// <summary>
     /// Whether the output is currently reconnecting
@@ -64,7 +64,7 @@ public sealed partial record GetStreamStatusResponseData
     /// </summary>
     [JsonPropertyName("outputSkippedFrames")]
     [Key("outputSkippedFrames")]
-    public required double OutputSkippedFrames { get; init; }
+    public required int OutputSkippedFrames { get; init; }
 
     /// <summary>
     /// Current formatted timecode string for the output
@@ -78,7 +78,7 @@ public sealed partial record GetStreamStatusResponseData
     /// </summary>
     [JsonPropertyName("outputTotalFrames")]
     [Key("outputTotalFrames")]
-    public required double OutputTotalFrames { get; init; }
+    public required int OutputTotalFrames { get; init; }
 
     /// <summary>Initializes a new instance for deserialization via <see cref="JsonConstructorAttribute"/>.</summary>
     [JsonConstructor]
@@ -89,7 +89,7 @@ public sealed partial record GetStreamStatusResponseData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetStreamStatusResponseData(bool outputActive, bool outputReconnecting, double outputDuration, double outputCongestion, double outputBytes, double outputSkippedFrames, double outputTotalFrames, string? outputTimecode = null)
+    public GetStreamStatusResponseData(bool outputActive, bool outputReconnecting, long outputDuration, double outputCongestion, long outputBytes, int outputSkippedFrames, int outputTotalFrames, string? outputTimecode = null)
     {
         this.OutputActive = outputActive;
         this.OutputReconnecting = outputReconnecting;

--- a/ObsWebSocket.Core/Generated/Protocol/Responses/GetVersion.Response.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Responses/GetVersion.Response.g.cs
@@ -64,7 +64,7 @@ public sealed partial record GetVersionResponseData
     /// </summary>
     [JsonPropertyName("rpcVersion")]
     [Key("rpcVersion")]
-    public required double RpcVersion { get; init; }
+    public required int RpcVersion { get; init; }
 
     /// <summary>
     /// Image formats available in `GetSourceScreenshot` and `SaveSourceScreenshot` requests.
@@ -82,7 +82,7 @@ public sealed partial record GetVersionResponseData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetVersionResponseData(double rpcVersion, string? obsVersion = null, string? obsWebSocketVersion = null, System.Collections.Generic.List<string>? availableRequests = null, System.Collections.Generic.List<string>? supportedImageFormats = null, string? platform = null, string? platformDescription = null)
+    public GetVersionResponseData(int rpcVersion, string? obsVersion = null, string? obsWebSocketVersion = null, System.Collections.Generic.List<string>? availableRequests = null, System.Collections.Generic.List<string>? supportedImageFormats = null, string? platform = null, string? platformDescription = null)
     {
         this.ObsVersion = obsVersion;
         this.ObsWebSocketVersion = obsWebSocketVersion;

--- a/ObsWebSocket.Core/Generated/Protocol/Responses/GetVideoSettings.Response.g.cs
+++ b/ObsWebSocket.Core/Generated/Protocol/Responses/GetVideoSettings.Response.g.cs
@@ -31,42 +31,42 @@ public sealed partial record GetVideoSettingsResponseData
     /// </summary>
     [JsonPropertyName("baseHeight")]
     [Key("baseHeight")]
-    public required double BaseHeight { get; init; }
+    public required int BaseHeight { get; init; }
 
     /// <summary>
     /// Width of the base (canvas) resolution in pixels
     /// </summary>
     [JsonPropertyName("baseWidth")]
     [Key("baseWidth")]
-    public required double BaseWidth { get; init; }
+    public required int BaseWidth { get; init; }
 
     /// <summary>
     /// Denominator of the fractional FPS value
     /// </summary>
     [JsonPropertyName("fpsDenominator")]
     [Key("fpsDenominator")]
-    public required double FpsDenominator { get; init; }
+    public required int FpsDenominator { get; init; }
 
     /// <summary>
     /// Numerator of the fractional FPS value
     /// </summary>
     [JsonPropertyName("fpsNumerator")]
     [Key("fpsNumerator")]
-    public required double FpsNumerator { get; init; }
+    public required int FpsNumerator { get; init; }
 
     /// <summary>
     /// Height of the output resolution in pixels
     /// </summary>
     [JsonPropertyName("outputHeight")]
     [Key("outputHeight")]
-    public required double OutputHeight { get; init; }
+    public required int OutputHeight { get; init; }
 
     /// <summary>
     /// Width of the output resolution in pixels
     /// </summary>
     [JsonPropertyName("outputWidth")]
     [Key("outputWidth")]
-    public required double OutputWidth { get; init; }
+    public required int OutputWidth { get; init; }
 
     /// <summary>Initializes a new instance for deserialization via <see cref="JsonConstructorAttribute"/>.</summary>
     [JsonConstructor]
@@ -77,7 +77,7 @@ public sealed partial record GetVideoSettingsResponseData
     /// <para>Parameters are ordered with required properties first, then optional properties (with defaults). Follows protocol definition order where possible.</para>
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
-    public GetVideoSettingsResponseData(double fpsNumerator, double fpsDenominator, double baseWidth, double baseHeight, double outputWidth, double outputHeight)
+    public GetVideoSettingsResponseData(int fpsNumerator, int fpsDenominator, int baseWidth, int baseHeight, int outputWidth, int outputHeight)
     {
         this.FpsNumerator = fpsNumerator;
         this.FpsDenominator = fpsDenominator;

--- a/ObsWebSocket.Core/Groups/ConfigGroup.cs
+++ b/ObsWebSocket.Core/Groups/ConfigGroup.cs
@@ -1,11 +1,11 @@
-using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.Logging;
 using ObsWebSocket.Core.Events;
 using ObsWebSocket.Core.Events.Generated;
+using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol;
 using ObsWebSocket.Core.Protocol.Common;
-using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol.Common.FilterSettings;
 using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
@@ -28,7 +28,8 @@ public readonly partial struct ConfigGroup
     /// <returns>The deserialized stream service settings, or <see langword="null"/> if no settings are present.</returns>
     /// <exception cref="ObsWebSocketException">Thrown if OBS returns an error or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<T?> GetStreamServiceSettingsAsync<T>(JsonTypeInfo<T> typeInfo,
+    public async Task<T?> GetStreamServiceSettingsAsync<T>(
+        JsonTypeInfo<T> typeInfo,
         CancellationToken cancellationToken = default
     )
         where T : class
@@ -40,7 +41,9 @@ public readonly partial struct ConfigGroup
             .Config.GetStreamServiceSettingsAsync(cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
-        return response?.StreamServiceSettings is not { } element ? null : JsonSerializer.Deserialize(element, typeInfo);
+        return response?.StreamServiceSettings is not { } element
+            ? null
+            : JsonSerializer.Deserialize(element, typeInfo);
     }
 
     /// <summary>
@@ -51,8 +54,7 @@ public readonly partial struct ConfigGroup
     /// <returns>The deserialized stream service settings, or <see langword="null"/> if no settings are present.</returns>
     /// <exception cref="ObsWebSocketException">Thrown if the type is not registered, OBS returns an error, or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public Task<T?> GetStreamServiceSettingsAsync<T>(CancellationToken cancellationToken = default
-    )
+    public Task<T?> GetStreamServiceSettingsAsync<T>(CancellationToken cancellationToken = default)
         where T : class
     {
         JsonTypeInfo<T> typeInfo = ObsWebSocketClientHelpers.GetRegisteredTypeInfo<T>();
@@ -69,7 +71,8 @@ public readonly partial struct ConfigGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if OBS returns an error or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task SetStreamServiceSettingsAsync<T>(string streamServiceType,
+    public async Task SetStreamServiceSettingsAsync<T>(
+        string streamServiceType,
         T settings,
         JsonTypeInfo<T> typeInfo,
         CancellationToken cancellationToken = default
@@ -83,7 +86,8 @@ public readonly partial struct ConfigGroup
         JsonElement settingsElement = JsonSerializer.SerializeToElement(settings, typeInfo);
 
         await client
-            .Config.SetStreamServiceSettingsAsync(new SetStreamServiceSettingsRequestData(
+            .Config.SetStreamServiceSettingsAsync(
+                new SetStreamServiceSettingsRequestData(
                     streamServiceType: streamServiceType,
                     streamServiceSettings: settingsElement
                 ),
@@ -101,14 +105,20 @@ public readonly partial struct ConfigGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if the type is not registered, OBS returns an error, or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public Task SetStreamServiceSettingsAsync<T>(string streamServiceType,
+    public Task SetStreamServiceSettingsAsync<T>(
+        string streamServiceType,
         T settings,
         CancellationToken cancellationToken = default
     )
         where T : class
     {
         JsonTypeInfo<T> typeInfo = ObsWebSocketClientHelpers.GetRegisteredTypeInfo<T>();
-        return client.Config.SetStreamServiceSettingsAsync(streamServiceType, settings, typeInfo, cancellationToken);
+        return client.Config.SetStreamServiceSettingsAsync(
+            streamServiceType,
+            settings,
+            typeInfo,
+            cancellationToken
+        );
     }
 
     /// <summary>
@@ -119,7 +129,8 @@ public readonly partial struct ConfigGroup
     /// <returns>True if the target scene collection is active after the call; false if the switch failed (e.g., not found).</returns>
     /// <exception cref="ObsWebSocketException">Thrown for unexpected OBS errors during the process.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<bool> EnsureSceneCollectionActiveAsync(string targetSceneCollectionName,
+    public async Task<bool> EnsureSceneCollectionActiveAsync(
+        string targetSceneCollectionName,
         CancellationToken cancellationToken = default
     )
     {
@@ -146,7 +157,9 @@ public readonly partial struct ConfigGroup
         {
             await client
                 .Config.SetCurrentSceneCollectionAsync(
-                    new SetCurrentSceneCollectionRequestData(sceneCollectionName: targetSceneCollectionName),
+                    new SetCurrentSceneCollectionRequestData(
+                        sceneCollectionName: targetSceneCollectionName
+                    ),
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -180,7 +193,8 @@ public readonly partial struct ConfigGroup
     /// <returns>True if the target profile is active after the call; false if the switch failed (e.g., not found).</returns>
     /// <exception cref="ObsWebSocketException">Thrown for unexpected OBS errors during the process.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<bool> EnsureProfileActiveAsync(string targetProfileName,
+    public async Task<bool> EnsureProfileActiveAsync(
+        string targetProfileName,
         CancellationToken cancellationToken = default
     )
     {

--- a/ObsWebSocket.Core/Groups/ConfigGroup.cs
+++ b/ObsWebSocket.Core/Groups/ConfigGroup.cs
@@ -11,6 +11,7 @@ using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
 using ObsWebSocket.Core.Protocol.Requests;
 using ObsWebSocket.Core.Protocol.Responses;
+using ObsRequestStatus = ObsWebSocket.Core.Protocol.Generated.RequestStatus;
 
 namespace ObsWebSocket.Core;
 
@@ -165,15 +166,11 @@ public readonly partial struct ConfigGroup
                 .ConfigureAwait(false);
             return true; // Switch command sent successfully
         }
-        catch (ObsWebSocketException ex)
-            when (ex.Message.Contains("NotFound", StringComparison.OrdinalIgnoreCase)
-                || // General not found
-                ex.Message.Contains(
-                    $"code {(int)Core.Protocol.Generated.RequestStatus.ResourceNotFound}:",
-                    StringComparison.Ordinal
-                )
-                || // Specific code
-                ex.Message.Contains("InvalidParameter", StringComparison.OrdinalIgnoreCase) // Might be InvalidParameter if name doesn't exist
+        // OBS answers a name it does not know with either status, depending on the request.
+        catch (ObsWebSocketRequestException ex)
+            when (ex.StatusCode
+                    is ObsRequestStatus.ResourceNotFound
+                        or ObsRequestStatus.InvalidRequestField
             )
         {
             client._logger.LogWarning(
@@ -227,15 +224,11 @@ public readonly partial struct ConfigGroup
                 .ConfigureAwait(false);
             return true; // Switch command sent successfully
         }
-        catch (ObsWebSocketException ex)
-            when (ex.Message.Contains("NotFound", StringComparison.OrdinalIgnoreCase)
-                || // General not found
-                ex.Message.Contains(
-                    $"code {(int)Core.Protocol.Generated.RequestStatus.ResourceNotFound}:",
-                    StringComparison.Ordinal
-                )
-                || // Specific code
-                ex.Message.Contains("InvalidParameter", StringComparison.OrdinalIgnoreCase) // Might be InvalidParameter if name doesn't exist
+        // OBS answers a name it does not know with either status, depending on the request.
+        catch (ObsWebSocketRequestException ex)
+            when (ex.StatusCode
+                    is ObsRequestStatus.ResourceNotFound
+                        or ObsRequestStatus.InvalidRequestField
             )
         {
             client._logger.LogWarning(

--- a/ObsWebSocket.Core/Groups/ConfigGroup.cs
+++ b/ObsWebSocket.Core/Groups/ConfigGroup.cs
@@ -17,7 +17,7 @@ namespace ObsWebSocket.Core;
 /// <summary>
 /// Conveniences for the <c>Config</c> category, alongside its generated requests.
 /// </summary>
-public readonly partial struct ConfigRequestGroup
+public readonly partial struct ConfigGroup
 {
     /// <summary>
     /// Gets the current stream service settings as a strongly-typed object. The service type string is discarded.

--- a/ObsWebSocket.Core/Groups/ConfigGroup.cs
+++ b/ObsWebSocket.Core/Groups/ConfigGroup.cs
@@ -11,7 +11,6 @@ using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
 using ObsWebSocket.Core.Protocol.Requests;
 using ObsWebSocket.Core.Protocol.Responses;
-using ObsRequestStatus = ObsWebSocket.Core.Protocol.Generated.RequestStatus;
 
 namespace ObsWebSocket.Core;
 
@@ -169,8 +168,8 @@ public readonly partial struct ConfigGroup
         // OBS answers a name it does not know with either status, depending on the request.
         catch (ObsWebSocketRequestException ex)
             when (ex.StatusCode
-                    is ObsRequestStatus.ResourceNotFound
-                        or ObsRequestStatus.InvalidRequestField
+                    is RequestStatusCode.ResourceNotFound
+                        or RequestStatusCode.InvalidRequestField
             )
         {
             client._logger.LogWarning(
@@ -227,8 +226,8 @@ public readonly partial struct ConfigGroup
         // OBS answers a name it does not know with either status, depending on the request.
         catch (ObsWebSocketRequestException ex)
             when (ex.StatusCode
-                    is ObsRequestStatus.ResourceNotFound
-                        or ObsRequestStatus.InvalidRequestField
+                    is RequestStatusCode.ResourceNotFound
+                        or RequestStatusCode.InvalidRequestField
             )
         {
             client._logger.LogWarning(

--- a/ObsWebSocket.Core/Groups/FiltersGroup.cs
+++ b/ObsWebSocket.Core/Groups/FiltersGroup.cs
@@ -11,7 +11,6 @@ using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
 using ObsWebSocket.Core.Protocol.Requests;
 using ObsWebSocket.Core.Protocol.Responses;
-using ObsRequestStatus = ObsWebSocket.Core.Protocol.Generated.RequestStatus;
 
 namespace ObsWebSocket.Core;
 
@@ -56,7 +55,7 @@ public readonly partial struct FiltersGroup
                 .ConfigureAwait(false);
         }
         catch (ObsWebSocketRequestException ex)
-            when (ex.StatusCode is ObsRequestStatus.ResourceNotFound)
+            when (ex.StatusCode is RequestStatusCode.ResourceNotFound)
         {
             return null;
         }

--- a/ObsWebSocket.Core/Groups/FiltersGroup.cs
+++ b/ObsWebSocket.Core/Groups/FiltersGroup.cs
@@ -11,6 +11,7 @@ using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
 using ObsWebSocket.Core.Protocol.Requests;
 using ObsWebSocket.Core.Protocol.Responses;
+using ObsRequestStatus = ObsWebSocket.Core.Protocol.Generated.RequestStatus;
 
 namespace ObsWebSocket.Core;
 
@@ -54,13 +55,8 @@ public readonly partial struct FiltersGroup
                 )
                 .ConfigureAwait(false);
         }
-        catch (ObsWebSocketException ex)
-            when (ex.Message.Contains("NotFound", StringComparison.OrdinalIgnoreCase)
-                || ex.Message.Contains(
-                    $"code {(int)Core.Protocol.Generated.RequestStatus.ResourceNotFound}:",
-                    StringComparison.Ordinal
-                )
-            )
+        catch (ObsWebSocketRequestException ex)
+            when (ex.StatusCode is ObsRequestStatus.ResourceNotFound)
         {
             return null;
         }

--- a/ObsWebSocket.Core/Groups/FiltersGroup.cs
+++ b/ObsWebSocket.Core/Groups/FiltersGroup.cs
@@ -1,11 +1,11 @@
-using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.Logging;
 using ObsWebSocket.Core.Events;
 using ObsWebSocket.Core.Events.Generated;
+using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol;
 using ObsWebSocket.Core.Protocol.Common;
-using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol.Common.FilterSettings;
 using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
@@ -31,7 +31,8 @@ public readonly partial struct FiltersGroup
     /// <returns>The deserialized settings, or null if the source/filter is not found or deserialization fails.</returns>
     /// <exception cref="ObsWebSocketException">Thrown for OBS errors other than 'ResourceNotFound'.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<T?> GetSourceFilterSettingsAsync<T>(string sourceName,
+    public async Task<T?> GetSourceFilterSettingsAsync<T>(
+        string sourceName,
         string filterName,
         JsonTypeInfo<T> typeInfo,
         CancellationToken cancellationToken = default
@@ -96,14 +97,20 @@ public readonly partial struct FiltersGroup
     /// <returns>The deserialized settings, or null if the source/filter is not found or deserialization fails.</returns>
     /// <exception cref="ObsWebSocketException">Thrown for OBS errors other than 'ResourceNotFound'.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public Task<T?> GetSourceFilterSettingsAsync<T>(string sourceName,
+    public Task<T?> GetSourceFilterSettingsAsync<T>(
+        string sourceName,
         string filterName,
         CancellationToken cancellationToken = default
     )
         where T : class
     {
         JsonTypeInfo<T> typeInfo = ObsWebSocketClientHelpers.GetRegisteredTypeInfo<T>();
-        return client.Filters.GetSourceFilterSettingsAsync(sourceName, filterName, typeInfo, cancellationToken);
+        return client.Filters.GetSourceFilterSettingsAsync(
+            sourceName,
+            filterName,
+            typeInfo,
+            cancellationToken
+        );
     }
 
     /// <summary>
@@ -119,7 +126,8 @@ public readonly partial struct FiltersGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if OBS fails or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task SetSourceFilterSettingsAsync<T>(string sourceName,
+    public async Task SetSourceFilterSettingsAsync<T>(
+        string sourceName,
         string filterName,
         T settings,
         JsonTypeInfo<T> typeInfo,
@@ -148,7 +156,8 @@ public readonly partial struct FiltersGroup
         }
 
         await client
-            .Filters.SetSourceFilterSettingsAsync(new SetSourceFilterSettingsRequestData(
+            .Filters.SetSourceFilterSettingsAsync(
+                new SetSourceFilterSettingsRequestData(
                     filterSettings: settingsElement,
                     sourceName: sourceName,
                     filterName: filterName,
@@ -170,7 +179,8 @@ public readonly partial struct FiltersGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if the type is not registered, OBS returns an error, or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public Task SetSourceFilterSettingsAsync<T>(string sourceName,
+    public Task SetSourceFilterSettingsAsync<T>(
+        string sourceName,
         string filterName,
         T settings,
         bool overlay = true,
@@ -179,7 +189,14 @@ public readonly partial struct FiltersGroup
         where T : class
     {
         JsonTypeInfo<T> typeInfo = ObsWebSocketClientHelpers.GetRegisteredTypeInfo<T>();
-        return client.Filters.SetSourceFilterSettingsAsync(sourceName, filterName, settings, typeInfo, overlay, cancellationToken);
+        return client.Filters.SetSourceFilterSettingsAsync(
+            sourceName,
+            filterName,
+            settings,
+            typeInfo,
+            overlay,
+            cancellationToken
+        );
     }
 
     /// <summary>
@@ -195,7 +212,8 @@ public readonly partial struct FiltersGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if OBS fails or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task CreateSourceFilterAsync<T>(string sourceName,
+    public async Task CreateSourceFilterAsync<T>(
+        string sourceName,
         string filterName,
         string filterKind,
         T settings,
@@ -225,7 +243,8 @@ public readonly partial struct FiltersGroup
         }
 
         await client
-            .Filters.CreateSourceFilterAsync(new CreateSourceFilterRequestData(
+            .Filters.CreateSourceFilterAsync(
+                new CreateSourceFilterRequestData(
                     filterName: filterName,
                     filterKind: filterKind,
                     sourceName: sourceName,
@@ -247,7 +266,8 @@ public readonly partial struct FiltersGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if the type is not registered, OBS returns an error, or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public Task CreateSourceFilterAsync<T>(string sourceName,
+    public Task CreateSourceFilterAsync<T>(
+        string sourceName,
         string filterName,
         string filterKind,
         T settings,
@@ -256,7 +276,14 @@ public readonly partial struct FiltersGroup
         where T : class
     {
         JsonTypeInfo<T> typeInfo = ObsWebSocketClientHelpers.GetRegisteredTypeInfo<T>();
-        return client.Filters.CreateSourceFilterAsync(sourceName, filterName, filterKind, settings, typeInfo, cancellationToken);
+        return client.Filters.CreateSourceFilterAsync(
+            sourceName,
+            filterName,
+            filterKind,
+            settings,
+            typeInfo,
+            cancellationToken
+        );
     }
 
     /// <summary>
@@ -269,7 +296,8 @@ public readonly partial struct FiltersGroup
     /// <returns>The deserialized default settings, or <see langword="null"/> if no settings are present.</returns>
     /// <exception cref="ObsWebSocketException">Thrown if OBS returns an error or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<T?> GetSourceFilterDefaultSettingsAsync<T>(string filterKind,
+    public async Task<T?> GetSourceFilterDefaultSettingsAsync<T>(
+        string filterKind,
         JsonTypeInfo<T> typeInfo,
         CancellationToken cancellationToken = default
     )
@@ -280,12 +308,15 @@ public readonly partial struct FiltersGroup
         client.EnsureConnected();
 
         GetSourceFilterDefaultSettingsResponseData? response = await client
-            .Filters.GetSourceFilterDefaultSettingsAsync(new GetSourceFilterDefaultSettingsRequestData(filterKind: filterKind),
+            .Filters.GetSourceFilterDefaultSettingsAsync(
+                new GetSourceFilterDefaultSettingsRequestData(filterKind: filterKind),
                 cancellationToken: cancellationToken
             )
             .ConfigureAwait(false);
 
-        return response?.DefaultFilterSettings is not { } element ? null : JsonSerializer.Deserialize(element, typeInfo);
+        return response?.DefaultFilterSettings is not { } element
+            ? null
+            : JsonSerializer.Deserialize(element, typeInfo);
     }
 
     /// <summary>
@@ -297,12 +328,17 @@ public readonly partial struct FiltersGroup
     /// <returns>The deserialized default settings, or <see langword="null"/> if no settings are present.</returns>
     /// <exception cref="ObsWebSocketException">Thrown if the type is not registered, OBS returns an error, or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public Task<T?> GetSourceFilterDefaultSettingsAsync<T>(string filterKind,
+    public Task<T?> GetSourceFilterDefaultSettingsAsync<T>(
+        string filterKind,
         CancellationToken cancellationToken = default
     )
         where T : class
     {
         JsonTypeInfo<T> typeInfo = ObsWebSocketClientHelpers.GetRegisteredTypeInfo<T>();
-        return client.Filters.GetSourceFilterDefaultSettingsAsync(filterKind, typeInfo, cancellationToken);
+        return client.Filters.GetSourceFilterDefaultSettingsAsync(
+            filterKind,
+            typeInfo,
+            cancellationToken
+        );
     }
 }

--- a/ObsWebSocket.Core/Groups/FiltersGroup.cs
+++ b/ObsWebSocket.Core/Groups/FiltersGroup.cs
@@ -17,7 +17,7 @@ namespace ObsWebSocket.Core;
 /// <summary>
 /// Conveniences for the <c>Filters</c> category, alongside its generated requests.
 /// </summary>
-public readonly partial struct FiltersRequestGroup
+public readonly partial struct FiltersGroup
 {
     /// <summary>
     /// Retrieves the settings for a specific filter on a source and deserializes them using an explicit <see cref="JsonTypeInfo{T}"/>.

--- a/ObsWebSocket.Core/Groups/GeneralGroup.cs
+++ b/ObsWebSocket.Core/Groups/GeneralGroup.cs
@@ -1,11 +1,11 @@
-using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.Logging;
 using ObsWebSocket.Core.Events;
 using ObsWebSocket.Core.Events.Generated;
+using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol;
 using ObsWebSocket.Core.Protocol.Common;
-using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol.Common.FilterSettings;
 using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
@@ -26,7 +26,8 @@ public readonly partial struct GeneralGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if OBS fails to trigger the hotkey (e.g., hotkey not found).</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task TriggerHotkeyAsync(string hotkeyName,
+    public async Task TriggerHotkeyAsync(
+        string hotkeyName,
         CancellationToken cancellationToken = default
     )
     {

--- a/ObsWebSocket.Core/Groups/GeneralGroup.cs
+++ b/ObsWebSocket.Core/Groups/GeneralGroup.cs
@@ -17,7 +17,7 @@ namespace ObsWebSocket.Core;
 /// <summary>
 /// Conveniences for the <c>General</c> category, alongside its generated requests.
 /// </summary>
-public readonly partial struct GeneralRequestGroup
+public readonly partial struct GeneralGroup
 {
     /// <summary>
     /// Triggers an OBS hotkey by its canonical name (e.g., "OBSWebSocket.StartStream").

--- a/ObsWebSocket.Core/Groups/InputsGroup.cs
+++ b/ObsWebSocket.Core/Groups/InputsGroup.cs
@@ -11,6 +11,7 @@ using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
 using ObsWebSocket.Core.Protocol.Requests;
 using ObsWebSocket.Core.Protocol.Responses;
+using ObsRequestStatus = ObsWebSocket.Core.Protocol.Generated.RequestStatus;
 
 namespace ObsWebSocket.Core;
 
@@ -49,15 +50,18 @@ public readonly partial struct InputsGroup
     }
 
     /// <summary>
-    /// Sets the mute state for multiple audio inputs using a single batch request.
+    /// Sets the mute state for several audio inputs in one batch.
     /// </summary>
-    /// <param name="inputMutes">An enumerable of tuples, where each tuple contains the input name (string) and desired mute state (bool: true=muted, false=unmuted).</param>
+    /// <param name="inputMutes">The inputs to change, each with the mute state to apply.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A Task representing the completion of the batch request submission. Inspect logs for individual item failures.</returns>
-    /// <exception cref="ObsWebSocketException">Thrown if the batch request itself fails (e.g., timeout).</exception>
+    /// <returns>
+    /// One result per input, in the order given, so a caller can see which inputs OBS rejected.
+    /// The batch does not halt on a failure, so one unknown input does not skip the rest.
+    /// </returns>
+    /// <exception cref="ObsWebSocketException">Thrown if the batch itself fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    /// <exception cref="ArgumentNullException">Thrown if inputMutes is null.</exception>
-    public async Task SetInputMutesAsync(
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="inputMutes"/> is null.</exception>
+    public async Task<BatchResults> SetInputMutesAsync(
         IEnumerable<(string InputName, bool IsMuted)> inputMutes,
         CancellationToken cancellationToken = default
     )
@@ -65,49 +69,47 @@ public readonly partial struct InputsGroup
         ArgumentNullException.ThrowIfNull(inputMutes);
         client.EnsureConnected();
 
-        List<BatchRequestItem> batchItems =
-        [
-            .. inputMutes.Select(im => new BatchRequestItem(
-                RequestType: "SetInputMute",
-                RequestData: new SetInputMuteRequestData(
-                    inputName: im.InputName,
-                    inputMuted: im.IsMuted
-                )
-            )),
-        ];
-
-        if (batchItems.Count == 0)
+        ObsBatchBuilder batch = new();
+        List<string> names = [];
+        foreach ((string inputName, bool isMuted) in inputMutes)
         {
-            client._logger.LogDebug("SetInputMutesAsync called with empty list, nothing to do.");
-            return; // Nothing to send
+            _ = batch.Inputs.SetInputMute(
+                new SetInputMuteRequestData(inputName: inputName, inputMuted: isMuted)
+            );
+            names.Add(inputName);
         }
 
-        // Send batch, don't halt on failure
-        List<RequestResponsePayload<object>> results = await client
+        if (names.Count == 0)
+        {
+            client._logger.LogDebug("SetInputMutesAsync called with an empty list, nothing to do.");
+            return new BatchResults([]);
+        }
+
+        BatchResults results = await client
             .CallBatchAsync(
-                requests: batchItems,
+                batch,
+                // Serial keeps each result paired with the input at the same position.
+                executionType: RequestBatchExecutionType.SerialRealtime,
                 haltOnFailure: false,
-                executionType: RequestBatchExecutionType.SerialRealtime, // Appropriate for simple state changes
                 cancellationToken: cancellationToken
             )
             .ConfigureAwait(false);
 
-        // Optional: Log failures from results
-        foreach (RequestResponsePayload<object> result in results)
+        for (int i = 0; i < results.Count; i++)
         {
+            RequestResponsePayload<object> result = results[i];
             if (!result.RequestStatus.Result)
             {
-                // Attempt to find original input name (requires parsing RequestId or matching RequestData - complex)
-                // For now, log the failed request type and ID
                 client._logger.LogWarning(
-                    "Failed batch item in SetInputMutesAsync: RequestType={ReqType}, RequestId={ReqId}, Code={Code}, Comment={Comment}",
-                    result.RequestType,
-                    result.RequestId,
+                    "Failed to set mute state for input '{InputName}': code {Code}, {Comment}",
+                    names[i],
                     result.RequestStatus.Code,
-                    result.RequestStatus.Comment ?? "N/A"
+                    result.RequestStatus.Comment ?? "no comment"
                 );
             }
         }
+
+        return results;
     }
 
     /// <summary>
@@ -142,13 +144,8 @@ public readonly partial struct InputsGroup
                 )
                 .ConfigureAwait(false);
         }
-        catch (ObsWebSocketException ex)
-            when (ex.Message.Contains("NotFound", StringComparison.OrdinalIgnoreCase)
-                || ex.Message.Contains(
-                    $"code {(int)Core.Protocol.Generated.RequestStatus.ResourceNotFound}:",
-                    StringComparison.Ordinal
-                )
-            )
+        catch (ObsWebSocketRequestException ex)
+            when (ex.StatusCode is ObsRequestStatus.ResourceNotFound)
         {
             return null;
         }

--- a/ObsWebSocket.Core/Groups/InputsGroup.cs
+++ b/ObsWebSocket.Core/Groups/InputsGroup.cs
@@ -1,11 +1,11 @@
-using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.Logging;
 using ObsWebSocket.Core.Events;
 using ObsWebSocket.Core.Events.Generated;
+using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol;
 using ObsWebSocket.Core.Protocol.Common;
-using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol.Common.FilterSettings;
 using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
@@ -27,7 +27,8 @@ public readonly partial struct InputsGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if OBS fails to set the text (e.g., input not found, not a text source).</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task SetInputTextAsync(string inputName,
+    public async Task SetInputTextAsync(
+        string inputName,
         string text,
         CancellationToken cancellationToken = default
     )
@@ -37,7 +38,8 @@ public readonly partial struct InputsGroup
         client.EnsureConnected();
 
         await client
-            .Inputs.SetInputSettingsAsync(inputName: inputName,
+            .Inputs.SetInputSettingsAsync(
+                inputName: inputName,
                 settings: new TextGdiPlusInputSettings(Text: text),
                 overlay: true,
                 cancellationToken: cancellationToken
@@ -55,7 +57,8 @@ public readonly partial struct InputsGroup
     /// <exception cref="ObsWebSocketException">Thrown if the batch request itself fails (e.g., timeout).</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
     /// <exception cref="ArgumentNullException">Thrown if inputMutes is null.</exception>
-    public async Task SetInputMutesAsync(IEnumerable<(string InputName, bool IsMuted)> inputMutes,
+    public async Task SetInputMutesAsync(
+        IEnumerable<(string InputName, bool IsMuted)> inputMutes,
         CancellationToken cancellationToken = default
     )
     {
@@ -118,7 +121,8 @@ public readonly partial struct InputsGroup
     /// <returns>The deserialized settings, or null if the input is not found or deserialization fails.</returns>
     /// <exception cref="ObsWebSocketException">Thrown for unexpected OBS errors.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<T?> GetInputSettingsAsync<T>(string inputName,
+    public async Task<T?> GetInputSettingsAsync<T>(
+        string inputName,
         JsonTypeInfo<T> typeInfo,
         CancellationToken cancellationToken = default
     )
@@ -132,7 +136,8 @@ public readonly partial struct InputsGroup
         try
         {
             response = await client
-                .Inputs.GetInputSettingsAsync(new GetInputSettingsRequestData(inputName: inputName),
+                .Inputs.GetInputSettingsAsync(
+                    new GetInputSettingsRequestData(inputName: inputName),
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -178,7 +183,8 @@ public readonly partial struct InputsGroup
     /// <returns>The deserialized settings, or null if the input is not found or deserialization fails.</returns>
     /// <exception cref="ObsWebSocketException">Thrown if the type is not registered or OBS returns an error.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public Task<T?> GetInputSettingsAsync<T>(string inputName,
+    public Task<T?> GetInputSettingsAsync<T>(
+        string inputName,
         CancellationToken cancellationToken = default
     )
         where T : class
@@ -199,7 +205,8 @@ public readonly partial struct InputsGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if OBS fails or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task SetInputSettingsAsync<T>(string inputName,
+    public async Task SetInputSettingsAsync<T>(
+        string inputName,
         T settings,
         JsonTypeInfo<T> typeInfo,
         bool overlay = true,
@@ -226,7 +233,8 @@ public readonly partial struct InputsGroup
         }
 
         await client
-            .Inputs.SetInputSettingsAsync(new SetInputSettingsRequestData(
+            .Inputs.SetInputSettingsAsync(
+                new SetInputSettingsRequestData(
                     inputSettings: settingsElement,
                     inputName: inputName,
                     overlay: overlay
@@ -246,7 +254,8 @@ public readonly partial struct InputsGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if the type is not registered, OBS returns an error, or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public Task SetInputSettingsAsync<T>(string inputName,
+    public Task SetInputSettingsAsync<T>(
+        string inputName,
         T settings,
         bool overlay = true,
         CancellationToken cancellationToken = default
@@ -254,7 +263,13 @@ public readonly partial struct InputsGroup
         where T : class
     {
         JsonTypeInfo<T> typeInfo = ObsWebSocketClientHelpers.GetRegisteredTypeInfo<T>();
-        return client.Inputs.SetInputSettingsAsync(inputName, settings, typeInfo, overlay, cancellationToken);
+        return client.Inputs.SetInputSettingsAsync(
+            inputName,
+            settings,
+            typeInfo,
+            overlay,
+            cancellationToken
+        );
     }
 
     /// <summary>
@@ -273,7 +288,8 @@ public readonly partial struct InputsGroup
     /// <returns>The response data containing the new scene item ID, or null on failure.</returns>
     /// <exception cref="ObsWebSocketException">Thrown if OBS fails or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<CreateInputResponseData?> CreateInputAsync<T>(string inputKind,
+    public async Task<CreateInputResponseData?> CreateInputAsync<T>(
+        string inputKind,
         string inputName,
         T settings,
         JsonTypeInfo<T> typeInfo,
@@ -304,7 +320,8 @@ public readonly partial struct InputsGroup
         }
 
         return await client
-            .Inputs.CreateInputAsync(new CreateInputRequestData(
+            .Inputs.CreateInputAsync(
+                new CreateInputRequestData(
                     inputName: inputName,
                     inputKind: inputKind,
                     sceneName: sceneName,
@@ -331,7 +348,8 @@ public readonly partial struct InputsGroup
     /// <returns>The response data containing the new scene item ID, or null on failure.</returns>
     /// <exception cref="ObsWebSocketException">Thrown if the type is not registered, OBS returns an error, or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public Task<CreateInputResponseData?> CreateInputAsync<T>(string inputKind,
+    public Task<CreateInputResponseData?> CreateInputAsync<T>(
+        string inputKind,
         string inputName,
         T settings,
         string? sceneName = null,
@@ -342,7 +360,16 @@ public readonly partial struct InputsGroup
         where T : class
     {
         JsonTypeInfo<T> typeInfo = ObsWebSocketClientHelpers.GetRegisteredTypeInfo<T>();
-        return client.Inputs.CreateInputAsync(inputKind, inputName, settings, typeInfo, sceneName, sceneUuid, sceneItemEnabled, cancellationToken);
+        return client.Inputs.CreateInputAsync(
+            inputKind,
+            inputName,
+            settings,
+            typeInfo,
+            sceneName,
+            sceneUuid,
+            sceneItemEnabled,
+            cancellationToken
+        );
     }
 
     /// <summary>
@@ -355,7 +382,8 @@ public readonly partial struct InputsGroup
     /// <returns>The deserialized default settings, or <see langword="null"/> if no settings are present.</returns>
     /// <exception cref="ObsWebSocketException">Thrown if OBS returns an error or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<T?> GetInputDefaultSettingsAsync<T>(string inputKind,
+    public async Task<T?> GetInputDefaultSettingsAsync<T>(
+        string inputKind,
         JsonTypeInfo<T> typeInfo,
         CancellationToken cancellationToken = default
     )
@@ -366,12 +394,15 @@ public readonly partial struct InputsGroup
         client.EnsureConnected();
 
         GetInputDefaultSettingsResponseData? response = await client
-            .Inputs.GetInputDefaultSettingsAsync(new GetInputDefaultSettingsRequestData(inputKind: inputKind),
+            .Inputs.GetInputDefaultSettingsAsync(
+                new GetInputDefaultSettingsRequestData(inputKind: inputKind),
                 cancellationToken: cancellationToken
             )
             .ConfigureAwait(false);
 
-        return response?.DefaultInputSettings is not { } element ? null : JsonSerializer.Deserialize(element, typeInfo);
+        return response?.DefaultInputSettings is not { } element
+            ? null
+            : JsonSerializer.Deserialize(element, typeInfo);
     }
 
     /// <summary>
@@ -383,7 +414,8 @@ public readonly partial struct InputsGroup
     /// <returns>The deserialized default settings, or <see langword="null"/> if no settings are present.</returns>
     /// <exception cref="ObsWebSocketException">Thrown if the type is not registered, OBS returns an error, or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public Task<T?> GetInputDefaultSettingsAsync<T>(string inputKind,
+    public Task<T?> GetInputDefaultSettingsAsync<T>(
+        string inputKind,
         CancellationToken cancellationToken = default
     )
         where T : class
@@ -392,54 +424,54 @@ public readonly partial struct InputsGroup
         return client.Inputs.GetInputDefaultSettingsAsync(inputKind, typeInfo, cancellationToken);
     }
 
-        /// <summary>
-        /// Sets an input's volume in decibels. The underlying request accepts either decibels or
-        /// a multiplier and fails when given neither.
-        /// </summary>
-        /// <param name="inputName">The name of the input.</param>
-        /// <param name="volumeDb">The desired volume in dB. OBS accepts -100 through 26.</param>
-        /// <param name="cancellationToken">A token to cancel the operation.</param>
-        /// <exception cref="ObsWebSocketException">Thrown if OBS rejects the request.</exception>
-        /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-        public async Task SetInputVolumeDbAsync(
-            string inputName,
-            double volumeDb,
-            CancellationToken cancellationToken = default
-        )
-        {
-            ArgumentException.ThrowIfNullOrEmpty(inputName);
-            client.EnsureConnected();
+    /// <summary>
+    /// Sets an input's volume in decibels. The underlying request accepts either decibels or
+    /// a multiplier and fails when given neither.
+    /// </summary>
+    /// <param name="inputName">The name of the input.</param>
+    /// <param name="volumeDb">The desired volume in dB. OBS accepts -100 through 26.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <exception cref="ObsWebSocketException">Thrown if OBS rejects the request.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
+    public async Task SetInputVolumeDbAsync(
+        string inputName,
+        double volumeDb,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrEmpty(inputName);
+        client.EnsureConnected();
 
-            await client
-                .Inputs.SetInputVolumeAsync(
-                    new SetInputVolumeRequestData { InputName = inputName, InputVolumeDb = volumeDb },
-                    cancellationToken
-                )
-                .ConfigureAwait(false);
-        }
+        await client
+            .Inputs.SetInputVolumeAsync(
+                new SetInputVolumeRequestData { InputName = inputName, InputVolumeDb = volumeDb },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+    }
 
-        /// <summary>
-        /// Sets an input's volume as a linear multiplier, where <c>1.0</c> is unity gain.
-        /// </summary>
-        /// <param name="inputName">The name of the input.</param>
-        /// <param name="volumeMul">The desired volume multiplier. OBS accepts 0 through 20.</param>
-        /// <param name="cancellationToken">A token to cancel the operation.</param>
-        /// <exception cref="ObsWebSocketException">Thrown if OBS rejects the request.</exception>
-        /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-        public async Task SetInputVolumeMulAsync(
-            string inputName,
-            double volumeMul,
-            CancellationToken cancellationToken = default
-        )
-        {
-            ArgumentException.ThrowIfNullOrEmpty(inputName);
-            client.EnsureConnected();
+    /// <summary>
+    /// Sets an input's volume as a linear multiplier, where <c>1.0</c> is unity gain.
+    /// </summary>
+    /// <param name="inputName">The name of the input.</param>
+    /// <param name="volumeMul">The desired volume multiplier. OBS accepts 0 through 20.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <exception cref="ObsWebSocketException">Thrown if OBS rejects the request.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
+    public async Task SetInputVolumeMulAsync(
+        string inputName,
+        double volumeMul,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrEmpty(inputName);
+        client.EnsureConnected();
 
-            await client
-                .Inputs.SetInputVolumeAsync(
-                    new SetInputVolumeRequestData { InputName = inputName, InputVolumeMul = volumeMul },
-                    cancellationToken
-                )
-                .ConfigureAwait(false);
-        }
+        await client
+            .Inputs.SetInputVolumeAsync(
+                new SetInputVolumeRequestData { InputName = inputName, InputVolumeMul = volumeMul },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+    }
 }

--- a/ObsWebSocket.Core/Groups/InputsGroup.cs
+++ b/ObsWebSocket.Core/Groups/InputsGroup.cs
@@ -17,7 +17,7 @@ namespace ObsWebSocket.Core;
 /// <summary>
 /// Conveniences for the <c>Inputs</c> category, alongside its generated requests.
 /// </summary>
-public readonly partial struct InputsRequestGroup
+public readonly partial struct InputsGroup
 {
     /// <summary>
     /// Sets the text content of a Text (GDI+, Freetype 2, Pango) source.

--- a/ObsWebSocket.Core/Groups/InputsGroup.cs
+++ b/ObsWebSocket.Core/Groups/InputsGroup.cs
@@ -11,7 +11,6 @@ using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
 using ObsWebSocket.Core.Protocol.Requests;
 using ObsWebSocket.Core.Protocol.Responses;
-using ObsRequestStatus = ObsWebSocket.Core.Protocol.Generated.RequestStatus;
 
 namespace ObsWebSocket.Core;
 
@@ -145,7 +144,7 @@ public readonly partial struct InputsGroup
                 .ConfigureAwait(false);
         }
         catch (ObsWebSocketRequestException ex)
-            when (ex.StatusCode is ObsRequestStatus.ResourceNotFound)
+            when (ex.StatusCode is RequestStatusCode.ResourceNotFound)
         {
             return null;
         }

--- a/ObsWebSocket.Core/Groups/MediaInputsGroup.cs
+++ b/ObsWebSocket.Core/Groups/MediaInputsGroup.cs
@@ -1,11 +1,11 @@
-using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.Logging;
 using ObsWebSocket.Core.Events;
 using ObsWebSocket.Core.Events.Generated;
+using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol;
 using ObsWebSocket.Core.Protocol.Common;
-using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol.Common.FilterSettings;
 using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
@@ -19,57 +19,68 @@ namespace ObsWebSocket.Core;
 /// </summary>
 public readonly partial struct MediaInputsGroup
 {
-        /// <summary>
-        /// Triggers a media action on an input using the typed <see cref="MediaInputAction"/> enum
-        /// rather than a protocol string constant.
-        /// </summary>
-        /// <param name="inputName">The name of the media input.</param>
-        /// <param name="action">The transport action to perform.</param>
-        /// <param name="cancellationToken">A token to cancel the operation.</param>
-        /// <exception cref="ObsWebSocketException">Thrown if OBS rejects the request.</exception>
-        /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-        public async Task TriggerMediaActionAsync(
-            string inputName,
-            MediaInputAction action,
-            CancellationToken cancellationToken = default
-        )
-        {
-            ArgumentException.ThrowIfNullOrEmpty(inputName);
-            client.EnsureConnected();
+    /// <summary>
+    /// Triggers a media action on an input using the typed <see cref="MediaInputAction"/> enum
+    /// rather than a protocol string constant.
+    /// </summary>
+    /// <param name="inputName">The name of the media input.</param>
+    /// <param name="action">The transport action to perform.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <exception cref="ObsWebSocketException">Thrown if OBS rejects the request.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
+    public async Task TriggerMediaActionAsync(
+        string inputName,
+        MediaInputAction action,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrEmpty(inputName);
+        client.EnsureConnected();
 
-            await client
-                .MediaInputs.TriggerMediaInputActionAsync(
-                    new TriggerMediaInputActionRequestData
-                    {
-                        InputName = inputName,
-                        MediaAction = action.ToWireValue(),
-                    },
-                    cancellationToken
-                )
-                .ConfigureAwait(false);
-        }
+        await client
+            .MediaInputs.TriggerMediaInputActionAsync(
+                new TriggerMediaInputActionRequestData
+                {
+                    InputName = inputName,
+                    MediaAction = action.ToWireValue(),
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+    }
 
-        /// <summary>Plays a media input.</summary>
-        public Task PlayMediaAsync(
-            string inputName,
-            CancellationToken cancellationToken = default
-        ) => client.MediaInputs.TriggerMediaActionAsync(inputName, MediaInputAction.Play, cancellationToken);
+    /// <summary>Plays a media input.</summary>
+    public Task PlayMediaAsync(string inputName, CancellationToken cancellationToken = default) =>
+        client.MediaInputs.TriggerMediaActionAsync(
+            inputName,
+            MediaInputAction.Play,
+            cancellationToken
+        );
 
-        /// <summary>Pauses a media input.</summary>
-        public Task PauseMediaAsync(
-            string inputName,
-            CancellationToken cancellationToken = default
-        ) => client.MediaInputs.TriggerMediaActionAsync(inputName, MediaInputAction.Pause, cancellationToken);
+    /// <summary>Pauses a media input.</summary>
+    public Task PauseMediaAsync(string inputName, CancellationToken cancellationToken = default) =>
+        client.MediaInputs.TriggerMediaActionAsync(
+            inputName,
+            MediaInputAction.Pause,
+            cancellationToken
+        );
 
-        /// <summary>Stops a media input.</summary>
-        public Task StopMediaAsync(
-            string inputName,
-            CancellationToken cancellationToken = default
-        ) => client.MediaInputs.TriggerMediaActionAsync(inputName, MediaInputAction.Stop, cancellationToken);
+    /// <summary>Stops a media input.</summary>
+    public Task StopMediaAsync(string inputName, CancellationToken cancellationToken = default) =>
+        client.MediaInputs.TriggerMediaActionAsync(
+            inputName,
+            MediaInputAction.Stop,
+            cancellationToken
+        );
 
-        /// <summary>Restarts a media input from the beginning.</summary>
-        public Task RestartMediaAsync(
-            string inputName,
-            CancellationToken cancellationToken = default
-        ) => client.MediaInputs.TriggerMediaActionAsync(inputName, MediaInputAction.Restart, cancellationToken);
+    /// <summary>Restarts a media input from the beginning.</summary>
+    public Task RestartMediaAsync(
+        string inputName,
+        CancellationToken cancellationToken = default
+    ) =>
+        client.MediaInputs.TriggerMediaActionAsync(
+            inputName,
+            MediaInputAction.Restart,
+            cancellationToken
+        );
 }

--- a/ObsWebSocket.Core/Groups/MediaInputsGroup.cs
+++ b/ObsWebSocket.Core/Groups/MediaInputsGroup.cs
@@ -17,7 +17,7 @@ namespace ObsWebSocket.Core;
 /// <summary>
 /// Conveniences for the <c>MediaInputs</c> category, alongside its generated requests.
 /// </summary>
-public readonly partial struct MediaInputsRequestGroup
+public readonly partial struct MediaInputsGroup
 {
         /// <summary>
         /// Triggers a media action on an input using the typed <see cref="MediaInputAction"/> enum

--- a/ObsWebSocket.Core/Groups/OutputsGroup.cs
+++ b/ObsWebSocket.Core/Groups/OutputsGroup.cs
@@ -17,7 +17,7 @@ namespace ObsWebSocket.Core;
 /// <summary>
 /// Conveniences for the <c>Outputs</c> category, alongside its generated requests.
 /// </summary>
-public readonly partial struct OutputsRequestGroup
+public readonly partial struct OutputsGroup
 {
     /// <summary>
     /// Gets the settings for an output as a strongly-typed object.

--- a/ObsWebSocket.Core/Groups/OutputsGroup.cs
+++ b/ObsWebSocket.Core/Groups/OutputsGroup.cs
@@ -1,11 +1,11 @@
-using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.Logging;
 using ObsWebSocket.Core.Events;
 using ObsWebSocket.Core.Events.Generated;
+using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol;
 using ObsWebSocket.Core.Protocol.Common;
-using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol.Common.FilterSettings;
 using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
@@ -29,7 +29,8 @@ public readonly partial struct OutputsGroup
     /// <returns>The deserialized output settings, or <see langword="null"/> if no settings are present.</returns>
     /// <exception cref="ObsWebSocketException">Thrown if OBS returns an error or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<T?> GetOutputSettingsAsync<T>(string outputName,
+    public async Task<T?> GetOutputSettingsAsync<T>(
+        string outputName,
         JsonTypeInfo<T> typeInfo,
         CancellationToken cancellationToken = default
     )
@@ -40,12 +41,15 @@ public readonly partial struct OutputsGroup
         client.EnsureConnected();
 
         GetOutputSettingsResponseData? response = await client
-            .Outputs.GetOutputSettingsAsync(new GetOutputSettingsRequestData(outputName: outputName),
+            .Outputs.GetOutputSettingsAsync(
+                new GetOutputSettingsRequestData(outputName: outputName),
                 cancellationToken: cancellationToken
             )
             .ConfigureAwait(false);
 
-        return response?.OutputSettings is not { } element ? null : JsonSerializer.Deserialize(element, typeInfo);
+        return response?.OutputSettings is not { } element
+            ? null
+            : JsonSerializer.Deserialize(element, typeInfo);
     }
 
     /// <summary>
@@ -57,7 +61,8 @@ public readonly partial struct OutputsGroup
     /// <returns>The deserialized output settings, or <see langword="null"/> if no settings are present.</returns>
     /// <exception cref="ObsWebSocketException">Thrown if the type is not registered, OBS returns an error, or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public Task<T?> GetOutputSettingsAsync<T>(string outputName,
+    public Task<T?> GetOutputSettingsAsync<T>(
+        string outputName,
         CancellationToken cancellationToken = default
     )
         where T : class
@@ -76,7 +81,8 @@ public readonly partial struct OutputsGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if OBS returns an error or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task SetOutputSettingsAsync<T>(string outputName,
+    public async Task SetOutputSettingsAsync<T>(
+        string outputName,
         T settings,
         JsonTypeInfo<T> typeInfo,
         CancellationToken cancellationToken = default
@@ -90,7 +96,8 @@ public readonly partial struct OutputsGroup
         JsonElement settingsElement = JsonSerializer.SerializeToElement(settings, typeInfo);
 
         await client
-            .Outputs.SetOutputSettingsAsync(new SetOutputSettingsRequestData(
+            .Outputs.SetOutputSettingsAsync(
+                new SetOutputSettingsRequestData(
                     outputName: outputName,
                     outputSettings: settingsElement
                 ),
@@ -108,14 +115,20 @@ public readonly partial struct OutputsGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if the type is not registered, OBS returns an error, or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public Task SetOutputSettingsAsync<T>(string outputName,
+    public Task SetOutputSettingsAsync<T>(
+        string outputName,
         T settings,
         CancellationToken cancellationToken = default
     )
         where T : class
     {
         JsonTypeInfo<T> typeInfo = ObsWebSocketClientHelpers.GetRegisteredTypeInfo<T>();
-        return client.Outputs.SetOutputSettingsAsync(outputName, settings, typeInfo, cancellationToken);
+        return client.Outputs.SetOutputSettingsAsync(
+            outputName,
+            settings,
+            typeInfo,
+            cancellationToken
+        );
     }
 
     /// <summary>
@@ -148,19 +161,23 @@ public readonly partial struct OutputsGroup
     /// or <see langword="null"/> if the timeout elapsed before the event arrived.
     /// </returns>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<bool?> SetVirtualCamActiveAndWaitAsync(bool activate,
+    public async Task<bool?> SetVirtualCamActiveAndWaitAsync(
+        bool activate,
         TimeSpan? timeout = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         client.EnsureConnected();
 
         TimeSpan effectiveTimeout = timeout ?? TimeSpan.FromSeconds(10);
 
         // Set up the wait before issuing the command to avoid missing the event.
-        Task<VirtualcamStateChangedEventArgs> waitTask = client.WaitForEventAsync<VirtualcamStateChangedEventArgs>(
-            predicate: _ => true,
-            timeout: effectiveTimeout,
-            cancellationToken: cancellationToken);
+        Task<VirtualcamStateChangedEventArgs> waitTask =
+            client.WaitForEventAsync<VirtualcamStateChangedEventArgs>(
+                predicate: _ => true,
+                timeout: effectiveTimeout,
+                cancellationToken: cancellationToken
+            );
 
         if (activate)
         {

--- a/ObsWebSocket.Core/Groups/RecordGroup.cs
+++ b/ObsWebSocket.Core/Groups/RecordGroup.cs
@@ -15,23 +15,23 @@ using ObsWebSocket.Core.Protocol.Responses;
 namespace ObsWebSocket.Core;
 
 /// <summary>
-/// Conveniences for the <c>Stream</c> category, alongside its generated requests.
+/// Conveniences for the <c>Record</c> category, alongside its generated requests.
 /// </summary>
-public readonly partial struct StreamRequestGroup
+public readonly partial struct RecordGroup
 {
     private static readonly TimeSpan s_defaultOutputTimeout = TimeSpan.FromSeconds(10);
 
         /// <summary>
-        /// Starts or stops streaming and waits for OBS to confirm the state change.
+        /// Starts or stops recording and waits for OBS to confirm the state change.
         /// </summary>
-        /// <param name="activate"><see langword="true"/> to start streaming; <see langword="false"/> to stop it.</param>
+        /// <param name="activate"><see langword="true"/> to start recording; <see langword="false"/> to stop it.</param>
         /// <param name="timeout">Maximum time to wait for the state-change event. Defaults to 10 seconds.</param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>
         /// The state reported by the event, or <see langword="null"/> if the timeout elapsed first.
         /// </returns>
         /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-        public async Task<OutputState?> SetStreamActiveAndWaitAsync(
+        public async Task<OutputState?> SetRecordActiveAndWaitAsync(
             bool activate,
             TimeSpan? timeout = null,
             CancellationToken cancellationToken = default
@@ -39,7 +39,8 @@ public readonly partial struct StreamRequestGroup
         {
             client.EnsureConnected();
 
-            Task<StreamStateChangedEventArgs> waitTask = client.WaitForEventAsync<StreamStateChangedEventArgs>(
+            // Set up the wait before issuing the command to avoid missing the event.
+            Task<RecordStateChangedEventArgs> waitTask = client.WaitForEventAsync<RecordStateChangedEventArgs>(
                 predicate: _ => true,
                 timeout: timeout ?? s_defaultOutputTimeout,
                 cancellationToken: cancellationToken
@@ -47,16 +48,16 @@ public readonly partial struct StreamRequestGroup
 
             if (activate)
             {
-                await client.Stream.StartStreamAsync(cancellationToken).ConfigureAwait(false);
+                await client.Record.StartRecordAsync(cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                await client.Stream.StopStreamAsync(cancellationToken).ConfigureAwait(false);
+                _ = await client.Record.StopRecordAsync(cancellationToken).ConfigureAwait(false);
             }
 
             try
             {
-                StreamStateChangedEventArgs ev = await waitTask.ConfigureAwait(false);
+                RecordStateChangedEventArgs ev = await waitTask.ConfigureAwait(false);
                 return OutputStateExtensions.FromWireValue(ev.EventData.OutputState);
             }
             catch (TimeoutException)
@@ -66,17 +67,17 @@ public readonly partial struct StreamRequestGroup
         }
 
         /// <summary>
-        /// Returns whether streaming is currently active.
+        /// Returns whether recording is currently active.
         /// </summary>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-        public async Task<bool> IsStreamActiveAsync(
+        public async Task<bool> IsRecordActiveAsync(
             CancellationToken cancellationToken = default
         )
         {
             client.EnsureConnected();
-            GetStreamStatusResponseData? status = await client
-                .Stream.GetStreamStatusAsync(cancellationToken)
+            GetRecordStatusResponseData? status = await client
+                .Record.GetRecordStatusAsync(cancellationToken)
                 .ConfigureAwait(false);
             return status?.OutputActive ?? false;
         }

--- a/ObsWebSocket.Core/Groups/RecordGroup.cs
+++ b/ObsWebSocket.Core/Groups/RecordGroup.cs
@@ -1,11 +1,11 @@
-using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.Logging;
 using ObsWebSocket.Core.Events;
 using ObsWebSocket.Core.Events.Generated;
+using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol;
 using ObsWebSocket.Core.Protocol.Common;
-using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol.Common.FilterSettings;
 using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
@@ -21,64 +21,63 @@ public readonly partial struct RecordGroup
 {
     private static readonly TimeSpan s_defaultOutputTimeout = TimeSpan.FromSeconds(10);
 
-        /// <summary>
-        /// Starts or stops recording and waits for OBS to confirm the state change.
-        /// </summary>
-        /// <param name="activate"><see langword="true"/> to start recording; <see langword="false"/> to stop it.</param>
-        /// <param name="timeout">Maximum time to wait for the state-change event. Defaults to 10 seconds.</param>
-        /// <param name="cancellationToken">A token to cancel the operation.</param>
-        /// <returns>
-        /// The state reported by the event, or <see langword="null"/> if the timeout elapsed first.
-        /// </returns>
-        /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-        public async Task<OutputState?> SetRecordActiveAndWaitAsync(
-            bool activate,
-            TimeSpan? timeout = null,
-            CancellationToken cancellationToken = default
-        )
-        {
-            client.EnsureConnected();
+    /// <summary>
+    /// Starts or stops recording and waits for OBS to confirm the state change.
+    /// </summary>
+    /// <param name="activate"><see langword="true"/> to start recording; <see langword="false"/> to stop it.</param>
+    /// <param name="timeout">Maximum time to wait for the state-change event. Defaults to 10 seconds.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>
+    /// The state reported by the event, or <see langword="null"/> if the timeout elapsed first.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
+    public async Task<OutputState?> SetRecordActiveAndWaitAsync(
+        bool activate,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        client.EnsureConnected();
 
-            // Set up the wait before issuing the command to avoid missing the event.
-            Task<RecordStateChangedEventArgs> waitTask = client.WaitForEventAsync<RecordStateChangedEventArgs>(
+        // Set up the wait before issuing the command to avoid missing the event.
+        Task<RecordStateChangedEventArgs> waitTask =
+            client.WaitForEventAsync<RecordStateChangedEventArgs>(
                 predicate: _ => true,
                 timeout: timeout ?? s_defaultOutputTimeout,
                 cancellationToken: cancellationToken
             );
 
-            if (activate)
-            {
-                await client.Record.StartRecordAsync(cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                _ = await client.Record.StopRecordAsync(cancellationToken).ConfigureAwait(false);
-            }
-
-            try
-            {
-                RecordStateChangedEventArgs ev = await waitTask.ConfigureAwait(false);
-                return OutputStateExtensions.FromWireValue(ev.EventData.OutputState);
-            }
-            catch (TimeoutException)
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Returns whether recording is currently active.
-        /// </summary>
-        /// <param name="cancellationToken">A token to cancel the operation.</param>
-        /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-        public async Task<bool> IsRecordActiveAsync(
-            CancellationToken cancellationToken = default
-        )
+        if (activate)
         {
-            client.EnsureConnected();
-            GetRecordStatusResponseData? status = await client
-                .Record.GetRecordStatusAsync(cancellationToken)
-                .ConfigureAwait(false);
-            return status?.OutputActive ?? false;
+            await client.Record.StartRecordAsync(cancellationToken).ConfigureAwait(false);
         }
+        else
+        {
+            _ = await client.Record.StopRecordAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        try
+        {
+            RecordStateChangedEventArgs ev = await waitTask.ConfigureAwait(false);
+            return OutputStateExtensions.FromWireValue(ev.EventData.OutputState);
+        }
+        catch (TimeoutException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Returns whether recording is currently active.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
+    public async Task<bool> IsRecordActiveAsync(CancellationToken cancellationToken = default)
+    {
+        client.EnsureConnected();
+        GetRecordStatusResponseData? status = await client
+            .Record.GetRecordStatusAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return status?.OutputActive ?? false;
+    }
 }

--- a/ObsWebSocket.Core/Groups/SceneItemsGroup.cs
+++ b/ObsWebSocket.Core/Groups/SceneItemsGroup.cs
@@ -17,7 +17,7 @@ namespace ObsWebSocket.Core;
 /// <summary>
 /// Conveniences for the <c>SceneItems</c> category, alongside its generated requests.
 /// </summary>
-public readonly partial struct SceneItemsRequestGroup
+public readonly partial struct SceneItemsGroup
 {
     /// <summary>
     /// Sets or toggles the enabled (visibility) state of a scene item, identified by its numeric ID.

--- a/ObsWebSocket.Core/Groups/SceneItemsGroup.cs
+++ b/ObsWebSocket.Core/Groups/SceneItemsGroup.cs
@@ -11,7 +11,6 @@ using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
 using ObsWebSocket.Core.Protocol.Requests;
 using ObsWebSocket.Core.Protocol.Responses;
-using ObsRequestStatus = ObsWebSocket.Core.Protocol.Generated.RequestStatus;
 
 namespace ObsWebSocket.Core;
 
@@ -149,7 +148,7 @@ public readonly partial struct SceneItemsGroup
             return response?.SceneItemId;
         }
         catch (ObsWebSocketRequestException ex)
-            when (ex.StatusCode is ObsRequestStatus.ResourceNotFound)
+            when (ex.StatusCode is RequestStatusCode.ResourceNotFound)
         {
             // Item or scene not found, which is the expected 'failure' for a 'TryGet' pattern
             return null;

--- a/ObsWebSocket.Core/Groups/SceneItemsGroup.cs
+++ b/ObsWebSocket.Core/Groups/SceneItemsGroup.cs
@@ -11,6 +11,7 @@ using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
 using ObsWebSocket.Core.Protocol.Requests;
 using ObsWebSocket.Core.Protocol.Responses;
+using ObsRequestStatus = ObsWebSocket.Core.Protocol.Generated.RequestStatus;
 
 namespace ObsWebSocket.Core;
 
@@ -118,25 +119,6 @@ public readonly partial struct SceneItemsGroup
     }
 
     /// <summary>
-    /// Attempts to get the numeric ID of a scene item within a specific scene.
-    /// Returns null if the scene or source is not found.
-    /// </summary>
-    /// <param name="sceneName">The name of the scene to search within.</param>
-    /// <param name="sourceName">The name of the source corresponding to the scene item.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A Task resulting in the nullable scene item ID (double?). Returns null if the item or scene is not found.</returns>
-    /// <exception cref="ObsWebSocketException">Thrown for OBS errors other than 'ResourceNotFound'.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    [Obsolete(
-        "Renamed to FindSceneItemIdAsync. Async methods cannot use the out-parameter Try pattern, so the Try prefix was misleading. This forwarder will be removed in a future release."
-    )]
-    public Task<double?> TryGetSceneItemIdAsync(
-        string sceneName,
-        string sourceName,
-        CancellationToken cancellationToken = default
-    ) => client.SceneItems.FindSceneItemIdAsync(sceneName, sourceName, cancellationToken);
-
-    /// <summary>
     /// Returns the scene item id for a source within a scene, or <see langword="null"/> when the
     /// scene does not contain it.
     /// </summary>
@@ -145,7 +127,7 @@ public readonly partial struct SceneItemsGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>The scene item id, or <see langword="null"/> if the source is not in the scene.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<double?> FindSceneItemIdAsync(
+    public async Task<int?> FindSceneItemIdAsync(
         string sceneName,
         string sourceName,
         CancellationToken cancellationToken = default
@@ -164,18 +146,12 @@ public readonly partial struct SceneItemsGroup
                 )
                 .ConfigureAwait(false);
 
-            // If response is not null, return the ID. The underlying GetSceneItemIdAsync
-            // should guarantee the response isn't null on success.
-            return response?.SceneItemId;
+            // Scene item ids are Number on the wire because the protocol has no integer type,
+            // but OBS only ever assigns whole numbers.
+            return response is null ? null : checked((int)response.SceneItemId);
         }
-        catch (ObsWebSocketException ex)
-            when (ex.Message.Contains("NotFound", StringComparison.OrdinalIgnoreCase)
-                || // General not found
-                ex.Message.Contains(
-                    $"code {(int)Core.Protocol.Generated.RequestStatus.ResourceNotFound}:",
-                    StringComparison.Ordinal
-                ) // Specific code check
-            )
+        catch (ObsWebSocketRequestException ex)
+            when (ex.StatusCode is ObsRequestStatus.ResourceNotFound)
         {
             // Item or scene not found, which is the expected 'failure' for a 'TryGet' pattern
             return null;
@@ -211,15 +187,12 @@ public readonly partial struct SceneItemsGroup
     /// <param name="sceneName">The name of the scene to search.</param>
     /// <param name="sourceName">The name of the source to locate.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    public async Task<int?> FindSceneItemIdInt32Async(
+    [Obsolete(
+        "FindSceneItemIdAsync now returns int?, so this variant is redundant. This forwarder will be removed in a future release."
+    )]
+    public Task<int?> FindSceneItemIdInt32Async(
         string sceneName,
         string sourceName,
         CancellationToken cancellationToken = default
-    )
-    {
-        double? id = await client
-            .SceneItems.FindSceneItemIdAsync(sceneName, sourceName, cancellationToken)
-            .ConfigureAwait(false);
-        return id is null ? null : checked((int)id.Value);
-    }
+    ) => FindSceneItemIdAsync(sceneName, sourceName, cancellationToken);
 }

--- a/ObsWebSocket.Core/Groups/SceneItemsGroup.cs
+++ b/ObsWebSocket.Core/Groups/SceneItemsGroup.cs
@@ -32,7 +32,7 @@ public readonly partial struct SceneItemsGroup
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
     public async Task<bool> SetSceneItemEnabledAsync(
         string sceneName,
-        double sceneItemId, // Use double as sceneItemId is Number in protocol
+        int sceneItemId,
         bool? isEnabled = null, // If null, toggles; otherwise sets to the specified state
         CancellationToken cancellationToken = default
     )
@@ -100,7 +100,7 @@ public readonly partial struct SceneItemsGroup
         ArgumentException.ThrowIfNullOrEmpty(sourceName);
         client.EnsureConnected();
 
-        double? sceneItemId = await client
+        int? sceneItemId = await client
             .SceneItems.FindSceneItemIdAsync(sceneName, sourceName, cancellationToken)
             .ConfigureAwait(false);
 
@@ -146,9 +146,7 @@ public readonly partial struct SceneItemsGroup
                 )
                 .ConfigureAwait(false);
 
-            // Scene item ids are Number on the wire because the protocol has no integer type,
-            // but OBS only ever assigns whole numbers.
-            return response is null ? null : checked((int)response.SceneItemId);
+            return response?.SceneItemId;
         }
         catch (ObsWebSocketRequestException ex)
             when (ex.StatusCode is ObsRequestStatus.ResourceNotFound)
@@ -158,27 +156,6 @@ public readonly partial struct SceneItemsGroup
         }
         // Let other ObsWebSocketExceptions or different exception types propagate
     }
-
-    /// <summary>
-    /// Sets or toggles a scene item's enabled state using an integer item id.
-    /// </summary>
-    /// <param name="sceneName">The name of the scene containing the item.</param>
-    /// <param name="sceneItemId">The numeric id of the scene item.</param>
-    /// <param name="isEnabled">The desired state, or <see langword="null"/> to toggle.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>The resulting enabled state.</returns>
-    public Task<bool> SetSceneItemEnabledAsync(
-        string sceneName,
-        int sceneItemId,
-        bool? isEnabled = null,
-        CancellationToken cancellationToken = default
-    ) =>
-        client.SceneItems.SetSceneItemEnabledAsync(
-            sceneName,
-            (double)sceneItemId,
-            isEnabled,
-            cancellationToken
-        );
 
     /// <summary>
     /// Returns the scene item id for a source within a scene as an <see cref="int"/>, or

--- a/ObsWebSocket.Core/Groups/SceneItemsGroup.cs
+++ b/ObsWebSocket.Core/Groups/SceneItemsGroup.cs
@@ -1,11 +1,11 @@
-using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.Logging;
 using ObsWebSocket.Core.Events;
 using ObsWebSocket.Core.Events.Generated;
+using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol;
 using ObsWebSocket.Core.Protocol.Common;
-using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol.Common.FilterSettings;
 using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
@@ -29,7 +29,8 @@ public readonly partial struct SceneItemsGroup
     /// <returns>The final enabled state of the scene item after the operation.</returns>
     /// <exception cref="ObsWebSocketException">Thrown if OBS fails the operation (e.g., scene/item not found).</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<bool> SetSceneItemEnabledAsync(string sceneName,
+    public async Task<bool> SetSceneItemEnabledAsync(
+        string sceneName,
         double sceneItemId, // Use double as sceneItemId is Number in protocol
         bool? isEnabled = null, // If null, toggles; otherwise sets to the specified state
         CancellationToken cancellationToken = default
@@ -49,7 +50,10 @@ public readonly partial struct SceneItemsGroup
             GetSceneItemEnabledResponseData currentStateResponse =
                 await client
                     .SceneItems.GetSceneItemEnabledAsync(
-                        new GetSceneItemEnabledRequestData(sceneItemId: sceneItemId, sceneName: sceneName),
+                        new GetSceneItemEnabledRequestData(
+                            sceneItemId: sceneItemId,
+                            sceneName: sceneName
+                        ),
                         cancellationToken: cancellationToken
                     )
                     .ConfigureAwait(false)
@@ -60,7 +64,8 @@ public readonly partial struct SceneItemsGroup
         }
 
         await client
-            .SceneItems.SetSceneItemEnabledAsync(new SetSceneItemEnabledRequestData(
+            .SceneItems.SetSceneItemEnabledAsync(
+                new SetSceneItemEnabledRequestData(
                     sceneItemId: sceneItemId,
                     sceneItemEnabled: targetState,
                     sceneName: sceneName
@@ -83,7 +88,8 @@ public readonly partial struct SceneItemsGroup
     /// <exception cref="ObsWebSocketException">Thrown if OBS fails the operation (e.g., scene/item not found).</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
     /// <exception cref="SceneItemNotFoundException">Thrown if the source name is not found within the specified scene.</exception>
-    public async Task<bool> SetSceneItemEnabledAsync(string sceneName,
+    public async Task<bool> SetSceneItemEnabledAsync(
+        string sceneName,
         string sourceName,
         bool? isEnabled = null, // If null, toggles; otherwise sets to the specified state
         CancellationToken cancellationToken = default
@@ -99,7 +105,8 @@ public readonly partial struct SceneItemsGroup
 
         return sceneItemId.HasValue
             ? await client
-                .SceneItems.SetSceneItemEnabledAsync(sceneName,
+                .SceneItems.SetSceneItemEnabledAsync(
+                    sceneName,
                     sceneItemId.Value,
                     isEnabled,
                     cancellationToken
@@ -120,8 +127,11 @@ public readonly partial struct SceneItemsGroup
     /// <returns>A Task resulting in the nullable scene item ID (double?). Returns null if the item or scene is not found.</returns>
     /// <exception cref="ObsWebSocketException">Thrown for OBS errors other than 'ResourceNotFound'.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    [Obsolete("Renamed to FindSceneItemIdAsync. Async methods cannot use the out-parameter Try pattern, so the Try prefix was misleading. This forwarder will be removed in a future release.")]
-    public Task<double?> TryGetSceneItemIdAsync(string sceneName,
+    [Obsolete(
+        "Renamed to FindSceneItemIdAsync. Async methods cannot use the out-parameter Try pattern, so the Try prefix was misleading. This forwarder will be removed in a future release."
+    )]
+    public Task<double?> TryGetSceneItemIdAsync(
+        string sceneName,
         string sourceName,
         CancellationToken cancellationToken = default
     ) => client.SceneItems.FindSceneItemIdAsync(sceneName, sourceName, cancellationToken);
@@ -135,7 +145,8 @@ public readonly partial struct SceneItemsGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>The scene item id, or <see langword="null"/> if the source is not in the scene.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<double?> FindSceneItemIdAsync(string sceneName,
+    public async Task<double?> FindSceneItemIdAsync(
+        string sceneName,
         string sourceName,
         CancellationToken cancellationToken = default
     )
@@ -172,42 +183,43 @@ public readonly partial struct SceneItemsGroup
         // Let other ObsWebSocketExceptions or different exception types propagate
     }
 
-        /// <summary>
-        /// Sets or toggles a scene item's enabled state using an integer item id.
-        /// </summary>
-        /// <param name="sceneName">The name of the scene containing the item.</param>
-        /// <param name="sceneItemId">The numeric id of the scene item.</param>
-        /// <param name="isEnabled">The desired state, or <see langword="null"/> to toggle.</param>
-        /// <param name="cancellationToken">A token to cancel the operation.</param>
-        /// <returns>The resulting enabled state.</returns>
-        public Task<bool> SetSceneItemEnabledAsync(
-            string sceneName,
-            int sceneItemId,
-            bool? isEnabled = null,
-            CancellationToken cancellationToken = default
-        ) =>
-            client.SceneItems.SetSceneItemEnabledAsync(sceneName,
-                (double)sceneItemId,
-                isEnabled,
-                cancellationToken
-            );
+    /// <summary>
+    /// Sets or toggles a scene item's enabled state using an integer item id.
+    /// </summary>
+    /// <param name="sceneName">The name of the scene containing the item.</param>
+    /// <param name="sceneItemId">The numeric id of the scene item.</param>
+    /// <param name="isEnabled">The desired state, or <see langword="null"/> to toggle.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The resulting enabled state.</returns>
+    public Task<bool> SetSceneItemEnabledAsync(
+        string sceneName,
+        int sceneItemId,
+        bool? isEnabled = null,
+        CancellationToken cancellationToken = default
+    ) =>
+        client.SceneItems.SetSceneItemEnabledAsync(
+            sceneName,
+            (double)sceneItemId,
+            isEnabled,
+            cancellationToken
+        );
 
-        /// <summary>
-        /// Returns the scene item id for a source within a scene as an <see cref="int"/>, or
-        /// <see langword="null"/> when the scene does not contain it.
-        /// </summary>
-        /// <param name="sceneName">The name of the scene to search.</param>
-        /// <param name="sourceName">The name of the source to locate.</param>
-        /// <param name="cancellationToken">A token to cancel the operation.</param>
-        public async Task<int?> FindSceneItemIdInt32Async(
-            string sceneName,
-            string sourceName,
-            CancellationToken cancellationToken = default
-        )
-        {
-            double? id = await client
-                .SceneItems.FindSceneItemIdAsync(sceneName, sourceName, cancellationToken)
-                .ConfigureAwait(false);
-            return id is null ? null : checked((int)id.Value);
-        }
+    /// <summary>
+    /// Returns the scene item id for a source within a scene as an <see cref="int"/>, or
+    /// <see langword="null"/> when the scene does not contain it.
+    /// </summary>
+    /// <param name="sceneName">The name of the scene to search.</param>
+    /// <param name="sourceName">The name of the source to locate.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    public async Task<int?> FindSceneItemIdInt32Async(
+        string sceneName,
+        string sourceName,
+        CancellationToken cancellationToken = default
+    )
+    {
+        double? id = await client
+            .SceneItems.FindSceneItemIdAsync(sceneName, sourceName, cancellationToken)
+            .ConfigureAwait(false);
+        return id is null ? null : checked((int)id.Value);
+    }
 }

--- a/ObsWebSocket.Core/Groups/ScenesGroup.cs
+++ b/ObsWebSocket.Core/Groups/ScenesGroup.cs
@@ -1,11 +1,11 @@
-using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.Logging;
 using ObsWebSocket.Core.Events;
 using ObsWebSocket.Core.Events.Generated;
+using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol;
 using ObsWebSocket.Core.Protocol.Common;
-using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol.Common.FilterSettings;
 using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
@@ -30,7 +30,8 @@ public readonly partial struct ScenesGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if OBS fails to perform any step (e.g., scene/transition not found).</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task SwitchSceneAsync(string sceneName,
+    public async Task SwitchSceneAsync(
+        string sceneName,
         string? transitionName = null,
         int? transitionDurationMs = null,
         bool switchToProgram = true,
@@ -106,7 +107,8 @@ public readonly partial struct ScenesGroup
     /// <exception cref="TimeoutException">Thrown if the expected event confirming the switch completion is not received within the timeout period.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected, or if trying to switch Preview scene when Studio Mode is disabled.</exception>
     /// <exception cref="OperationCanceledException">Thrown if the operation is canceled via the cancellationToken.</exception>
-    public async Task SwitchSceneAndWaitAsync(string sceneName,
+    public async Task SwitchSceneAndWaitAsync(
+        string sceneName,
         string? transitionName = null,
         int? transitionDurationMs = null,
         bool switchToProgram = true,
@@ -210,75 +212,76 @@ public readonly partial struct ScenesGroup
         // The finally block within WaitForEventAsync handles unsubscribing the temporary event handler.
     }
 
-        /// <summary>
-        /// Checks whether a scene with the given name exists.
-        /// </summary>
-        /// <param name="sceneName">The scene name to look for.</param>
-        /// <param name="cancellationToken">A token to cancel the operation.</param>
-        /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-        public async Task<bool> SceneExistsAsync(
-            string sceneName,
-            CancellationToken cancellationToken = default
-        )
-        {
-            ArgumentException.ThrowIfNullOrEmpty(sceneName);
-            client.EnsureConnected();
+    /// <summary>
+    /// Checks whether a scene with the given name exists.
+    /// </summary>
+    /// <param name="sceneName">The scene name to look for.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
+    public async Task<bool> SceneExistsAsync(
+        string sceneName,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sceneName);
+        client.EnsureConnected();
 
-            GetSceneListResponseData? scenes = await client
-                .Scenes.GetSceneListAsync(new GetSceneListRequestData(), cancellationToken)
-                .ConfigureAwait(false);
+        GetSceneListResponseData? scenes = await client
+            .Scenes.GetSceneListAsync(new GetSceneListRequestData(), cancellationToken)
+            .ConfigureAwait(false);
 
-            return scenes?.Scenes?.Any(s =>
+        return scenes?.Scenes?.Any(s =>
                 string.Equals(s.SceneName, sceneName, StringComparison.Ordinal)
-            ) ?? false;
-        }
+            )
+            ?? false;
+    }
 
-        /// <summary>Switches the Program scene.</summary>
-        /// <param name="sceneName">The scene to switch to.</param>
-        /// <param name="transitionName">Optional transition to use for this switch only.</param>
-        /// <param name="transitionDurationMs">Optional transition duration for this switch only.</param>
-        /// <param name="cancellationToken">A token to cancel the operation.</param>
-        public Task SwitchProgramSceneAsync(
-            string sceneName,
-            string? transitionName = null,
-            int? transitionDurationMs = null,
-            CancellationToken cancellationToken = default
-        ) =>
-            client.Scenes.SwitchSceneAsync(
-                sceneName,
-                transitionName,
-                transitionDurationMs,
-                switchToProgram: true,
-                cancellationToken
-            );
+    /// <summary>Switches the Program scene.</summary>
+    /// <param name="sceneName">The scene to switch to.</param>
+    /// <param name="transitionName">Optional transition to use for this switch only.</param>
+    /// <param name="transitionDurationMs">Optional transition duration for this switch only.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    public Task SwitchProgramSceneAsync(
+        string sceneName,
+        string? transitionName = null,
+        int? transitionDurationMs = null,
+        CancellationToken cancellationToken = default
+    ) =>
+        client.Scenes.SwitchSceneAsync(
+            sceneName,
+            transitionName,
+            transitionDurationMs,
+            switchToProgram: true,
+            cancellationToken
+        );
 
-        /// <summary>Switches the Preview scene. Requires Studio Mode.</summary>
-        /// <param name="sceneName">The scene to switch to.</param>
-        /// <param name="cancellationToken">A token to cancel the operation.</param>
-        public Task SwitchPreviewSceneAsync(
-            string sceneName,
-            CancellationToken cancellationToken = default
-        ) =>
-            client.Scenes.SwitchSceneAsync(
-                sceneName,
-                switchToProgram: false,
-                cancellationToken: cancellationToken
-            );
+    /// <summary>Switches the Preview scene. Requires Studio Mode.</summary>
+    /// <param name="sceneName">The scene to switch to.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    public Task SwitchPreviewSceneAsync(
+        string sceneName,
+        CancellationToken cancellationToken = default
+    ) =>
+        client.Scenes.SwitchSceneAsync(
+            sceneName,
+            switchToProgram: false,
+            cancellationToken: cancellationToken
+        );
 
-        /// <summary>Switches the Program scene and waits for OBS to confirm it.</summary>
-        /// <param name="sceneName">The scene to switch to.</param>
-        /// <param name="timeout">How long to wait for confirmation.</param>
-        /// <param name="cancellationToken">A token to cancel the operation.</param>
-        /// <exception cref="TimeoutException">Thrown if the confirmation does not arrive in time.</exception>
-        public Task SwitchProgramSceneAndWaitAsync(
-            string sceneName,
-            TimeSpan? timeout = null,
-            CancellationToken cancellationToken = default
-        ) =>
-            client.Scenes.SwitchSceneAndWaitAsync(
-                sceneName,
-                switchToProgram: true,
-                timeout: timeout,
-                cancellationToken: cancellationToken
-            );
+    /// <summary>Switches the Program scene and waits for OBS to confirm it.</summary>
+    /// <param name="sceneName">The scene to switch to.</param>
+    /// <param name="timeout">How long to wait for confirmation.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <exception cref="TimeoutException">Thrown if the confirmation does not arrive in time.</exception>
+    public Task SwitchProgramSceneAndWaitAsync(
+        string sceneName,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default
+    ) =>
+        client.Scenes.SwitchSceneAndWaitAsync(
+            sceneName,
+            switchToProgram: true,
+            timeout: timeout,
+            cancellationToken: cancellationToken
+        );
 }

--- a/ObsWebSocket.Core/Groups/ScenesGroup.cs
+++ b/ObsWebSocket.Core/Groups/ScenesGroup.cs
@@ -17,7 +17,7 @@ namespace ObsWebSocket.Core;
 /// <summary>
 /// Conveniences for the <c>Scenes</c> category, alongside its generated requests.
 /// </summary>
-public readonly partial struct ScenesRequestGroup
+public readonly partial struct ScenesGroup
 {
     /// <summary>
     /// Switches the active Program or Preview scene, optionally setting a specific transition and duration beforehand.

--- a/ObsWebSocket.Core/Groups/ScenesGroup.cs
+++ b/ObsWebSocket.Core/Groups/ScenesGroup.cs
@@ -30,7 +30,7 @@ public readonly partial struct ScenesGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if OBS fails to perform any step (e.g., scene/transition not found).</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task SwitchSceneAsync(
+    private async Task SwitchSceneCoreAsync(
         string sceneName,
         string? transitionName = null,
         int? transitionDurationMs = null,
@@ -107,7 +107,7 @@ public readonly partial struct ScenesGroup
     /// <exception cref="TimeoutException">Thrown if the expected event confirming the switch completion is not received within the timeout period.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected, or if trying to switch Preview scene when Studio Mode is disabled.</exception>
     /// <exception cref="OperationCanceledException">Thrown if the operation is canceled via the cancellationToken.</exception>
-    public async Task SwitchSceneAndWaitAsync(
+    private async Task SwitchSceneAndWaitCoreAsync(
         string sceneName,
         string? transitionName = null,
         int? transitionDurationMs = null,
@@ -158,8 +158,7 @@ public readonly partial struct ScenesGroup
         {
             // Trigger the scene switch using the non-waiting helper
             // This call happens *after* WaitForEventAsync has set up its subscription
-            await client
-                .Scenes.SwitchSceneAsync(
+            await SwitchSceneCoreAsync(
                     sceneName: sceneName,
                     transitionName: switchToProgram ? transitionName : null,
                     transitionDurationMs: switchToProgram ? transitionDurationMs : null,
@@ -247,7 +246,7 @@ public readonly partial struct ScenesGroup
         int? transitionDurationMs = null,
         CancellationToken cancellationToken = default
     ) =>
-        client.Scenes.SwitchSceneAsync(
+        SwitchSceneCoreAsync(
             sceneName,
             transitionName,
             transitionDurationMs,
@@ -262,7 +261,7 @@ public readonly partial struct ScenesGroup
         string sceneName,
         CancellationToken cancellationToken = default
     ) =>
-        client.Scenes.SwitchSceneAsync(
+        SwitchSceneCoreAsync(
             sceneName,
             switchToProgram: false,
             cancellationToken: cancellationToken
@@ -278,10 +277,81 @@ public readonly partial struct ScenesGroup
         TimeSpan? timeout = null,
         CancellationToken cancellationToken = default
     ) =>
-        client.Scenes.SwitchSceneAndWaitAsync(
+        SwitchSceneAndWaitCoreAsync(
             sceneName,
             switchToProgram: true,
             timeout: timeout,
             cancellationToken: cancellationToken
+        );
+
+    /// <summary>Switches the Preview scene and waits for OBS to confirm it. Requires Studio Mode.</summary>
+    /// <param name="sceneName">The scene to switch to.</param>
+    /// <param name="timeout">How long to wait for confirmation.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    public Task SwitchPreviewSceneAndWaitAsync(
+        string sceneName,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default
+    ) =>
+        SwitchSceneAndWaitCoreAsync(
+            sceneName,
+            switchToProgram: false,
+            timeout: timeout,
+            cancellationToken: cancellationToken
+        );
+
+    /// <summary>
+    /// Switches the Program or Preview scene, depending on <paramref name="switchToProgram"/>.
+    /// </summary>
+    /// <param name="sceneName">The scene to switch to.</param>
+    /// <param name="transitionName">Optional transition to use for this switch only.</param>
+    /// <param name="transitionDurationMs">Optional transition duration for this switch only.</param>
+    /// <param name="switchToProgram">Program when true, Preview when false.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    [Obsolete(
+        "Call SwitchProgramSceneAsync or SwitchPreviewSceneAsync, which say which scene they switch. This forwarder will be removed in a future release."
+    )]
+    public Task SwitchSceneAsync(
+        string sceneName,
+        string? transitionName = null,
+        int? transitionDurationMs = null,
+        bool switchToProgram = true,
+        CancellationToken cancellationToken = default
+    ) =>
+        SwitchSceneCoreAsync(
+            sceneName,
+            transitionName,
+            transitionDurationMs,
+            switchToProgram,
+            cancellationToken
+        );
+
+    /// <summary>
+    /// Switches the Program or Preview scene and waits for OBS to confirm it.
+    /// </summary>
+    /// <param name="sceneName">The scene to switch to.</param>
+    /// <param name="transitionName">Optional transition to use for this switch only.</param>
+    /// <param name="transitionDurationMs">Optional transition duration for this switch only.</param>
+    /// <param name="switchToProgram">Program when true, Preview when false.</param>
+    /// <param name="timeout">How long to wait for confirmation.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    [Obsolete(
+        "Call SwitchProgramSceneAndWaitAsync or SwitchPreviewSceneAndWaitAsync, which say which scene they switch. This forwarder will be removed in a future release."
+    )]
+    public Task SwitchSceneAndWaitAsync(
+        string sceneName,
+        string? transitionName = null,
+        int? transitionDurationMs = null,
+        bool switchToProgram = true,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default
+    ) =>
+        SwitchSceneAndWaitCoreAsync(
+            sceneName,
+            transitionName,
+            transitionDurationMs,
+            switchToProgram,
+            timeout,
+            cancellationToken
         );
 }

--- a/ObsWebSocket.Core/Groups/SourcesGroup.cs
+++ b/ObsWebSocket.Core/Groups/SourcesGroup.cs
@@ -17,7 +17,7 @@ namespace ObsWebSocket.Core;
 /// <summary>
 /// Conveniences for the <c>Sources</c> category, alongside its generated requests.
 /// </summary>
-public readonly partial struct SourcesRequestGroup
+public readonly partial struct SourcesGroup
 {
     /// <summary>
     /// Checks if an input or scene source with the given name exists in OBS.

--- a/ObsWebSocket.Core/Groups/SourcesGroup.cs
+++ b/ObsWebSocket.Core/Groups/SourcesGroup.cs
@@ -11,6 +11,7 @@ using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
 using ObsWebSocket.Core.Protocol.Requests;
 using ObsWebSocket.Core.Protocol.Responses;
+using ObsRequestStatus = ObsWebSocket.Core.Protocol.Generated.RequestStatus;
 
 namespace ObsWebSocket.Core;
 
@@ -118,13 +119,8 @@ public readonly partial struct SourcesGroup
                 )
                 .ConfigureAwait(false);
         }
-        catch (ObsWebSocketException ex)
-            when (ex.Message.Contains("NotFound", StringComparison.OrdinalIgnoreCase)
-                || ex.Message.Contains(
-                    $"code {(int)Core.Protocol.Generated.RequestStatus.ResourceNotFound}:",
-                    StringComparison.Ordinal
-                )
-            )
+        catch (ObsWebSocketRequestException ex)
+            when (ex.StatusCode is ObsRequestStatus.ResourceNotFound)
         {
             client._logger.LogWarning(
                 "Source '{SourceName}' not found for screenshot.",

--- a/ObsWebSocket.Core/Groups/SourcesGroup.cs
+++ b/ObsWebSocket.Core/Groups/SourcesGroup.cs
@@ -1,11 +1,11 @@
-using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.Logging;
 using ObsWebSocket.Core.Events;
 using ObsWebSocket.Core.Events.Generated;
+using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol;
 using ObsWebSocket.Core.Protocol.Common;
-using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol.Common.FilterSettings;
 using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
@@ -27,7 +27,8 @@ public readonly partial struct SourcesGroup
     /// <returns>True if a source (input or scene) with the specified name exists, false otherwise.</returns>
     /// <exception cref="ObsWebSocketException">Thrown if an unexpected error occurs during API calls.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<bool> SourceExistsAsync(string sourceName,
+    public async Task<bool> SourceExistsAsync(
+        string sourceName,
         CancellationToken cancellationToken = default
     )
     {
@@ -46,7 +47,8 @@ public readonly partial struct SourcesGroup
             if (
                 inputListResponse?.Inputs?.Any(i =>
                     string.Equals(i.InputName, sourceName, StringComparison.Ordinal)
-                ) ?? false
+                )
+                ?? false
             )
             {
                 return true;
@@ -59,7 +61,8 @@ public readonly partial struct SourcesGroup
                     .ConfigureAwait(false);
             return sceneListResponse?.Scenes?.Any(s =>
                     string.Equals(s.SceneName, sourceName, StringComparison.Ordinal)
-                ) ?? false;
+                )
+                ?? false;
         }
         catch (ObsWebSocketException ex)
         {
@@ -86,7 +89,8 @@ public readonly partial struct SourcesGroup
     /// <returns>A byte array containing the image data, or null if the source was not found or an error occurred.</returns>
     /// <exception cref="ObsWebSocketException">Thrown for OBS errors other than 'ResourceNotFound' or Base64 decoding errors.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<byte[]?> GetSourceScreenshotBytesAsync(string sourceName,
+    public async Task<byte[]?> GetSourceScreenshotBytesAsync(
+        string sourceName,
         string imageFormat = "png", // Common default
         int? width = null,
         int? height = null,
@@ -175,27 +179,32 @@ public readonly partial struct SourcesGroup
     /// <returns>The decoded image bytes, or an empty array if OBS returned no data.</returns>
     /// <exception cref="ObsWebSocketException">Thrown if OBS rejects the request.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<byte[]> GetSourceScreenshotOnCanvasBytesAsync(string sourceName,
+    public async Task<byte[]> GetSourceScreenshotOnCanvasBytesAsync(
+        string sourceName,
         string imageFormat = "png",
         int? width = null,
         int? height = null,
         int compressionQuality = -1,
         string? sourceUuid = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         ArgumentException.ThrowIfNullOrEmpty(sourceName);
         client.EnsureConnected();
 
-        GetSourceScreenshotResponseData? response = await client.Sources.GetSourceScreenshotAsync(
-            new GetSourceScreenshotRequestData(
-                imageFormat: imageFormat,
-                sourceName: sourceName,
-                sourceUuid: sourceUuid,
-                imageWidth: width,
-                imageHeight: height,
-                imageCompressionQuality: compressionQuality
-            ),
-            cancellationToken).ConfigureAwait(false);
+        GetSourceScreenshotResponseData? response = await client
+            .Sources.GetSourceScreenshotAsync(
+                new GetSourceScreenshotRequestData(
+                    imageFormat: imageFormat,
+                    sourceName: sourceName,
+                    sourceUuid: sourceUuid,
+                    imageWidth: width,
+                    imageHeight: height,
+                    imageCompressionQuality: compressionQuality
+                ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
 
         string? b64 = response?.ImageData;
         if (string.IsNullOrEmpty(b64))
@@ -226,30 +235,35 @@ public readonly partial struct SourcesGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if OBS rejects the request.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task SaveSourceScreenshotToFileAsync(string sourceName,
+    public async Task SaveSourceScreenshotToFileAsync(
+        string sourceName,
         string filePath,
         string imageFormat = "png",
         int? width = null,
         int? height = null,
         int compressionQuality = -1,
         string? sourceUuid = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         ArgumentException.ThrowIfNullOrEmpty(sourceName);
         ArgumentException.ThrowIfNullOrEmpty(filePath);
         client.EnsureConnected();
 
-        await client.Sources.SaveSourceScreenshotAsync(
-            new SaveSourceScreenshotRequestData(
-                imageFormat: imageFormat,
-                imageFilePath: filePath,
-                sourceName: sourceName,
-                sourceUuid: sourceUuid,
-                imageWidth: width,
-                imageHeight: height,
-                imageCompressionQuality: compressionQuality
-            ),
-            cancellationToken).ConfigureAwait(false);
+        await client
+            .Sources.SaveSourceScreenshotAsync(
+                new SaveSourceScreenshotRequestData(
+                    imageFormat: imageFormat,
+                    imageFilePath: filePath,
+                    sourceName: sourceName,
+                    sourceUuid: sourceUuid,
+                    imageWidth: width,
+                    imageHeight: height,
+                    imageCompressionQuality: compressionQuality
+                ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/ObsWebSocket.Core/Groups/SourcesGroup.cs
+++ b/ObsWebSocket.Core/Groups/SourcesGroup.cs
@@ -11,7 +11,6 @@ using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
 using ObsWebSocket.Core.Protocol.Requests;
 using ObsWebSocket.Core.Protocol.Responses;
-using ObsRequestStatus = ObsWebSocket.Core.Protocol.Generated.RequestStatus;
 
 namespace ObsWebSocket.Core;
 
@@ -120,7 +119,7 @@ public readonly partial struct SourcesGroup
                 .ConfigureAwait(false);
         }
         catch (ObsWebSocketRequestException ex)
-            when (ex.StatusCode is ObsRequestStatus.ResourceNotFound)
+            when (ex.StatusCode is RequestStatusCode.ResourceNotFound)
         {
             client._logger.LogWarning(
                 "Source '{SourceName}' not found for screenshot.",

--- a/ObsWebSocket.Core/Groups/SourcesRequestGroup.cs
+++ b/ObsWebSocket.Core/Groups/SourcesRequestGroup.cs
@@ -141,7 +141,7 @@ public readonly partial struct SourcesRequestGroup
 
         try
         {
-            return Convert.FromBase64String(response.ImageData);
+            return DecodeImageData(response.ImageData);
         }
         catch (FormatException formatEx)
         {
@@ -150,7 +150,6 @@ public readonly partial struct SourcesRequestGroup
                 "Failed to decode Base64 image data for screenshot of '{SourceName}'.",
                 sourceName
             );
-            // Wrap in ObsWebSocketException? Or just return null? Returning null seems reasonable for a helper.
             return null;
         }
     }
@@ -251,5 +250,17 @@ public readonly partial struct SourcesRequestGroup
                 imageCompressionQuality: compressionQuality
             ),
             cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Decodes the image OBS returns, which arrives as a data URI rather than bare Base64.
+    /// </summary>
+    /// <param name="imageData">The value of the response's image data field.</param>
+    internal static byte[] DecodeImageData(string imageData)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(imageData);
+
+        int comma = imageData.IndexOf(',', StringComparison.Ordinal);
+        return Convert.FromBase64String(comma >= 0 ? imageData[(comma + 1)..] : imageData);
     }
 }

--- a/ObsWebSocket.Core/Groups/StreamGroup.cs
+++ b/ObsWebSocket.Core/Groups/StreamGroup.cs
@@ -15,23 +15,23 @@ using ObsWebSocket.Core.Protocol.Responses;
 namespace ObsWebSocket.Core;
 
 /// <summary>
-/// Conveniences for the <c>Record</c> category, alongside its generated requests.
+/// Conveniences for the <c>Stream</c> category, alongside its generated requests.
 /// </summary>
-public readonly partial struct RecordRequestGroup
+public readonly partial struct StreamGroup
 {
     private static readonly TimeSpan s_defaultOutputTimeout = TimeSpan.FromSeconds(10);
 
         /// <summary>
-        /// Starts or stops recording and waits for OBS to confirm the state change.
+        /// Starts or stops streaming and waits for OBS to confirm the state change.
         /// </summary>
-        /// <param name="activate"><see langword="true"/> to start recording; <see langword="false"/> to stop it.</param>
+        /// <param name="activate"><see langword="true"/> to start streaming; <see langword="false"/> to stop it.</param>
         /// <param name="timeout">Maximum time to wait for the state-change event. Defaults to 10 seconds.</param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>
         /// The state reported by the event, or <see langword="null"/> if the timeout elapsed first.
         /// </returns>
         /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-        public async Task<OutputState?> SetRecordActiveAndWaitAsync(
+        public async Task<OutputState?> SetStreamActiveAndWaitAsync(
             bool activate,
             TimeSpan? timeout = null,
             CancellationToken cancellationToken = default
@@ -39,8 +39,7 @@ public readonly partial struct RecordRequestGroup
         {
             client.EnsureConnected();
 
-            // Set up the wait before issuing the command to avoid missing the event.
-            Task<RecordStateChangedEventArgs> waitTask = client.WaitForEventAsync<RecordStateChangedEventArgs>(
+            Task<StreamStateChangedEventArgs> waitTask = client.WaitForEventAsync<StreamStateChangedEventArgs>(
                 predicate: _ => true,
                 timeout: timeout ?? s_defaultOutputTimeout,
                 cancellationToken: cancellationToken
@@ -48,16 +47,16 @@ public readonly partial struct RecordRequestGroup
 
             if (activate)
             {
-                await client.Record.StartRecordAsync(cancellationToken).ConfigureAwait(false);
+                await client.Stream.StartStreamAsync(cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                _ = await client.Record.StopRecordAsync(cancellationToken).ConfigureAwait(false);
+                await client.Stream.StopStreamAsync(cancellationToken).ConfigureAwait(false);
             }
 
             try
             {
-                RecordStateChangedEventArgs ev = await waitTask.ConfigureAwait(false);
+                StreamStateChangedEventArgs ev = await waitTask.ConfigureAwait(false);
                 return OutputStateExtensions.FromWireValue(ev.EventData.OutputState);
             }
             catch (TimeoutException)
@@ -67,17 +66,17 @@ public readonly partial struct RecordRequestGroup
         }
 
         /// <summary>
-        /// Returns whether recording is currently active.
+        /// Returns whether streaming is currently active.
         /// </summary>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-        public async Task<bool> IsRecordActiveAsync(
+        public async Task<bool> IsStreamActiveAsync(
             CancellationToken cancellationToken = default
         )
         {
             client.EnsureConnected();
-            GetRecordStatusResponseData? status = await client
-                .Record.GetRecordStatusAsync(cancellationToken)
+            GetStreamStatusResponseData? status = await client
+                .Stream.GetStreamStatusAsync(cancellationToken)
                 .ConfigureAwait(false);
             return status?.OutputActive ?? false;
         }

--- a/ObsWebSocket.Core/Groups/StreamGroup.cs
+++ b/ObsWebSocket.Core/Groups/StreamGroup.cs
@@ -1,11 +1,11 @@
-using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.Logging;
 using ObsWebSocket.Core.Events;
 using ObsWebSocket.Core.Events.Generated;
+using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol;
 using ObsWebSocket.Core.Protocol.Common;
-using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol.Common.FilterSettings;
 using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
@@ -21,63 +21,62 @@ public readonly partial struct StreamGroup
 {
     private static readonly TimeSpan s_defaultOutputTimeout = TimeSpan.FromSeconds(10);
 
-        /// <summary>
-        /// Starts or stops streaming and waits for OBS to confirm the state change.
-        /// </summary>
-        /// <param name="activate"><see langword="true"/> to start streaming; <see langword="false"/> to stop it.</param>
-        /// <param name="timeout">Maximum time to wait for the state-change event. Defaults to 10 seconds.</param>
-        /// <param name="cancellationToken">A token to cancel the operation.</param>
-        /// <returns>
-        /// The state reported by the event, or <see langword="null"/> if the timeout elapsed first.
-        /// </returns>
-        /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-        public async Task<OutputState?> SetStreamActiveAndWaitAsync(
-            bool activate,
-            TimeSpan? timeout = null,
-            CancellationToken cancellationToken = default
-        )
-        {
-            client.EnsureConnected();
+    /// <summary>
+    /// Starts or stops streaming and waits for OBS to confirm the state change.
+    /// </summary>
+    /// <param name="activate"><see langword="true"/> to start streaming; <see langword="false"/> to stop it.</param>
+    /// <param name="timeout">Maximum time to wait for the state-change event. Defaults to 10 seconds.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>
+    /// The state reported by the event, or <see langword="null"/> if the timeout elapsed first.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
+    public async Task<OutputState?> SetStreamActiveAndWaitAsync(
+        bool activate,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        client.EnsureConnected();
 
-            Task<StreamStateChangedEventArgs> waitTask = client.WaitForEventAsync<StreamStateChangedEventArgs>(
+        Task<StreamStateChangedEventArgs> waitTask =
+            client.WaitForEventAsync<StreamStateChangedEventArgs>(
                 predicate: _ => true,
                 timeout: timeout ?? s_defaultOutputTimeout,
                 cancellationToken: cancellationToken
             );
 
-            if (activate)
-            {
-                await client.Stream.StartStreamAsync(cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                await client.Stream.StopStreamAsync(cancellationToken).ConfigureAwait(false);
-            }
-
-            try
-            {
-                StreamStateChangedEventArgs ev = await waitTask.ConfigureAwait(false);
-                return OutputStateExtensions.FromWireValue(ev.EventData.OutputState);
-            }
-            catch (TimeoutException)
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Returns whether streaming is currently active.
-        /// </summary>
-        /// <param name="cancellationToken">A token to cancel the operation.</param>
-        /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-        public async Task<bool> IsStreamActiveAsync(
-            CancellationToken cancellationToken = default
-        )
+        if (activate)
         {
-            client.EnsureConnected();
-            GetStreamStatusResponseData? status = await client
-                .Stream.GetStreamStatusAsync(cancellationToken)
-                .ConfigureAwait(false);
-            return status?.OutputActive ?? false;
+            await client.Stream.StartStreamAsync(cancellationToken).ConfigureAwait(false);
         }
+        else
+        {
+            await client.Stream.StopStreamAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        try
+        {
+            StreamStateChangedEventArgs ev = await waitTask.ConfigureAwait(false);
+            return OutputStateExtensions.FromWireValue(ev.EventData.OutputState);
+        }
+        catch (TimeoutException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Returns whether streaming is currently active.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
+    public async Task<bool> IsStreamActiveAsync(CancellationToken cancellationToken = default)
+    {
+        client.EnsureConnected();
+        GetStreamStatusResponseData? status = await client
+            .Stream.GetStreamStatusAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return status?.OutputActive ?? false;
+    }
 }

--- a/ObsWebSocket.Core/Groups/TransitionsGroup.cs
+++ b/ObsWebSocket.Core/Groups/TransitionsGroup.cs
@@ -17,7 +17,7 @@ namespace ObsWebSocket.Core;
 /// <summary>
 /// Conveniences for the <c>Transitions</c> category, alongside its generated requests.
 /// </summary>
-public readonly partial struct TransitionsRequestGroup
+public readonly partial struct TransitionsGroup
 {
     /// <summary>
     /// Gets the settings for the current scene transition as a strongly-typed object.

--- a/ObsWebSocket.Core/Groups/TransitionsGroup.cs
+++ b/ObsWebSocket.Core/Groups/TransitionsGroup.cs
@@ -1,11 +1,11 @@
-using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.Logging;
 using ObsWebSocket.Core.Events;
 using ObsWebSocket.Core.Events.Generated;
+using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol;
 using ObsWebSocket.Core.Protocol.Common;
-using ObsWebSocket.Core.Networking;
 using ObsWebSocket.Core.Protocol.Common.FilterSettings;
 using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
@@ -28,7 +28,8 @@ public readonly partial struct TransitionsGroup
     /// <returns>The deserialized transition settings, or <see langword="null"/> if no settings are present.</returns>
     /// <exception cref="ObsWebSocketException">Thrown if OBS returns an error or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task<T?> GetCurrentSceneTransitionSettingsAsync<T>(JsonTypeInfo<T> typeInfo,
+    public async Task<T?> GetCurrentSceneTransitionSettingsAsync<T>(
+        JsonTypeInfo<T> typeInfo,
         CancellationToken cancellationToken = default
     )
         where T : class
@@ -40,7 +41,9 @@ public readonly partial struct TransitionsGroup
             .Transitions.GetCurrentSceneTransitionAsync(cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
-        return response?.TransitionSettings is not { } element ? null : JsonSerializer.Deserialize(element, typeInfo);
+        return response?.TransitionSettings is not { } element
+            ? null
+            : JsonSerializer.Deserialize(element, typeInfo);
     }
 
     /// <summary>
@@ -51,12 +54,16 @@ public readonly partial struct TransitionsGroup
     /// <returns>The deserialized transition settings, or <see langword="null"/> if no settings are present.</returns>
     /// <exception cref="ObsWebSocketException">Thrown if the type is not registered, OBS returns an error, or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public Task<T?> GetCurrentSceneTransitionSettingsAsync<T>(CancellationToken cancellationToken = default
+    public Task<T?> GetCurrentSceneTransitionSettingsAsync<T>(
+        CancellationToken cancellationToken = default
     )
         where T : class
     {
         JsonTypeInfo<T> typeInfo = ObsWebSocketClientHelpers.GetRegisteredTypeInfo<T>();
-        return client.Transitions.GetCurrentSceneTransitionSettingsAsync(typeInfo, cancellationToken);
+        return client.Transitions.GetCurrentSceneTransitionSettingsAsync(
+            typeInfo,
+            cancellationToken
+        );
     }
 
     /// <summary>
@@ -69,7 +76,8 @@ public readonly partial struct TransitionsGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if OBS returns an error or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public async Task SetCurrentSceneTransitionSettingsAsync<T>(T settings,
+    public async Task SetCurrentSceneTransitionSettingsAsync<T>(
+        T settings,
         JsonTypeInfo<T> typeInfo,
         bool? overlay = true,
         CancellationToken cancellationToken = default
@@ -82,7 +90,8 @@ public readonly partial struct TransitionsGroup
         JsonElement settingsElement = JsonSerializer.SerializeToElement(settings, typeInfo);
 
         await client
-            .Transitions.SetCurrentSceneTransitionSettingsAsync(new SetCurrentSceneTransitionSettingsRequestData(
+            .Transitions.SetCurrentSceneTransitionSettingsAsync(
+                new SetCurrentSceneTransitionSettingsRequestData(
                     transitionSettings: settingsElement,
                     overlay: overlay
                 ),
@@ -100,13 +109,19 @@ public readonly partial struct TransitionsGroup
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <exception cref="ObsWebSocketException">Thrown if the type is not registered, OBS returns an error, or serialization fails.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-    public Task SetCurrentSceneTransitionSettingsAsync<T>(T settings,
+    public Task SetCurrentSceneTransitionSettingsAsync<T>(
+        T settings,
         bool? overlay = true,
         CancellationToken cancellationToken = default
     )
         where T : class
     {
         JsonTypeInfo<T> typeInfo = ObsWebSocketClientHelpers.GetRegisteredTypeInfo<T>();
-        return client.Transitions.SetCurrentSceneTransitionSettingsAsync(settings, typeInfo, overlay, cancellationToken);
+        return client.Transitions.SetCurrentSceneTransitionSettingsAsync(
+            settings,
+            typeInfo,
+            overlay,
+            cancellationToken
+        );
     }
 }

--- a/ObsWebSocket.Core/ObsBatchBuilder.cs
+++ b/ObsWebSocket.Core/ObsBatchBuilder.cs
@@ -95,5 +95,4 @@ public sealed partial class ObsBatchBuilder
     /// Returns the accumulated items as the list <see cref="ObsWebSocketClient.CallBatchAsync"/> takes.
     /// </summary>
     public List<BatchRequestItem> Build() => [.. _items];
-
 }

--- a/ObsWebSocket.Core/ObsWebSocket.Core.csproj
+++ b/ObsWebSocket.Core/ObsWebSocket.Core.csproj
@@ -31,18 +31,35 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
   <PropertyGroup>
-    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+    <IsAotCompatible
+      Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"
+      >true</IsAotCompatible>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+    <PackageReference
+      Include="Microsoft.Extensions.DependencyInjection.Abstractions"
+      Version="10.0.11"
+    />
     <PackageReference Include="Microsoft.Extensions.Diagnostics" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.11" />
+    <PackageReference
+      Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions"
+      Version="10.0.11"
+    />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-    <PackageReference Include="MessagePack" Version="3.1.8" ExcludeAssets="build;buildTransitive;analyzers" />
-    <PackageReference Include="MessagePackAnalyzer" Version="3.1.8" IncludeAssets="none" PrivateAssets="all" />
+    <PackageReference
+      Include="MessagePack"
+      Version="3.1.8"
+      ExcludeAssets="build;buildTransitive;analyzers"
+    />
+    <PackageReference
+      Include="MessagePackAnalyzer"
+      Version="3.1.8"
+      IncludeAssets="none"
+      PrivateAssets="all"
+    />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Resilience" Version="10.9.0" />
     <PackageReference Include="MinVer" Version="7.0.0">
@@ -61,23 +78,60 @@
     <ObsCodegenOutputPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)Generated'))</ObsCodegenOutputPath>
     <ObsCodegenKeyFile>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)Generated\Serialization\ObsWebSocketJsonContext.g.cs'))</ObsCodegenKeyFile>
   </PropertyGroup>
-  <UsingTask TaskName="ObsWebSocket.Codegen.Tasks.GenerateObsWebSocketSourcesTask" AssemblyFile="$(ObsCodegenTaskAssembly)" />
-  <Target Name="BuildObsCodegenTask" Condition="'$(DesignTimeBuild)' != 'true' and ('$(Rebuild)' == 'true' or '$(ObsCodegenForceRegeneration)' == 'true' or !Exists('$(ObsCodegenKeyFile)'))">
+  <UsingTask
+    TaskName="ObsWebSocket.Codegen.Tasks.GenerateObsWebSocketSourcesTask"
+    AssemblyFile="$(ObsCodegenTaskAssembly)"
+  />
+  <Target
+    Name="BuildObsCodegenTask"
+    Condition="'$(DesignTimeBuild)' != 'true' and ('$(Rebuild)' == 'true' or '$(ObsCodegenForceRegeneration)' == 'true' or !Exists('$(ObsCodegenKeyFile)'))"
+  >
     <Message Text="Building codegen task project $(ObsCodegenTaskProject)..." Importance="high" />
-    <Exec Command="dotnet build &quot;$(ObsCodegenTaskProject)&quot; -c $(Configuration) --nologo" WorkingDirectory="$(MSBuildProjectDirectory)" />
+    <Exec
+      Command="dotnet build &quot;$(ObsCodegenTaskProject)&quot; -c $(Configuration) --nologo"
+      WorkingDirectory="$(MSBuildProjectDirectory)"
+    />
   </Target>
-  <Target Name="SetObsCodegenForceRegeneration" BeforeTargets="Rebuild" Condition="'$(DesignTimeBuild)' != 'true'">
+  <Target
+    Name="SetObsCodegenForceRegeneration"
+    BeforeTargets="Rebuild"
+    Condition="'$(DesignTimeBuild)' != 'true'"
+  >
     <PropertyGroup>
       <ObsCodegenForceRegeneration>true</ObsCodegenForceRegeneration>
     </PropertyGroup>
   </Target>
-  <Target Name="GenerateObsWebSocketSourcesCrossTargeting" BeforeTargets="DispatchToInnerBuilds" DependsOnTargets="BuildObsCodegenTask" Condition="'$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' == 'true' and ('$(Rebuild)' == 'true' or '$(ObsCodegenForceRegeneration)' == 'true' or !Exists('$(ObsCodegenKeyFile)'))">
-    <Message Text="Generating ObsWebSocket.Core sources using $(ObsCodegenTaskAssembly)..." Importance="high" />
-    <GenerateObsWebSocketSourcesTask ProtocolPath="$(ObsCodegenProtocolPath)" OutputDirectory="$(ObsCodegenOutputPath)" DownloadIfMissing="true" />
+  <Target
+    Name="GenerateObsWebSocketSourcesCrossTargeting"
+    BeforeTargets="DispatchToInnerBuilds"
+    DependsOnTargets="BuildObsCodegenTask"
+    Condition="'$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' == 'true' and ('$(Rebuild)' == 'true' or '$(ObsCodegenForceRegeneration)' == 'true' or !Exists('$(ObsCodegenKeyFile)'))"
+  >
+    <Message
+      Text="Generating ObsWebSocket.Core sources using $(ObsCodegenTaskAssembly)..."
+      Importance="high"
+    />
+    <GenerateObsWebSocketSourcesTask
+      ProtocolPath="$(ObsCodegenProtocolPath)"
+      OutputDirectory="$(ObsCodegenOutputPath)"
+      DownloadIfMissing="true"
+    />
   </Target>
-  <Target Name="GenerateObsWebSocketSourcesSingleTarget" BeforeTargets="CoreCompile" DependsOnTargets="BuildObsCodegenTask" Condition="'$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' != 'true' and ('$(Rebuild)' == 'true' or '$(ObsCodegenForceRegeneration)' == 'true' or !Exists('$(ObsCodegenKeyFile)'))">
-    <Message Text="Generating ObsWebSocket.Core sources using $(ObsCodegenTaskAssembly)..." Importance="high" />
-    <GenerateObsWebSocketSourcesTask ProtocolPath="$(ObsCodegenProtocolPath)" OutputDirectory="$(ObsCodegenOutputPath)" DownloadIfMissing="true" />
+  <Target
+    Name="GenerateObsWebSocketSourcesSingleTarget"
+    BeforeTargets="CoreCompile"
+    DependsOnTargets="BuildObsCodegenTask"
+    Condition="'$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' != 'true' and ('$(Rebuild)' == 'true' or '$(ObsCodegenForceRegeneration)' == 'true' or !Exists('$(ObsCodegenKeyFile)'))"
+  >
+    <Message
+      Text="Generating ObsWebSocket.Core sources using $(ObsCodegenTaskAssembly)..."
+      Importance="high"
+    />
+    <GenerateObsWebSocketSourcesTask
+      ProtocolPath="$(ObsCodegenProtocolPath)"
+      OutputDirectory="$(ObsCodegenOutputPath)"
+      DownloadIfMissing="true"
+    />
   </Target>
   <ItemGroup>
     <None Include="..\LICENSE.txt" Pack="true" PackagePath="" />

--- a/ObsWebSocket.Core/ObsWebSocketClient.Helper.Convenience.cs
+++ b/ObsWebSocket.Core/ObsWebSocketClient.Helper.Convenience.cs
@@ -1,66 +1,17 @@
 using ObsWebSocket.Core.Events;
-using ObsWebSocket.Core.Events.Generated;
-using ObsWebSocket.Core.Protocol.Generated;
 using ObsWebSocket.Core.Protocol;
-using ObsWebSocket.Core.Protocol.Requests;
-using ObsWebSocket.Core.Protocol.Responses;
+using ObsWebSocket.Core.Protocol.Generated;
 
 namespace ObsWebSocket.Core;
 
 /// <summary>
-/// Output control, existence checks, volume, media transport, and event-wait conveniences.
+/// The client level conveniences: waiting for an event, and sending a batch. Neither belongs to
+/// one protocol category, so both stay on the client rather than on a category group.
 /// </summary>
-public static class ObsWebSocketClientConvenienceExtensions
+public static partial class ObsWebSocketClientHelpers
 {
-    private static readonly TimeSpan s_defaultOutputTimeout = TimeSpan.FromSeconds(10);
-
     extension(ObsWebSocketClient client)
     {
-
-        // ────────────────────────────────────────────────────────────────────────
-        // Output control
-        // ────────────────────────────────────────────────────────────────────────
-
-
-
-
-
-
-
-
-
-        // ────────────────────────────────────────────────────────────────────────
-        // Existence checks
-        // ────────────────────────────────────────────────────────────────────────
-
-
-
-        // ────────────────────────────────────────────────────────────────────────
-        // Volume
-        // ────────────────────────────────────────────────────────────────────────
-
-
-
-
-
-        // ────────────────────────────────────────────────────────────────────────
-        // Media transport
-        // ────────────────────────────────────────────────────────────────────────
-
-
-
-
-
-
-
-
-
-
-
-        // ────────────────────────────────────────────────────────────────────────
-        // WaitForEventAsync overloads
-        // ────────────────────────────────────────────────────────────────────────
-
         /// <summary>
         /// Waits for the next occurrence of a typed OBS event, with no timeout. The wait ends only
         /// when the event arrives or <paramref name="cancellationToken"/> fires.
@@ -85,7 +36,7 @@ public static class ObsWebSocketClientConvenienceExtensions
         /// <param name="timeout">How long to wait before giving up.</param>
         /// <param name="cancellationToken">A token to cancel the wait.</param>
         /// <returns>The event args.</returns>
-        /// <exception cref="TimeoutException">Thrown if the timeout elapses first.</exception>
+        /// <exception cref="ObsWebSocketTimeoutException">Thrown if the timeout elapses first.</exception>
         public Task<TEventArgs> WaitForEventAsync<TEventArgs>(
             TimeSpan timeout,
             CancellationToken cancellationToken = default
@@ -107,10 +58,6 @@ public static class ObsWebSocketClientConvenienceExtensions
             where TEventArgs : ObsEventArgs =>
             client.WaitForEventAsync(predicate, Timeout.InfiniteTimeSpan, cancellationToken);
 
-        // ────────────────────────────────────────────────────────────────────────
-        // Typed batch execution
-        // ────────────────────────────────────────────────────────────────────────
-
         /// <summary>
         /// Sends a batch built with <see cref="ObsBatchBuilder"/>, returning results addressable
         /// by the references the builder handed out.
@@ -121,6 +68,7 @@ public static class ObsWebSocketClientConvenienceExtensions
         /// <param name="timeoutMs">Optional override for the request timeout.</param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>The results, addressable by reference or by position.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
         public async Task<BatchResults> CallBatchAsync(
             ObsBatchBuilder batch,
             RequestBatchExecutionType? executionType = null,
@@ -149,17 +97,17 @@ public static class ObsWebSocketClientConvenienceExtensions
         }
 
         /// <summary>
-        /// Builds and sends a batch using the typed builder, so each request type is paired with
-        /// its own data record instead of a loose string and object.
+        /// Builds and sends a batch in one call, for the common case where the references are
+        /// captured in the same scope they are read in.
         /// </summary>
         /// <param name="build">Adds the requests to send.</param>
         /// <param name="executionType">How OBS should schedule the requests.</param>
         /// <param name="haltOnFailure">Whether OBS should stop at the first failing request.</param>
         /// <param name="timeoutMs">Optional override for the request timeout.</param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
-        /// <returns>One result per request, in order.</returns>
+        /// <returns>The results, addressable by reference or by position.</returns>
         /// <exception cref="InvalidOperationException">Thrown if the client is not connected.</exception>
-        public Task<List<RequestResponsePayload<object>>> CallBatchAsync(
+        public Task<BatchResults> CallBatchAsync(
             Action<ObsBatchBuilder> build,
             RequestBatchExecutionType? executionType = null,
             bool? haltOnFailure = null,
@@ -172,24 +120,12 @@ public static class ObsWebSocketClientConvenienceExtensions
             ObsBatchBuilder builder = new();
             build(builder);
             return client.CallBatchAsync(
-                builder.Build(),
+                builder,
                 executionType,
                 haltOnFailure,
                 timeoutMs,
                 cancellationToken
             );
         }
-
-        // Scene item ids are Number on the wire, so the generated surface uses double.
-
-
-
-
-
-
-
-
-
-
     }
 }

--- a/ObsWebSocket.Core/ObsWebSocketClient.Helper.cs
+++ b/ObsWebSocket.Core/ObsWebSocketClient.Helper.cs
@@ -1,36 +1,37 @@
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
-using Microsoft.Extensions.Logging;
-using ObsWebSocket.Core.Events;
-using ObsWebSocket.Core.Events.Generated;
-using ObsWebSocket.Core.Protocol;
-using ObsWebSocket.Core.Protocol.Common.InputSettings;
-using ObsWebSocket.Core.Protocol.Generated; // Assuming generated enums are here
-using ObsWebSocket.Core.Protocol.Requests;
-using ObsWebSocket.Core.Protocol.Responses;
+using ObsWebSocket.Core.Serialization;
 
-namespace ObsWebSocket.Core; // Or ObsWebSocket.Core.Extensions
+namespace ObsWebSocket.Core;
 
 /// <summary>
-/// Provides helpful extension methods for common OBS WebSocket tasks.
+/// Client level extensions that do not belong to one protocol category, alongside the generated
+/// <c>WaitForEventAsync</c>. Everything category scoped lives on the category group instead, so
+/// <c>client.Scenes</c>, <c>client.Inputs</c> and the rest are where those methods are found.
 /// </summary>
 public static partial class ObsWebSocketClientHelpers
 {
     private static readonly JsonSerializerOptions s_helperJsonOptions = CreateHelperOptions();
 
-    private static JsonSerializerOptions CreateHelperOptions()
-    {
-        JsonSerializerOptions options = new(ObsWebSocket.Core.Serialization.ObsWebSocketJsonContext.Default.Options)
+    private static JsonSerializerOptions CreateHelperOptions() =>
+        new(ObsWebSocketJsonContext.Default.Options)
         {
-            TypeInfoResolver = System.Text.Json.Serialization.Metadata.JsonTypeInfoResolver.Combine(
-                ObsWebSocket.Core.Serialization.ObsWebSocketJsonContext.Default,
-                ObsWebSocket.Core.Serialization.ObsWebSocketSettingsJsonContext.Default
+            TypeInfoResolver = JsonTypeInfoResolver.Combine(
+                ObsWebSocketJsonContext.Default,
+                ObsWebSocketSettingsJsonContext.Default
             ),
         };
-        return options;
-    }
 
-    internal static JsonTypeInfo<T> GetRegisteredTypeInfo<T>() where T : class
+    /// <summary>
+    /// Resolves the source generated metadata for a settings type the library knows about.
+    /// </summary>
+    /// <typeparam name="T">The settings type to resolve.</typeparam>
+    /// <exception cref="ObsWebSocketException">
+    /// Thrown when the type is not registered in either generated context, since serializing it
+    /// would otherwise fall back to reflection and break under trimming.
+    /// </exception>
+    internal static JsonTypeInfo<T> GetRegisteredTypeInfo<T>()
+        where T : class
     {
         JsonTypeInfo<T>? typeInfo;
         try
@@ -39,139 +40,13 @@ public static partial class ObsWebSocketClientHelpers
         }
         catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException)
         {
-            throw new ObsWebSocketException(
-                $"Type '{typeof(T).Name}' is not registered in ObsWebSocketJsonContext. Pass an explicit JsonTypeInfo<T> or use a library-registered settings type.",
-                ex
-            );
+            throw new ObsWebSocketException(NotRegistered<T>(), ex);
         }
-        return typeInfo ?? throw new ObsWebSocketException(
-            $"Type '{typeof(T).Name}' is not registered in ObsWebSocketJsonContext. Pass an explicit JsonTypeInfo<T> or use a library-registered settings type."
-        );
+
+        return typeInfo ?? throw new ObsWebSocketException(NotRegistered<T>());
     }
 
-
-
-
-
-
-
-
-
-    // Helper #4 (SwitchSceneAndWaitAsync) - Deferred due to complexity without reflection
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    // ────────────────────────────────────────────────────────────────────────
-    // Generic input settings helpers
-    // ────────────────────────────────────────────────────────────────────────
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    // -------------------------------------------------------------------------
-    // Transition Settings helpers
-    // -------------------------------------------------------------------------
-
-
-
-
-
-
-
-
-
-    // -------------------------------------------------------------------------
-    // Output Settings helpers
-    // -------------------------------------------------------------------------
-
-
-
-
-
-
-
-
-
-    // -------------------------------------------------------------------------
-    // Stream Service Settings helpers
-    // -------------------------------------------------------------------------
-
-
-
-
-
-
-
-
-
-    // -------------------------------------------------------------------------
-    // Default Settings helpers (read-only)
-    // -------------------------------------------------------------------------
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    // Helper #14 (WaitForEventAsync<TEventArgs>) - Deferred due to complexity/reflection constraints.
-
-    // ────────────────────────────────────────────────────────────────────────
-    // Virtualcam helpers
-    // ────────────────────────────────────────────────────────────────────────
-
-
-
-
-
-    // ────────────────────────────────────────────────────────────────────────
-    // Canvas-aware screenshot helpers
-    // ────────────────────────────────────────────────────────────────────────
-
-
-
-
-
-
+    private static string NotRegistered<T>() =>
+        $"Type '{typeof(T).Name}' is not registered in ObsWebSocketJsonContext. "
+        + "Pass an explicit JsonTypeInfo<T> or use a library-registered settings type.";
 }
-
-

--- a/ObsWebSocket.Core/ObsWebSocketClient.cs
+++ b/ObsWebSocket.Core/ObsWebSocketClient.cs
@@ -113,8 +113,12 @@ public sealed partial class ObsWebSocketClient(
         TaskCreationOptions.RunContinuationsAsynchronously
     );
 
-    private static readonly JsonSerializerOptions s_payloadJsonOptions =
-        ObsWebSocket.Core.Serialization.ObsWebSocketJsonContext.Default.Options;
+    private static readonly JsonSerializerOptions s_payloadJsonOptions = ObsWebSocket
+        .Core
+        .Serialization
+        .ObsWebSocketJsonContext
+        .Default
+        .Options;
     #endregion
 
     #region Properties
@@ -208,7 +212,10 @@ public sealed partial class ObsWebSocketClient(
                 options.Value.HandshakeTimeoutMs * 2,
                 DefaultRequestTimeoutMs
             ); // Be generous
-            linkedTimeoutCts.CancelAfterUsing(_timeProvider, TimeSpan.FromMilliseconds(overallTimeout));
+            linkedTimeoutCts.CancelAfterUsing(
+                _timeProvider,
+                TimeSpan.FromMilliseconds(overallTimeout)
+            );
 
             await currentInitialConnectionTcs
                 .Task.WaitAsync(linkedTimeoutCts.Token)
@@ -640,7 +647,11 @@ public sealed partial class ObsWebSocketClient(
                     (baseTimeout * DefaultBatchTimeoutMultiplier)
                     + (baseTimeout * requestPayloads.Count / 2)
                 );
-            _logger.LogWaitingForBatchResponseTimeoutMs(batchRequestId, requestPayloads.Count, effectiveTimeout);
+            _logger.LogWaitingForBatchResponseTimeoutMs(
+                batchRequestId,
+                requestPayloads.Count,
+                effectiveTimeout
+            );
 
             object responseObj = await WaitForResponseAsync(
                     tcs,
@@ -825,7 +836,11 @@ public sealed partial class ObsWebSocketClient(
                         TimeSpan backoff = await _reconnectDelays
                             .GetDelayAsync(attempt - 2, loopToken)
                             .ConfigureAwait(false);
-                        _logger.LogReconnectingAttemptAfterMs(attempt, maxAttempts < 0 ? "Infinite" : maxAttempts.ToString(), (int)backoff.TotalMilliseconds);
+                        _logger.LogReconnectingAttemptAfterMs(
+                            attempt,
+                            maxAttempts < 0 ? "Infinite" : maxAttempts.ToString(),
+                            (int)backoff.TotalMilliseconds
+                        );
                         _metrics.Reconnects.Add(1);
                         await Task.Delay(backoff, _timeProvider, loopToken).ConfigureAwait(false);
                     }
@@ -894,7 +909,10 @@ public sealed partial class ObsWebSocketClient(
                 }
                 catch (ConnectionAttemptFailedException connEx)
                 {
-                    _logger.LogConnectAttemptFailedRetrying(connEx.InnerException ?? connEx, attempt);
+                    _logger.LogConnectAttemptFailedRetrying(
+                        connEx.InnerException ?? connEx,
+                        attempt
+                    );
                     attemptException = connEx;
                     RaiseConnectionFailedEvent(options.ServerUri!, attempt, connEx);
                     // Only fail initial TCS if retries are disabled or exhausted on the *first* attempt
@@ -908,7 +926,10 @@ public sealed partial class ObsWebSocketClient(
                 }
                 catch (WebSocketException wsEx)
                 {
-                    _logger.LogWebsocketexceptionDuringConnectionReceiveAttemptRetrying(wsEx, attempt);
+                    _logger.LogWebsocketexceptionDuringConnectionReceiveAttemptRetrying(
+                        wsEx,
+                        attempt
+                    );
                     attemptException = wsEx;
                     RaiseConnectionFailedEvent(options.ServerUri!, attempt, wsEx);
                     if (
@@ -968,7 +989,9 @@ public sealed partial class ObsWebSocketClient(
 
                         if (isConnectedThisAttempt && attemptException != null)
                         {
-                            _logger.LogConnectionLostDuringConnectedStateDueTo(attemptException.GetType().Name);
+                            _logger.LogConnectionLostDuringConnectedStateDueTo(
+                                attemptException.GetType().Name
+                            );
                         }
                     }
                 }
@@ -1028,7 +1051,10 @@ public sealed partial class ObsWebSocketClient(
                 }
                 catch (ArgumentException ex)
                 {
-                    _logger.LogAttemptedDuplicateSubprotocolAdd(ex, _serializer.ProtocolSubProtocol);
+                    _logger.LogAttemptedDuplicateSubprotocolAdd(
+                        ex,
+                        _serializer.ProtocolSubProtocol
+                    );
                 }
             }
 
@@ -1056,7 +1082,10 @@ public sealed partial class ObsWebSocketClient(
                 );
             }
 
-            _logger.LogAttemptWebsocketConnectionEstablishedProtocol(attempt, ws.SubProtocol ?? "(None)");
+            _logger.LogAttemptWebsocketConnectionEstablishedProtocol(
+                attempt,
+                ws.SubProtocol ?? "(None)"
+            );
 
             // --- Start Receive Loop *before* Handshake ---
             localReceiveCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -1100,11 +1129,16 @@ public sealed partial class ObsWebSocketClient(
                 );
             }
 
-            EventSubscription requestedEventSubs = options.EventSubscriptions ?? EventSubscription.All;
+            EventSubscription requestedEventSubs =
+                options.EventSubscriptions ?? EventSubscription.All;
 
             await SendMessageAsync(
                     WebSocketOpCode.Identify,
-                    new IdentifyPayload(helloPayload.RpcVersion, authResponse, (uint)requestedEventSubs),
+                    new IdentifyPayload(
+                        helloPayload.RpcVersion,
+                        authResponse,
+                        (uint)requestedEventSubs
+                    ),
                     ct
                 )
                 .ConfigureAwait(false);
@@ -1123,7 +1157,10 @@ public sealed partial class ObsWebSocketClient(
                 "Identified"
             );
 
-            _logger.LogAttemptReceivedIdentifiedNegotiatedRpcVersion(attempt, identifiedPayload.NegotiatedRpcVersion);
+            _logger.LogAttemptReceivedIdentifiedNegotiatedRpcVersion(
+                attempt,
+                identifiedPayload.NegotiatedRpcVersion
+            );
 
             NegotiatedRpcVersion = identifiedPayload.NegotiatedRpcVersion;
             CurrentEventSubscriptions = requestedEventSubs; //
@@ -1206,7 +1243,9 @@ public sealed partial class ObsWebSocketClient(
                 );
             }
 
-            _logger.LogReceiveLoopStartingForWebsocket(RuntimeHelpers.GetHashCode(currentWebSocket));
+            _logger.LogReceiveLoopStartingForWebsocket(
+                RuntimeHelpers.GetHashCode(currentWebSocket)
+            );
 
             while (!cancellationToken.IsCancellationRequested)
             {
@@ -1279,7 +1318,9 @@ public sealed partial class ObsWebSocketClient(
         finally
         {
             ArrayPool<byte>.Shared.Return(buffer);
-            _logger.LogReceiveLoopFinishedForWebsocket(RuntimeHelpers.GetHashCode(currentWebSocket));
+            _logger.LogReceiveLoopFinishedForWebsocket(
+                RuntimeHelpers.GetHashCode(currentWebSocket)
+            );
         }
     }
 
@@ -1331,7 +1372,10 @@ public sealed partial class ObsWebSocketClient(
     /// <summary> Cleans up current connection resources and fails pending tasks. </summary>
     private void CleanupConnectionOnly(Exception reasonException)
     {
-        _logger.LogCleanupconnectiononlyDueTo(reasonException.GetType().Name, reasonException.Message);
+        _logger.LogCleanupconnectiononlyDueTo(
+            reasonException.GetType().Name,
+            reasonException.Message
+        );
         IsConnected = false;
 
         NegotiatedRpcVersion = null;
@@ -1467,7 +1511,9 @@ public sealed partial class ObsWebSocketClient(
                 (opCode, payloadData) = (msgpackMsg.Op, msgpackMsg.D);
                 break;
             default:
-                _logger.LogUnexpectedIncomingMessageTypeEncountered(messageObject.GetType().FullName);
+                _logger.LogUnexpectedIncomingMessageTypeEncountered(
+                    messageObject.GetType().FullName
+                );
                 return;
         }
 
@@ -1515,7 +1561,10 @@ public sealed partial class ObsWebSocketClient(
                 return;
             }
 
-            _logger.LogProcessingRequestresponseForRequestidStatus(response.RequestId, response.RequestStatus.Result);
+            _logger.LogProcessingRequestresponseForRequestidStatus(
+                response.RequestId,
+                response.RequestStatus.Result
+            );
             if (
                 _pendingRequests.TryRemove(
                     response.RequestId,
@@ -1532,7 +1581,10 @@ public sealed partial class ObsWebSocketClient(
         }
         catch (Exception ex)
         {
-            _logger.LogExceptionDuringProcessingOfRequestresponsePayload(ex, payloadData?.ToString());
+            _logger.LogExceptionDuringProcessingOfRequestresponsePayload(
+                ex,
+                payloadData?.ToString()
+            );
         }
     }
 
@@ -1555,7 +1607,10 @@ public sealed partial class ObsWebSocketClient(
                 return;
             }
 
-            _logger.LogProcessingRequestbatchresponseForRequestidResults(response.RequestId, response.Results?.Count ?? 0);
+            _logger.LogProcessingRequestbatchresponseForRequestidResults(
+                response.RequestId,
+                response.Results?.Count ?? 0
+            );
             if (
                 _pendingBatchRequests.TryRemove(
                     response.RequestId,
@@ -1572,7 +1627,10 @@ public sealed partial class ObsWebSocketClient(
         }
         catch (Exception ex)
         {
-            _logger.LogExceptionDuringProcessingOfRequestbatchresponsePayload(ex, payloadData?.ToString());
+            _logger.LogExceptionDuringProcessingOfRequestbatchresponsePayload(
+                ex,
+                payloadData?.ToString()
+            );
         }
     }
 
@@ -1610,7 +1668,10 @@ public sealed partial class ObsWebSocketClient(
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogExceptionOccurredWithinTheEventHandlerFor(ex, eventPayloadBase.EventType);
+                    _logger.LogExceptionOccurredWithinTheEventHandlerFor(
+                        ex,
+                        eventPayloadBase.EventType
+                    );
                 }
             }
             else
@@ -1620,7 +1681,11 @@ public sealed partial class ObsWebSocketClient(
         }
         catch (Exception ex)
         {
-            _logger.LogCriticalExceptionDuringEventHandlingFor(ex, eventPayloadBase?.EventType ?? "Unknown Type", payloadData?.ToString());
+            _logger.LogCriticalExceptionDuringEventHandlingFor(
+                ex,
+                eventPayloadBase?.EventType ?? "Unknown Type",
+                payloadData?.ToString()
+            );
         }
     }
 
@@ -1669,10 +1734,7 @@ public sealed partial class ObsWebSocketClient(
             TPayload? payload = _serializer.DeserializePayload<TPayload>(rawData);
             if (payload is not null)
             {
-                _metrics.EventsReceived.Add(
-                    1,
-                    new TagList { { "obsws.event_type", eventType } }
-                );
+                _metrics.EventsReceived.Add(1, new TagList { { "obsws.event_type", eventType } });
                 invoker(argsFactory(payload));
             }
             else

--- a/ObsWebSocket.Core/ObsWebSocketClientBuilder.cs
+++ b/ObsWebSocket.Core/ObsWebSocketClientBuilder.cs
@@ -1,0 +1,148 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace ObsWebSocket.Core;
+
+/// <summary>
+/// The client returned by <c>AddObsWebSocketClient</c>, so the things that apply to one client are
+/// chained off the call that registered it rather than applied to the whole container.
+/// </summary>
+/// <remarks>
+/// This is what lets an application drive two OBS instances and give each its own behaviour, which
+/// a bare <see cref="IServiceCollection"/> extension cannot express because it has no way to know
+/// which client is meant.
+/// </remarks>
+public interface IObsWebSocketClientBuilder
+{
+    /// <summary>The collection the client was registered in.</summary>
+    IServiceCollection Services { get; }
+
+    /// <summary>
+    /// The key this client is registered under, or <see langword="null"/> for the unnamed client.
+    /// </summary>
+    string? Name { get; }
+}
+
+/// <param name="services">The collection the client was registered in.</param>
+/// <param name="name">The key the client is registered under, or null for the unnamed client.</param>
+internal sealed class ObsWebSocketClientBuilder(IServiceCollection services, string? name)
+    : IObsWebSocketClientBuilder
+{
+    /// <inheritdoc/>
+    public IServiceCollection Services { get; } = services;
+
+    /// <inheritdoc/>
+    public string? Name { get; } = name;
+}
+
+/// <summary>
+/// The per-client options, chained off the registration.
+/// </summary>
+public static class ObsWebSocketClientBuilderExtensions
+{
+    /// <summary>
+    /// Connects when the host starts and disconnects when it stops, so an application does not
+    /// need its own background service for the connection.
+    /// </summary>
+    /// <remarks>
+    /// A connection that cannot be established at startup is logged rather than thrown, because
+    /// OBS is often started after the application; reconnect takes over from there.
+    /// </remarks>
+    /// <param name="builder">The client to connect automatically.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    public static IObsWebSocketClientBuilder WithAutoConnect(
+        this IObsWebSocketClientBuilder builder
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        string? name = builder.Name;
+        _ = builder.Services.AddHostedService(sp => new ObsWebSocketConnectionService(
+            name is null
+                ? sp.GetRequiredService<ObsWebSocketClient>()
+                : sp.GetRequiredKeyedService<ObsWebSocketClient>(name),
+            sp.GetRequiredService<IOptionsMonitor<ObsWebSocketClientOptions>>(),
+            sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<ObsWebSocketConnectionService>>(),
+            name
+        ));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a health check reporting whether this client is connected.
+    /// </summary>
+    /// <param name="builder">The client to report on.</param>
+    /// <param name="name">
+    /// The name to register the check under. Defaults to <c>obs-websocket</c> for the unnamed
+    /// client, and <c>obs-websocket-{key}</c> for a named one, so two clients do not collide.
+    /// </param>
+    /// <param name="failureStatus">Status to report when not connected.</param>
+    /// <param name="tags">Tags for filtering checks.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    public static IObsWebSocketClientBuilder WithHealthCheck(
+        this IObsWebSocketClientBuilder builder,
+        string? name = null,
+        HealthStatus? failureStatus = null,
+        IEnumerable<string>? tags = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        string? key = builder.Name;
+        string checkName = name ?? (key is null ? "obs-websocket" : $"obs-websocket-{key}");
+
+        _ = builder
+            .Services.AddHealthChecks()
+            .Add(
+                new HealthCheckRegistration(
+                    checkName,
+                    sp => new ObsWebSocketHealthCheck(
+                        key is null
+                            ? sp.GetRequiredService<ObsWebSocketClient>()
+                            : sp.GetRequiredKeyedService<ObsWebSocketClient>(key)
+                    ),
+                    failureStatus,
+                    tags
+                )
+            );
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers the reconnect pipeline for this client.
+    /// </summary>
+    /// <param name="builder">The client to configure.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    public static IObsWebSocketClientBuilder WithReconnectPipeline(
+        this IObsWebSocketClientBuilder builder
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        _ = builder.Services.AddObsWebSocketReconnectPipeline();
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures this client's options.
+    /// </summary>
+    /// <param name="builder">The client to configure.</param>
+    /// <param name="configure">Applied to this client's options.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    public static IObsWebSocketClientBuilder Configure(
+        this IObsWebSocketClientBuilder builder,
+        Action<ObsWebSocketClientOptions> configure
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        _ = builder
+            .Services.AddOptions<ObsWebSocketClientOptions>(builder.Name ?? Options.DefaultName)
+            .Configure(configure);
+
+        return builder;
+    }
+}

--- a/ObsWebSocket.Core/ObsWebSocketClientLog.cs
+++ b/ObsWebSocket.Core/ObsWebSocketClientLog.cs
@@ -9,202 +9,909 @@ namespace ObsWebSocket.Core;
 /// <summary>Source-generated log messages.</summary>
 internal static partial class ObsWebSocketClientLog
 {
-    [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "Starting connection sequence for {Uri}...")]
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Information,
+        Message = "Starting connection sequence for {Uri}..."
+    )]
     public static partial void LogStartingConnectionSequenceFor(this ILogger logger, Uri? uri);
-    [LoggerMessage(EventId = 2, Level = LogLevel.Information, Message = "ConnectAsync initial connection confirmed successfully.")]
-    public static partial void LogConnectasyncInitialConnectionConfirmedSuccessfully(this ILogger logger);
-    [LoggerMessage(EventId = 3, Level = LogLevel.Error, Message = "ConnectAsync failed to establish initial connection.")]
-    public static partial void LogConnectasyncFailedToEstablishInitialConnection(this ILogger logger, Exception exception);
-    [LoggerMessage(EventId = 4, Level = LogLevel.Debug, Message = "Waiting for Identified after Reidentify (Timeout: {TimeoutMs}ms)...")]
-    public static partial void LogWaitingForIdentifiedAfterReidentifyTimeoutMs(this ILogger logger, int timeoutMs);
-    [LoggerMessage(EventId = 5, Level = LogLevel.Information, Message = "Re-identification successful. RPC Version: {RpcVersion}")]
-    public static partial void LogReIdentificationSuccessfulRpcVersion(this ILogger logger, int rpcVersion);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Information,
+        Message = "ConnectAsync initial connection confirmed successfully."
+    )]
+    public static partial void LogConnectasyncInitialConnectionConfirmedSuccessfully(
+        this ILogger logger
+    );
+
+    [LoggerMessage(
+        EventId = 3,
+        Level = LogLevel.Error,
+        Message = "ConnectAsync failed to establish initial connection."
+    )]
+    public static partial void LogConnectasyncFailedToEstablishInitialConnection(
+        this ILogger logger,
+        Exception exception
+    );
+
+    [LoggerMessage(
+        EventId = 4,
+        Level = LogLevel.Debug,
+        Message = "Waiting for Identified after Reidentify (Timeout: {TimeoutMs}ms)..."
+    )]
+    public static partial void LogWaitingForIdentifiedAfterReidentifyTimeoutMs(
+        this ILogger logger,
+        int timeoutMs
+    );
+
+    [LoggerMessage(
+        EventId = 5,
+        Level = LogLevel.Information,
+        Message = "Re-identification successful. RPC Version: {RpcVersion}"
+    )]
+    public static partial void LogReIdentificationSuccessfulRpcVersion(
+        this ILogger logger,
+        int rpcVersion
+    );
+
     [LoggerMessage(EventId = 6, Level = LogLevel.Error, Message = "ReidentifyAsync failed.")]
     public static partial void LogReidentifyasyncFailed(this ILogger logger, Exception exception);
-    [LoggerMessage(EventId = 7, Level = LogLevel.Warning, Message = "ReidentifyAsync canceled due to client shutdown.")]
+
+    [LoggerMessage(
+        EventId = 7,
+        Level = LogLevel.Warning,
+        Message = "ReidentifyAsync canceled due to client shutdown."
+    )]
     public static partial void LogReidentifyasyncCanceledDueToClientShutdown(this ILogger logger);
-    [LoggerMessage(EventId = 8, Level = LogLevel.Debug, Message = "Waiting for Response {RequestId} ({RequestType}, Timeout: {TimeoutMs}ms)...")]
-    public static partial void LogWaitingForResponseTimeoutMs(this ILogger logger, string requestId, string requestType, int timeoutMs);
-    [LoggerMessage(EventId = 9, Level = LogLevel.Error, Message = "CallAsync failed for {RequestType} ({RequestId})")]
-    public static partial void LogCallasyncFailedFor(this ILogger logger, Exception exception, string requestType, string requestId);
-    [LoggerMessage(EventId = 10, Level = LogLevel.Warning, Message = "CallAsync for {RequestType} ({RequestId}) canceled.")]
-    public static partial void LogCallasyncForCanceled(this ILogger logger, string requestType, string requestId);
-    [LoggerMessage(EventId = 11, Level = LogLevel.Error, Message = "CallAsyncValue failed for {RequestType} ({RequestId})")]
-    public static partial void LogCallasyncvalueFailedFor(this ILogger logger, Exception exception, string requestType, string requestId);
-    [LoggerMessage(EventId = 12, Level = LogLevel.Warning, Message = "CallAsyncValue for {RequestType} ({RequestId}) canceled.")]
-    public static partial void LogCallasyncvalueForCanceled(this ILogger logger, string requestType, string requestId);
+
+    [LoggerMessage(
+        EventId = 8,
+        Level = LogLevel.Debug,
+        Message = "Waiting for Response {RequestId} ({RequestType}, Timeout: {TimeoutMs}ms)..."
+    )]
+    public static partial void LogWaitingForResponseTimeoutMs(
+        this ILogger logger,
+        string requestId,
+        string requestType,
+        int timeoutMs
+    );
+
+    [LoggerMessage(
+        EventId = 9,
+        Level = LogLevel.Error,
+        Message = "CallAsync failed for {RequestType} ({RequestId})"
+    )]
+    public static partial void LogCallasyncFailedFor(
+        this ILogger logger,
+        Exception exception,
+        string requestType,
+        string requestId
+    );
+
+    [LoggerMessage(
+        EventId = 10,
+        Level = LogLevel.Warning,
+        Message = "CallAsync for {RequestType} ({RequestId}) canceled."
+    )]
+    public static partial void LogCallasyncForCanceled(
+        this ILogger logger,
+        string requestType,
+        string requestId
+    );
+
+    [LoggerMessage(
+        EventId = 11,
+        Level = LogLevel.Error,
+        Message = "CallAsyncValue failed for {RequestType} ({RequestId})"
+    )]
+    public static partial void LogCallasyncvalueFailedFor(
+        this ILogger logger,
+        Exception exception,
+        string requestType,
+        string requestId
+    );
+
+    [LoggerMessage(
+        EventId = 12,
+        Level = LogLevel.Warning,
+        Message = "CallAsyncValue for {RequestType} ({RequestId}) canceled."
+    )]
+    public static partial void LogCallasyncvalueForCanceled(
+        this ILogger logger,
+        string requestType,
+        string requestId
+    );
+
     [LoggerMessage(EventId = 13, Level = LogLevel.Warning, Message = "Empty batch request.")]
     public static partial void LogEmptyBatchRequest(this ILogger logger);
-    [LoggerMessage(EventId = 14, Level = LogLevel.Debug, Message = "Waiting for Batch Response {BatchRequestId} ({RequestCount}, Timeout: {TimeoutMs}ms)...")]
-    public static partial void LogWaitingForBatchResponseTimeoutMs(this ILogger logger, string batchRequestId, int requestCount, int timeoutMs);
-    [LoggerMessage(EventId = 15, Level = LogLevel.Debug, Message = "Received Batch Response {BatchRequestId} ({ResultCount} results).")]
-    public static partial void LogReceivedBatchResponseResults(this ILogger logger, string batchRequestId, int resultCount);
-    [LoggerMessage(EventId = 16, Level = LogLevel.Error, Message = "CallBatchAsync failed for batch {BatchRequestId}")]
-    public static partial void LogCallbatchasyncFailedForBatch(this ILogger logger, Exception exception, string batchRequestId);
-    [LoggerMessage(EventId = 17, Level = LogLevel.Warning, Message = "CallBatchAsync for {BatchRequestId} canceled.")]
-    public static partial void LogCallbatchasyncForCanceled(this ILogger logger, string batchRequestId);
-    [LoggerMessage(EventId = 18, Level = LogLevel.Debug, Message = "DisconnectAsync ignored, already {ConnectionState}.")]
-    public static partial void LogDisconnectasyncIgnoredAlready(this ILogger logger, ConnectionState connectionState);
-    [LoggerMessage(EventId = 19, Level = LogLevel.Information, Message = "DisconnectAsync initiating graceful shutdown...")]
+
+    [LoggerMessage(
+        EventId = 14,
+        Level = LogLevel.Debug,
+        Message = "Waiting for Batch Response {BatchRequestId} ({RequestCount}, Timeout: {TimeoutMs}ms)..."
+    )]
+    public static partial void LogWaitingForBatchResponseTimeoutMs(
+        this ILogger logger,
+        string batchRequestId,
+        int requestCount,
+        int timeoutMs
+    );
+
+    [LoggerMessage(
+        EventId = 15,
+        Level = LogLevel.Debug,
+        Message = "Received Batch Response {BatchRequestId} ({ResultCount} results)."
+    )]
+    public static partial void LogReceivedBatchResponseResults(
+        this ILogger logger,
+        string batchRequestId,
+        int resultCount
+    );
+
+    [LoggerMessage(
+        EventId = 16,
+        Level = LogLevel.Error,
+        Message = "CallBatchAsync failed for batch {BatchRequestId}"
+    )]
+    public static partial void LogCallbatchasyncFailedForBatch(
+        this ILogger logger,
+        Exception exception,
+        string batchRequestId
+    );
+
+    [LoggerMessage(
+        EventId = 17,
+        Level = LogLevel.Warning,
+        Message = "CallBatchAsync for {BatchRequestId} canceled."
+    )]
+    public static partial void LogCallbatchasyncForCanceled(
+        this ILogger logger,
+        string batchRequestId
+    );
+
+    [LoggerMessage(
+        EventId = 18,
+        Level = LogLevel.Debug,
+        Message = "DisconnectAsync ignored, already {ConnectionState}."
+    )]
+    public static partial void LogDisconnectasyncIgnoredAlready(
+        this ILogger logger,
+        ConnectionState connectionState
+    );
+
+    [LoggerMessage(
+        EventId = 19,
+        Level = LogLevel.Information,
+        Message = "DisconnectAsync initiating graceful shutdown..."
+    )]
     public static partial void LogDisconnectasyncInitiatingGracefulShutdown(this ILogger logger);
-    [LoggerMessage(EventId = 20, Level = LogLevel.Debug, Message = "Waiting for connection loop task to complete during disconnect...")]
+
+    [LoggerMessage(
+        EventId = 20,
+        Level = LogLevel.Debug,
+        Message = "Waiting for connection loop task to complete during disconnect..."
+    )]
     public static partial void LogWaitingForConnectionLoopTaskToComplete(this ILogger logger);
-    [LoggerMessage(EventId = 21, Level = LogLevel.Debug, Message = "Connection loop task completed or wait timed out/canceled during DisconnectAsync.")]
+
+    [LoggerMessage(
+        EventId = 21,
+        Level = LogLevel.Debug,
+        Message = "Connection loop task completed or wait timed out/canceled during DisconnectAsync."
+    )]
     public static partial void LogConnectionLoopTaskCompletedOrWaitTimed(this ILogger logger);
-    [LoggerMessage(EventId = 22, Level = LogLevel.Warning, Message = "Wait for connection loop task timed out or canceled during DisconnectAsync.")]
+
+    [LoggerMessage(
+        EventId = 22,
+        Level = LogLevel.Warning,
+        Message = "Wait for connection loop task timed out or canceled during DisconnectAsync."
+    )]
     public static partial void LogWaitForConnectionLoopTaskTimedOut(this ILogger logger);
-    [LoggerMessage(EventId = 23, Level = LogLevel.Error, Message = "Exception from connection loop task during DisconnectAsync.")]
-    public static partial void LogExceptionFromConnectionLoopTaskDuringDisconnectasync(this ILogger logger, Exception exception);
+
+    [LoggerMessage(
+        EventId = 23,
+        Level = LogLevel.Error,
+        Message = "Exception from connection loop task during DisconnectAsync."
+    )]
+    public static partial void LogExceptionFromConnectionLoopTaskDuringDisconnectasync(
+        this ILogger logger,
+        Exception exception
+    );
+
     [LoggerMessage(EventId = 24, Level = LogLevel.Debug, Message = "DisposeAsync called.")]
     public static partial void LogDisposeasyncCalled(this ILogger logger);
+
     [LoggerMessage(EventId = 25, Level = LogLevel.Debug, Message = "DisposeAsync completed.")]
     public static partial void LogDisposeasyncCompleted(this ILogger logger);
-    [LoggerMessage(EventId = 26, Level = LogLevel.Warning, Message = "Max reconnect attempts ({MaxAttempts}) reached or auto-reconnect disabled. Stopping.")]
-    public static partial void LogMaxReconnectAttemptsReachedOrAutoReconnect(this ILogger logger, int maxAttempts);
-    [LoggerMessage(EventId = 27, Level = LogLevel.Information, Message = "Reconnecting attempt {AttemptNumber}/{MaxAttempts} after {DelayMs}ms...")]
-    public static partial void LogReconnectingAttemptAfterMs(this ILogger logger, int attemptNumber, string maxAttempts, int delayMs);
-    [LoggerMessage(EventId = 28, Level = LogLevel.Information, Message = "Connected (Attempt {AttemptNumber}), but disconnect requested. Aborting.")]
-    public static partial void LogConnectedAttemptButDisconnectRequestedAborting(this ILogger logger, int attemptNumber);
-    [LoggerMessage(EventId = 29, Level = LogLevel.Debug, Message = "[Attempt:{AttemptNumber}] Handshake complete, receive loop is running.")]
-    public static partial void LogAttemptHandshakeCompleteReceiveLoopIsRunning(this ILogger logger, int attemptNumber);
-    [LoggerMessage(EventId = 30, Level = LogLevel.Information, Message = "Successfully connected and identified (Attempt {AttemptNumber}).")]
-    public static partial void LogSuccessfullyConnectedAndIdentifiedAttempt(this ILogger logger, int attemptNumber);
-    [LoggerMessage(EventId = 31, Level = LogLevel.Debug, Message = "Connection established. Waiting for receive loop completion or cancellation...")]
-    public static partial void LogConnectionEstablishedWaitingForReceiveLoopCompletion(this ILogger logger);
-    [LoggerMessage(EventId = 32, Level = LogLevel.Debug, Message = "Receive loop task completed while connected.")]
+
+    [LoggerMessage(
+        EventId = 26,
+        Level = LogLevel.Warning,
+        Message = "Max reconnect attempts ({MaxAttempts}) reached or auto-reconnect disabled. Stopping."
+    )]
+    public static partial void LogMaxReconnectAttemptsReachedOrAutoReconnect(
+        this ILogger logger,
+        int maxAttempts
+    );
+
+    [LoggerMessage(
+        EventId = 27,
+        Level = LogLevel.Information,
+        Message = "Reconnecting attempt {AttemptNumber}/{MaxAttempts} after {DelayMs}ms..."
+    )]
+    public static partial void LogReconnectingAttemptAfterMs(
+        this ILogger logger,
+        int attemptNumber,
+        string maxAttempts,
+        int delayMs
+    );
+
+    [LoggerMessage(
+        EventId = 28,
+        Level = LogLevel.Information,
+        Message = "Connected (Attempt {AttemptNumber}), but disconnect requested. Aborting."
+    )]
+    public static partial void LogConnectedAttemptButDisconnectRequestedAborting(
+        this ILogger logger,
+        int attemptNumber
+    );
+
+    [LoggerMessage(
+        EventId = 29,
+        Level = LogLevel.Debug,
+        Message = "[Attempt:{AttemptNumber}] Handshake complete, receive loop is running."
+    )]
+    public static partial void LogAttemptHandshakeCompleteReceiveLoopIsRunning(
+        this ILogger logger,
+        int attemptNumber
+    );
+
+    [LoggerMessage(
+        EventId = 30,
+        Level = LogLevel.Information,
+        Message = "Successfully connected and identified (Attempt {AttemptNumber})."
+    )]
+    public static partial void LogSuccessfullyConnectedAndIdentifiedAttempt(
+        this ILogger logger,
+        int attemptNumber
+    );
+
+    [LoggerMessage(
+        EventId = 31,
+        Level = LogLevel.Debug,
+        Message = "Connection established. Waiting for receive loop completion or cancellation..."
+    )]
+    public static partial void LogConnectionEstablishedWaitingForReceiveLoopCompletion(
+        this ILogger logger
+    );
+
+    [LoggerMessage(
+        EventId = 32,
+        Level = LogLevel.Debug,
+        Message = "Receive loop task completed while connected."
+    )]
     public static partial void LogReceiveLoopTaskCompletedWhileConnected(this ILogger logger);
-    [LoggerMessage(EventId = 33, Level = LogLevel.Information, Message = "Connection loop canceled (Attempt {AttemptNumber}).")]
-    public static partial void LogConnectionLoopCanceledAttempt(this ILogger logger, int attemptNumber);
-    [LoggerMessage(EventId = 34, Level = LogLevel.Error, Message = "Authentication failed (Attempt {AttemptNumber}). Stopping.")]
-    public static partial void LogAuthenticationFailedAttemptStopping(this ILogger logger, Exception exception, int attemptNumber);
-    [LoggerMessage(EventId = 35, Level = LogLevel.Warning, Message = "Connect attempt {AttemptNumber} failed. Retrying...")]
-    public static partial void LogConnectAttemptFailedRetrying(this ILogger logger, Exception exception, int attemptNumber);
-    [LoggerMessage(EventId = 36, Level = LogLevel.Warning, Message = "WebSocketException during connection/receive (Attempt {AttemptNumber}). Retrying...")]
-    public static partial void LogWebsocketexceptionDuringConnectionReceiveAttemptRetrying(this ILogger logger, Exception exception, int attemptNumber);
-    [LoggerMessage(EventId = 37, Level = LogLevel.Error, Message = "Unexpected error in connection loop (Attempt {AttemptNumber}). Retrying...")]
-    public static partial void LogUnexpectedErrorInConnectionLoopAttemptRetrying(this ILogger logger, Exception exception, int attemptNumber);
-    [LoggerMessage(EventId = 38, Level = LogLevel.Warning, Message = "Connection lost during connected state due to: {ErrorType}")]
-    public static partial void LogConnectionLostDuringConnectedStateDueTo(this ILogger logger, string errorType);
-    [LoggerMessage(EventId = 39, Level = LogLevel.Critical, Message = "Catastrophic error in ConnectionLoopAsync.")]
-    public static partial void LogCatastrophicErrorInConnectionloopasync(this ILogger logger, Exception exception);
-    [LoggerMessage(EventId = 40, Level = LogLevel.Information, Message = "Exited connection loop. Finalizing state.")]
+
+    [LoggerMessage(
+        EventId = 33,
+        Level = LogLevel.Information,
+        Message = "Connection loop canceled (Attempt {AttemptNumber})."
+    )]
+    public static partial void LogConnectionLoopCanceledAttempt(
+        this ILogger logger,
+        int attemptNumber
+    );
+
+    [LoggerMessage(
+        EventId = 34,
+        Level = LogLevel.Error,
+        Message = "Authentication failed (Attempt {AttemptNumber}). Stopping."
+    )]
+    public static partial void LogAuthenticationFailedAttemptStopping(
+        this ILogger logger,
+        Exception exception,
+        int attemptNumber
+    );
+
+    [LoggerMessage(
+        EventId = 35,
+        Level = LogLevel.Warning,
+        Message = "Connect attempt {AttemptNumber} failed. Retrying..."
+    )]
+    public static partial void LogConnectAttemptFailedRetrying(
+        this ILogger logger,
+        Exception exception,
+        int attemptNumber
+    );
+
+    [LoggerMessage(
+        EventId = 36,
+        Level = LogLevel.Warning,
+        Message = "WebSocketException during connection/receive (Attempt {AttemptNumber}). Retrying..."
+    )]
+    public static partial void LogWebsocketexceptionDuringConnectionReceiveAttemptRetrying(
+        this ILogger logger,
+        Exception exception,
+        int attemptNumber
+    );
+
+    [LoggerMessage(
+        EventId = 37,
+        Level = LogLevel.Error,
+        Message = "Unexpected error in connection loop (Attempt {AttemptNumber}). Retrying..."
+    )]
+    public static partial void LogUnexpectedErrorInConnectionLoopAttemptRetrying(
+        this ILogger logger,
+        Exception exception,
+        int attemptNumber
+    );
+
+    [LoggerMessage(
+        EventId = 38,
+        Level = LogLevel.Warning,
+        Message = "Connection lost during connected state due to: {ErrorType}"
+    )]
+    public static partial void LogConnectionLostDuringConnectedStateDueTo(
+        this ILogger logger,
+        string errorType
+    );
+
+    [LoggerMessage(
+        EventId = 39,
+        Level = LogLevel.Critical,
+        Message = "Catastrophic error in ConnectionLoopAsync."
+    )]
+    public static partial void LogCatastrophicErrorInConnectionloopasync(
+        this ILogger logger,
+        Exception exception
+    );
+
+    [LoggerMessage(
+        EventId = 40,
+        Level = LogLevel.Information,
+        Message = "Exited connection loop. Finalizing state."
+    )]
     public static partial void LogExitedConnectionLoopFinalizingState(this ILogger logger);
-    [LoggerMessage(EventId = 41, Level = LogLevel.Warning, Message = "Attempted duplicate subprotocol add: {SubProtocol}")]
-    public static partial void LogAttemptedDuplicateSubprotocolAdd(this ILogger logger, Exception exception, string subProtocol);
-    [LoggerMessage(EventId = 42, Level = LogLevel.Debug, Message = "[Attempt:{AttemptNumber}] Connecting...")]
+
+    [LoggerMessage(
+        EventId = 41,
+        Level = LogLevel.Warning,
+        Message = "Attempted duplicate subprotocol add: {SubProtocol}"
+    )]
+    public static partial void LogAttemptedDuplicateSubprotocolAdd(
+        this ILogger logger,
+        Exception exception,
+        string subProtocol
+    );
+
+    [LoggerMessage(
+        EventId = 42,
+        Level = LogLevel.Debug,
+        Message = "[Attempt:{AttemptNumber}] Connecting..."
+    )]
     public static partial void LogAttemptConnecting(this ILogger logger, int attemptNumber);
-    [LoggerMessage(EventId = 43, Level = LogLevel.Information, Message = "[Attempt:{AttemptNumber}] WebSocket connection established. Protocol: {SubProtocol}")]
-    public static partial void LogAttemptWebsocketConnectionEstablishedProtocol(this ILogger logger, int attemptNumber, string subProtocol);
-    [LoggerMessage(EventId = 44, Level = LogLevel.Debug, Message = "[Attempt:{AttemptNumber}] Receive loop started for handshake.")]
-    public static partial void LogAttemptReceiveLoopStartedForHandshake(this ILogger logger, int attemptNumber);
-    [LoggerMessage(EventId = 45, Level = LogLevel.Debug, Message = "[Attempt:{AttemptNumber}] Waiting for Hello...")]
+
+    [LoggerMessage(
+        EventId = 43,
+        Level = LogLevel.Information,
+        Message = "[Attempt:{AttemptNumber}] WebSocket connection established. Protocol: {SubProtocol}"
+    )]
+    public static partial void LogAttemptWebsocketConnectionEstablishedProtocol(
+        this ILogger logger,
+        int attemptNumber,
+        string subProtocol
+    );
+
+    [LoggerMessage(
+        EventId = 44,
+        Level = LogLevel.Debug,
+        Message = "[Attempt:{AttemptNumber}] Receive loop started for handshake."
+    )]
+    public static partial void LogAttemptReceiveLoopStartedForHandshake(
+        this ILogger logger,
+        int attemptNumber
+    );
+
+    [LoggerMessage(
+        EventId = 45,
+        Level = LogLevel.Debug,
+        Message = "[Attempt:{AttemptNumber}] Waiting for Hello..."
+    )]
     public static partial void LogAttemptWaitingForHello(this ILogger logger, int attemptNumber);
-    [LoggerMessage(EventId = 46, Level = LogLevel.Debug, Message = "[Attempt:{AttemptNumber}] Received Hello. RPC Version: {RpcVersion}")]
-    public static partial void LogAttemptReceivedHelloRpcVersion(this ILogger logger, int attemptNumber, int rpcVersion);
-    [LoggerMessage(EventId = 47, Level = LogLevel.Debug, Message = "[Attempt:{AttemptNumber}] Authentication required.")]
-    public static partial void LogAttemptAuthenticationRequired(this ILogger logger, int attemptNumber);
-    [LoggerMessage(EventId = 48, Level = LogLevel.Debug, Message = "[Attempt:{AttemptNumber}] Waiting for Identified...")]
-    public static partial void LogAttemptWaitingForIdentified(this ILogger logger, int attemptNumber);
-    [LoggerMessage(EventId = 49, Level = LogLevel.Debug, Message = "[Attempt:{AttemptNumber}] Received Identified. Negotiated RPC Version: {NegotiatedRpcVersion}")]
-    public static partial void LogAttemptReceivedIdentifiedNegotiatedRpcVersion(this ILogger logger, int attemptNumber, int negotiatedRpcVersion);
-    [LoggerMessage(EventId = 50, Level = LogLevel.Debug, Message = "Receive loop starting for WebSocket {HashCode}.")]
-    public static partial void LogReceiveLoopStartingForWebsocket(this ILogger logger, int hashCode);
-    [LoggerMessage(EventId = 51, Level = LogLevel.Warning, Message = "WebSocket state changed to {WebSocketState} during receive loop.")]
-    public static partial void LogWebsocketStateChangedToDuringReceiveLoop(this ILogger logger, WebSocketState webSocketState);
+
+    [LoggerMessage(
+        EventId = 46,
+        Level = LogLevel.Debug,
+        Message = "[Attempt:{AttemptNumber}] Received Hello. RPC Version: {RpcVersion}"
+    )]
+    public static partial void LogAttemptReceivedHelloRpcVersion(
+        this ILogger logger,
+        int attemptNumber,
+        int rpcVersion
+    );
+
+    [LoggerMessage(
+        EventId = 47,
+        Level = LogLevel.Debug,
+        Message = "[Attempt:{AttemptNumber}] Authentication required."
+    )]
+    public static partial void LogAttemptAuthenticationRequired(
+        this ILogger logger,
+        int attemptNumber
+    );
+
+    [LoggerMessage(
+        EventId = 48,
+        Level = LogLevel.Debug,
+        Message = "[Attempt:{AttemptNumber}] Waiting for Identified..."
+    )]
+    public static partial void LogAttemptWaitingForIdentified(
+        this ILogger logger,
+        int attemptNumber
+    );
+
+    [LoggerMessage(
+        EventId = 49,
+        Level = LogLevel.Debug,
+        Message = "[Attempt:{AttemptNumber}] Received Identified. Negotiated RPC Version: {NegotiatedRpcVersion}"
+    )]
+    public static partial void LogAttemptReceivedIdentifiedNegotiatedRpcVersion(
+        this ILogger logger,
+        int attemptNumber,
+        int negotiatedRpcVersion
+    );
+
+    [LoggerMessage(
+        EventId = 50,
+        Level = LogLevel.Debug,
+        Message = "Receive loop starting for WebSocket {HashCode}."
+    )]
+    public static partial void LogReceiveLoopStartingForWebsocket(
+        this ILogger logger,
+        int hashCode
+    );
+
+    [LoggerMessage(
+        EventId = 51,
+        Level = LogLevel.Warning,
+        Message = "WebSocket state changed to {WebSocketState} during receive loop."
+    )]
+    public static partial void LogWebsocketStateChangedToDuringReceiveLoop(
+        this ILogger logger,
+        WebSocketState webSocketState
+    );
+
     [LoggerMessage(EventId = 52, Level = LogLevel.Trace, Message = "Received empty message.")]
     public static partial void LogReceivedEmptyMessage(this ILogger logger);
-    [LoggerMessage(EventId = 53, Level = LogLevel.Warning, Message = "Deserialization returned null (Length: {BufferLength}).")]
-    public static partial void LogDeserializationReturnedNullLength(this ILogger logger, long bufferLength);
-    [LoggerMessage(EventId = 54, Level = LogLevel.Information, Message = "Receive loop exiting: cancellation requested.")]
+
+    [LoggerMessage(
+        EventId = 53,
+        Level = LogLevel.Warning,
+        Message = "Deserialization returned null (Length: {BufferLength})."
+    )]
+    public static partial void LogDeserializationReturnedNullLength(
+        this ILogger logger,
+        long bufferLength
+    );
+
+    [LoggerMessage(
+        EventId = 54,
+        Level = LogLevel.Information,
+        Message = "Receive loop exiting: cancellation requested."
+    )]
     public static partial void LogReceiveLoopExitingCancellationRequested(this ILogger logger);
-    [LoggerMessage(EventId = 55, Level = LogLevel.Information, Message = "Receive loop cancelled gracefully via token.")]
+
+    [LoggerMessage(
+        EventId = 55,
+        Level = LogLevel.Information,
+        Message = "Receive loop cancelled gracefully via token."
+    )]
     public static partial void LogReceiveLoopCancelledGracefullyViaToken(this ILogger logger);
-    [LoggerMessage(EventId = 56, Level = LogLevel.Warning, Message = "WebSocketException in receive loop (Code: {WebSocketErrorCode}).")]
-    public static partial void LogWebsocketexceptionInReceiveLoopCode(this ILogger logger, Exception exception, WebSocketError webSocketErrorCode);
-    [LoggerMessage(EventId = 57, Level = LogLevel.Error, Message = "Unexpected exception in receive loop.")]
-    public static partial void LogUnexpectedExceptionInReceiveLoop(this ILogger logger, Exception exception);
-    [LoggerMessage(EventId = 58, Level = LogLevel.Debug, Message = "Receive loop finished for WebSocket {HashCode}.")]
-    public static partial void LogReceiveLoopFinishedForWebsocket(this ILogger logger, int hashCode);
-    [LoggerMessage(EventId = 59, Level = LogLevel.Information, Message = "Server acknowledged client closure. Status: {WebSocketCloseStatus}, Desc: {Description}")]
-    public static partial void LogServerAcknowledgedClientClosureStatusDesc(this ILogger logger, WebSocketCloseStatus? webSocketCloseStatus, string? description);
-    [LoggerMessage(EventId = 60, Level = LogLevel.Warning, Message = "Server initiated unexpected close. Status: {WebSocketCloseStatus}, Desc: {Description}")]
-    public static partial void LogServerInitiatedUnexpectedCloseStatusDesc(this ILogger logger, WebSocketCloseStatus? webSocketCloseStatus, string? description);
-    [LoggerMessage(EventId = 61, Level = LogLevel.Debug, Message = "Acknowledging server close frame...")]
+
+    [LoggerMessage(
+        EventId = 56,
+        Level = LogLevel.Warning,
+        Message = "WebSocketException in receive loop (Code: {WebSocketErrorCode})."
+    )]
+    public static partial void LogWebsocketexceptionInReceiveLoopCode(
+        this ILogger logger,
+        Exception exception,
+        WebSocketError webSocketErrorCode
+    );
+
+    [LoggerMessage(
+        EventId = 57,
+        Level = LogLevel.Error,
+        Message = "Unexpected exception in receive loop."
+    )]
+    public static partial void LogUnexpectedExceptionInReceiveLoop(
+        this ILogger logger,
+        Exception exception
+    );
+
+    [LoggerMessage(
+        EventId = 58,
+        Level = LogLevel.Debug,
+        Message = "Receive loop finished for WebSocket {HashCode}."
+    )]
+    public static partial void LogReceiveLoopFinishedForWebsocket(
+        this ILogger logger,
+        int hashCode
+    );
+
+    [LoggerMessage(
+        EventId = 59,
+        Level = LogLevel.Information,
+        Message = "Server acknowledged client closure. Status: {WebSocketCloseStatus}, Desc: {Description}"
+    )]
+    public static partial void LogServerAcknowledgedClientClosureStatusDesc(
+        this ILogger logger,
+        WebSocketCloseStatus? webSocketCloseStatus,
+        string? description
+    );
+
+    [LoggerMessage(
+        EventId = 60,
+        Level = LogLevel.Warning,
+        Message = "Server initiated unexpected close. Status: {WebSocketCloseStatus}, Desc: {Description}"
+    )]
+    public static partial void LogServerInitiatedUnexpectedCloseStatusDesc(
+        this ILogger logger,
+        WebSocketCloseStatus? webSocketCloseStatus,
+        string? description
+    );
+
+    [LoggerMessage(
+        EventId = 61,
+        Level = LogLevel.Debug,
+        Message = "Acknowledging server close frame..."
+    )]
     public static partial void LogAcknowledgingServerCloseFrame(this ILogger logger);
-    [LoggerMessage(EventId = 62, Level = LogLevel.Debug, Message = "Server close frame acknowledged.")]
+
+    [LoggerMessage(
+        EventId = 62,
+        Level = LogLevel.Debug,
+        Message = "Server close frame acknowledged."
+    )]
     public static partial void LogServerCloseFrameAcknowledged(this ILogger logger);
-    [LoggerMessage(EventId = 63, Level = LogLevel.Warning, Message = "Failed to acknowledge server close frame.")]
-    public static partial void LogFailedToAcknowledgeServerCloseFrame(this ILogger logger, Exception exception);
-    [LoggerMessage(EventId = 64, Level = LogLevel.Trace, Message = "CleanupConnectionOnly due to: {ExceptionType} - {ExceptionMessage}")]
-    public static partial void LogCleanupconnectiononlyDueTo(this ILogger logger, string exceptionType, string exceptionMessage);
-    [LoggerMessage(EventId = 65, Level = LogLevel.Warning, Message = "Exception cancelling receive CTS during cleanup.")]
-    public static partial void LogExceptionCancellingReceiveCtsDuringCleanup(this ILogger logger, Exception exception);
-    [LoggerMessage(EventId = 66, Level = LogLevel.Warning, Message = "Exception disposing receive CTS during cleanup.")]
-    public static partial void LogExceptionDisposingReceiveCtsDuringCleanup(this ILogger logger, Exception exception);
-    [LoggerMessage(EventId = 67, Level = LogLevel.Debug, Message = "Disposing WebSocket instance {HashCode}")]
+
+    [LoggerMessage(
+        EventId = 63,
+        Level = LogLevel.Warning,
+        Message = "Failed to acknowledge server close frame."
+    )]
+    public static partial void LogFailedToAcknowledgeServerCloseFrame(
+        this ILogger logger,
+        Exception exception
+    );
+
+    [LoggerMessage(
+        EventId = 64,
+        Level = LogLevel.Trace,
+        Message = "CleanupConnectionOnly due to: {ExceptionType} - {ExceptionMessage}"
+    )]
+    public static partial void LogCleanupconnectiononlyDueTo(
+        this ILogger logger,
+        string exceptionType,
+        string exceptionMessage
+    );
+
+    [LoggerMessage(
+        EventId = 65,
+        Level = LogLevel.Warning,
+        Message = "Exception cancelling receive CTS during cleanup."
+    )]
+    public static partial void LogExceptionCancellingReceiveCtsDuringCleanup(
+        this ILogger logger,
+        Exception exception
+    );
+
+    [LoggerMessage(
+        EventId = 66,
+        Level = LogLevel.Warning,
+        Message = "Exception disposing receive CTS during cleanup."
+    )]
+    public static partial void LogExceptionDisposingReceiveCtsDuringCleanup(
+        this ILogger logger,
+        Exception exception
+    );
+
+    [LoggerMessage(
+        EventId = 67,
+        Level = LogLevel.Debug,
+        Message = "Disposing WebSocket instance {HashCode}"
+    )]
     public static partial void LogDisposingWebsocketInstance(this ILogger logger, int hashCode);
-    [LoggerMessage(EventId = 68, Level = LogLevel.Debug, Message = "Finalizing disconnection... Reason: {ReasonType}")]
-    public static partial void LogFinalizingDisconnectionReason(this ILogger logger, string reasonType);
-    [LoggerMessage(EventId = 69, Level = LogLevel.Information, Message = "Client definitively disconnected. Reason: {DisconnectionReason}")]
-    public static partial void LogClientDefinitivelyDisconnectedReason(this ILogger logger, string disconnectionReason);
-    [LoggerMessage(EventId = 70, Level = LogLevel.Error, Message = "Unexpected incoming message type encountered: {MessageType}")]
-    public static partial void LogUnexpectedIncomingMessageTypeEncountered(this ILogger logger, string? messageType);
+
+    [LoggerMessage(
+        EventId = 68,
+        Level = LogLevel.Debug,
+        Message = "Finalizing disconnection... Reason: {ReasonType}"
+    )]
+    public static partial void LogFinalizingDisconnectionReason(
+        this ILogger logger,
+        string reasonType
+    );
+
+    [LoggerMessage(
+        EventId = 69,
+        Level = LogLevel.Information,
+        Message = "Client definitively disconnected. Reason: {DisconnectionReason}"
+    )]
+    public static partial void LogClientDefinitivelyDisconnectedReason(
+        this ILogger logger,
+        string disconnectionReason
+    );
+
+    [LoggerMessage(
+        EventId = 70,
+        Level = LogLevel.Error,
+        Message = "Unexpected incoming message type encountered: {MessageType}"
+    )]
+    public static partial void LogUnexpectedIncomingMessageTypeEncountered(
+        this ILogger logger,
+        string? messageType
+    );
+
     [LoggerMessage(EventId = 71, Level = LogLevel.Trace, Message = "Processing Hello message.")]
     public static partial void LogProcessingHelloMessage(this ILogger logger);
-    [LoggerMessage(EventId = 72, Level = LogLevel.Trace, Message = "Processing Identified message.")]
+
+    [LoggerMessage(
+        EventId = 72,
+        Level = LogLevel.Trace,
+        Message = "Processing Identified message."
+    )]
     public static partial void LogProcessingIdentifiedMessage(this ILogger logger);
-    [LoggerMessage(EventId = 73, Level = LogLevel.Warning, Message = "Received message with unhandled OpCode: {OpCode}")]
-    public static partial void LogReceivedMessageWithUnhandledOpcode(this ILogger logger, WebSocketOpCode opCode);
-    [LoggerMessage(EventId = 74, Level = LogLevel.Warning, Message = "Received null payload for RequestResponse.")]
+
+    [LoggerMessage(
+        EventId = 73,
+        Level = LogLevel.Warning,
+        Message = "Received message with unhandled OpCode: {OpCode}"
+    )]
+    public static partial void LogReceivedMessageWithUnhandledOpcode(
+        this ILogger logger,
+        WebSocketOpCode opCode
+    );
+
+    [LoggerMessage(
+        EventId = 74,
+        Level = LogLevel.Warning,
+        Message = "Received null payload for RequestResponse."
+    )]
     public static partial void LogReceivedNullPayloadForRequestresponse(this ILogger logger);
-    [LoggerMessage(EventId = 75, Level = LogLevel.Trace, Message = "Processing RequestResponse for RequestId: {RequestId}, Status: {StatusResult}")]
-    public static partial void LogProcessingRequestresponseForRequestidStatus(this ILogger logger, string requestId, bool statusResult);
-    [LoggerMessage(EventId = 76, Level = LogLevel.Warning, Message = "Received response for unknown or timed out RequestId: {RequestId}")]
-    public static partial void LogReceivedResponseForUnknownOrTimedOut(this ILogger logger, string requestId);
-    [LoggerMessage(EventId = 77, Level = LogLevel.Error, Message = "Exception during processing of RequestResponse payload: {Payload}")]
-    public static partial void LogExceptionDuringProcessingOfRequestresponsePayload(this ILogger logger, Exception exception, string? payload);
-    [LoggerMessage(EventId = 78, Level = LogLevel.Warning, Message = "Received null payload for RequestBatchResponse.")]
+
+    [LoggerMessage(
+        EventId = 75,
+        Level = LogLevel.Trace,
+        Message = "Processing RequestResponse for RequestId: {RequestId}, Status: {StatusResult}"
+    )]
+    public static partial void LogProcessingRequestresponseForRequestidStatus(
+        this ILogger logger,
+        string requestId,
+        bool statusResult
+    );
+
+    [LoggerMessage(
+        EventId = 76,
+        Level = LogLevel.Warning,
+        Message = "Received response for unknown or timed out RequestId: {RequestId}"
+    )]
+    public static partial void LogReceivedResponseForUnknownOrTimedOut(
+        this ILogger logger,
+        string requestId
+    );
+
+    [LoggerMessage(
+        EventId = 77,
+        Level = LogLevel.Error,
+        Message = "Exception during processing of RequestResponse payload: {Payload}"
+    )]
+    public static partial void LogExceptionDuringProcessingOfRequestresponsePayload(
+        this ILogger logger,
+        Exception exception,
+        string? payload
+    );
+
+    [LoggerMessage(
+        EventId = 78,
+        Level = LogLevel.Warning,
+        Message = "Received null payload for RequestBatchResponse."
+    )]
     public static partial void LogReceivedNullPayloadForRequestbatchresponse(this ILogger logger);
-    [LoggerMessage(EventId = 79, Level = LogLevel.Trace, Message = "Processing RequestBatchResponse for RequestId: {RequestId} ({ResultCount} results)")]
-    public static partial void LogProcessingRequestbatchresponseForRequestidResults(this ILogger logger, string requestId, int resultCount);
-    [LoggerMessage(EventId = 80, Level = LogLevel.Warning, Message = "Received response for unknown or timed out BatchRequestId: {RequestId}")]
-    public static partial void LogReceivedResponseForUnknownOrTimedOut2(this ILogger logger, string requestId);
-    [LoggerMessage(EventId = 81, Level = LogLevel.Error, Message = "Exception during processing of RequestBatchResponse payload: {Payload}")]
-    public static partial void LogExceptionDuringProcessingOfRequestbatchresponsePayload(this ILogger logger, Exception exception, string? payload);
-    [LoggerMessage(EventId = 82, Level = LogLevel.Warning, Message = "Received null payload for Event.")]
+
+    [LoggerMessage(
+        EventId = 79,
+        Level = LogLevel.Trace,
+        Message = "Processing RequestBatchResponse for RequestId: {RequestId} ({ResultCount} results)"
+    )]
+    public static partial void LogProcessingRequestbatchresponseForRequestidResults(
+        this ILogger logger,
+        string requestId,
+        int resultCount
+    );
+
+    [LoggerMessage(
+        EventId = 80,
+        Level = LogLevel.Warning,
+        Message = "Received response for unknown or timed out BatchRequestId: {RequestId}"
+    )]
+    public static partial void LogReceivedResponseForUnknownOrTimedOut2(
+        this ILogger logger,
+        string requestId
+    );
+
+    [LoggerMessage(
+        EventId = 81,
+        Level = LogLevel.Error,
+        Message = "Exception during processing of RequestBatchResponse payload: {Payload}"
+    )]
+    public static partial void LogExceptionDuringProcessingOfRequestbatchresponsePayload(
+        this ILogger logger,
+        Exception exception,
+        string? payload
+    );
+
+    [LoggerMessage(
+        EventId = 82,
+        Level = LogLevel.Warning,
+        Message = "Received null payload for Event."
+    )]
     public static partial void LogReceivedNullPayloadForEvent(this ILogger logger);
-    [LoggerMessage(EventId = 83, Level = LogLevel.Trace, Message = "Handling incoming event: {EventType}")]
+
+    [LoggerMessage(
+        EventId = 83,
+        Level = LogLevel.Trace,
+        Message = "Handling incoming event: {EventType}"
+    )]
     public static partial void LogHandlingIncomingEvent(this ILogger logger, string eventType);
-    [LoggerMessage(EventId = 84, Level = LogLevel.Error, Message = "Exception occurred within the event handler for {EventType}.")]
-    public static partial void LogExceptionOccurredWithinTheEventHandlerFor(this ILogger logger, Exception exception, string eventType);
-    [LoggerMessage(EventId = 85, Level = LogLevel.Warning, Message = "Received event with unhandled type: {EventType}")]
-    public static partial void LogReceivedEventWithUnhandledType(this ILogger logger, string eventType);
-    [LoggerMessage(EventId = 86, Level = LogLevel.Error, Message = "Critical exception during event handling for '{EventType}': {Payload}")]
-    public static partial void LogCriticalExceptionDuringEventHandlingFor(this ILogger logger, Exception exception, string eventType, string? payload);
-    [LoggerMessage(EventId = 87, Level = LogLevel.Error, Message = "Exception while trying to handle event {EventType}.")]
-    public static partial void LogExceptionWhileTryingToHandleEvent(this ILogger logger, Exception exception, string eventType);
-    [LoggerMessage(EventId = 88, Level = LogLevel.Warning, Message = "{RequestDescription} canceled.")]
+
+    [LoggerMessage(
+        EventId = 84,
+        Level = LogLevel.Error,
+        Message = "Exception occurred within the event handler for {EventType}."
+    )]
+    public static partial void LogExceptionOccurredWithinTheEventHandlerFor(
+        this ILogger logger,
+        Exception exception,
+        string eventType
+    );
+
+    [LoggerMessage(
+        EventId = 85,
+        Level = LogLevel.Warning,
+        Message = "Received event with unhandled type: {EventType}"
+    )]
+    public static partial void LogReceivedEventWithUnhandledType(
+        this ILogger logger,
+        string eventType
+    );
+
+    [LoggerMessage(
+        EventId = 86,
+        Level = LogLevel.Error,
+        Message = "Critical exception during event handling for '{EventType}': {Payload}"
+    )]
+    public static partial void LogCriticalExceptionDuringEventHandlingFor(
+        this ILogger logger,
+        Exception exception,
+        string eventType,
+        string? payload
+    );
+
+    [LoggerMessage(
+        EventId = 87,
+        Level = LogLevel.Error,
+        Message = "Exception while trying to handle event {EventType}."
+    )]
+    public static partial void LogExceptionWhileTryingToHandleEvent(
+        this ILogger logger,
+        Exception exception,
+        string eventType
+    );
+
+    [LoggerMessage(
+        EventId = 88,
+        Level = LogLevel.Warning,
+        Message = "{RequestDescription} canceled."
+    )]
     public static partial void LogCanceled(this ILogger logger, string requestDescription);
+
     [LoggerMessage(EventId = 89, Level = LogLevel.Trace, Message = "Sending {OpCode} message...")]
     public static partial void LogSendingMessage(this ILogger logger, WebSocketOpCode opCode);
-    [LoggerMessage(EventId = 90, Level = LogLevel.Error, Message = "Serialization failed for {OpCode} message.")]
-    public static partial void LogSerializationFailedForMessage(this ILogger logger, Exception exception, WebSocketOpCode opCode);
+
+    [LoggerMessage(
+        EventId = 90,
+        Level = LogLevel.Error,
+        Message = "Serialization failed for {OpCode} message."
+    )]
+    public static partial void LogSerializationFailedForMessage(
+        this ILogger logger,
+        Exception exception,
+        WebSocketOpCode opCode
+    );
+
     [LoggerMessage(EventId = 91, Level = LogLevel.Trace, Message = "{OpCode} message sent.")]
     public static partial void LogMessageSent(this ILogger logger, WebSocketOpCode opCode);
-    [LoggerMessage(EventId = 92, Level = LogLevel.Warning, Message = "Send operation for {OpCode} canceled.")]
-    public static partial void LogSendOperationForCanceled(this ILogger logger, WebSocketOpCode opCode);
-    [LoggerMessage(EventId = 93, Level = LogLevel.Error, Message = "Failed to send {OpCode} message via WebSocket.")]
-    public static partial void LogFailedToSendMessageViaWebsocket(this ILogger logger, Exception exception, WebSocketOpCode opCode);
-    [LoggerMessage(EventId = 94, Level = LogLevel.Debug, Message = "Failing {RequestCount} pending request(s) due to: {ExceptionType}")]
-    public static partial void LogFailingPendingRequestSDueTo(this ILogger logger, int requestCount, string exceptionType);
-    [LoggerMessage(EventId = 95, Level = LogLevel.Error, Message = "Exception in user-provided Connecting event handler.")]
-    public static partial void LogExceptionInUserProvidedConnectingEventHandler(this ILogger logger, Exception exception);
-    [LoggerMessage(EventId = 96, Level = LogLevel.Error, Message = "Exception in user-provided Connected event handler.")]
-    public static partial void LogExceptionInUserProvidedConnectedEventHandler(this ILogger logger, Exception exception);
-    [LoggerMessage(EventId = 97, Level = LogLevel.Error, Message = "Exception in user-provided Disconnected event handler.")]
-    public static partial void LogExceptionInUserProvidedDisconnectedEventHandler(this ILogger logger, Exception exception);
-    [LoggerMessage(EventId = 98, Level = LogLevel.Error, Message = "Exception in user-provided ConnectionFailed event handler.")]
-    public static partial void LogExceptionInUserProvidedConnectionfailedEventHandler(this ILogger logger, Exception exception);
-    [LoggerMessage(EventId = 99, Level = LogLevel.Error, Message = "Exception in user-provided AuthenticationFailure event handler.")]
-    public static partial void LogExceptionInUserProvidedAuthenticationfailureEventHandler(this ILogger logger, Exception exception);
+
+    [LoggerMessage(
+        EventId = 92,
+        Level = LogLevel.Warning,
+        Message = "Send operation for {OpCode} canceled."
+    )]
+    public static partial void LogSendOperationForCanceled(
+        this ILogger logger,
+        WebSocketOpCode opCode
+    );
+
+    [LoggerMessage(
+        EventId = 93,
+        Level = LogLevel.Error,
+        Message = "Failed to send {OpCode} message via WebSocket."
+    )]
+    public static partial void LogFailedToSendMessageViaWebsocket(
+        this ILogger logger,
+        Exception exception,
+        WebSocketOpCode opCode
+    );
+
+    [LoggerMessage(
+        EventId = 94,
+        Level = LogLevel.Debug,
+        Message = "Failing {RequestCount} pending request(s) due to: {ExceptionType}"
+    )]
+    public static partial void LogFailingPendingRequestSDueTo(
+        this ILogger logger,
+        int requestCount,
+        string exceptionType
+    );
+
+    [LoggerMessage(
+        EventId = 95,
+        Level = LogLevel.Error,
+        Message = "Exception in user-provided Connecting event handler."
+    )]
+    public static partial void LogExceptionInUserProvidedConnectingEventHandler(
+        this ILogger logger,
+        Exception exception
+    );
+
+    [LoggerMessage(
+        EventId = 96,
+        Level = LogLevel.Error,
+        Message = "Exception in user-provided Connected event handler."
+    )]
+    public static partial void LogExceptionInUserProvidedConnectedEventHandler(
+        this ILogger logger,
+        Exception exception
+    );
+
+    [LoggerMessage(
+        EventId = 97,
+        Level = LogLevel.Error,
+        Message = "Exception in user-provided Disconnected event handler."
+    )]
+    public static partial void LogExceptionInUserProvidedDisconnectedEventHandler(
+        this ILogger logger,
+        Exception exception
+    );
+
+    [LoggerMessage(
+        EventId = 98,
+        Level = LogLevel.Error,
+        Message = "Exception in user-provided ConnectionFailed event handler."
+    )]
+    public static partial void LogExceptionInUserProvidedConnectionfailedEventHandler(
+        this ILogger logger,
+        Exception exception
+    );
+
+    [LoggerMessage(
+        EventId = 99,
+        Level = LogLevel.Error,
+        Message = "Exception in user-provided AuthenticationFailure event handler."
+    )]
+    public static partial void LogExceptionInUserProvidedAuthenticationfailureEventHandler(
+        this ILogger logger,
+        Exception exception
+    );
 }

--- a/ObsWebSocket.Core/ObsWebSocketClientOptionsValidator.cs
+++ b/ObsWebSocket.Core/ObsWebSocketClientOptionsValidator.cs
@@ -25,7 +25,9 @@ internal sealed class ObsWebSocketClientOptionsValidator
         }
         else if (options.ServerUri.Scheme is not ("ws" or "wss"))
         {
-            failures.Add($"ServerUri scheme must be ws or wss, but was '{options.ServerUri.Scheme}'.");
+            failures.Add(
+                $"ServerUri scheme must be ws or wss, but was '{options.ServerUri.Scheme}'."
+            );
         }
 
         if (options.HandshakeTimeoutMs <= 0)

--- a/ObsWebSocket.Core/ObsWebSocketHosting.cs
+++ b/ObsWebSocket.Core/ObsWebSocketHosting.cs
@@ -1,6 +1,6 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -95,7 +95,9 @@ internal sealed class ObsWebSocketConnectionService(
     {
         if (client.IsConnected)
         {
-            await client.DisconnectAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            await client
+                .DisconnectAsync(cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
         }
     }
 }

--- a/ObsWebSocket.Core/ObsWebSocketHosting.cs
+++ b/ObsWebSocket.Core/ObsWebSocketHosting.cs
@@ -13,25 +13,44 @@ namespace ObsWebSocket.Core;
 /// <param name="client">The client to manage.</param>
 /// <param name="options">Monitored options, watched for endpoint changes.</param>
 /// <param name="logger">Logger for connection outcomes.</param>
+/// <param name="name">The key this client is registered under, or null for the unnamed client.</param>
 internal sealed class ObsWebSocketConnectionService(
     ObsWebSocketClient client,
     IOptionsMonitor<ObsWebSocketClientOptions> options,
-    ILogger<ObsWebSocketConnectionService> logger
+    ILogger<ObsWebSocketConnectionService> logger,
+    string? name = null
 ) : IHostedService, IDisposable
 {
     private IDisposable? _optionsWatch;
     private (Uri? Uri, string? Password, SerializationFormat Format) _connectedWith;
 
+    private string OptionsName => name ?? Options.DefaultName;
+
     /// <inheritdoc/>
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        _optionsWatch = options.OnChange(OnOptionsChanged);
+        _optionsWatch = options.OnChange(
+            (updated, changedName) =>
+            {
+                // OnChange fires for every named instance, so ignore the ones that are not ours.
+                if (
+                    string.Equals(
+                        changedName ?? Options.DefaultName,
+                        OptionsName,
+                        StringComparison.Ordinal
+                    )
+                )
+                {
+                    OnOptionsChanged(updated);
+                }
+            }
+        );
         await ConnectAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private async Task ConnectAsync(CancellationToken cancellationToken)
     {
-        ObsWebSocketClientOptions current = options.CurrentValue;
+        ObsWebSocketClientOptions current = options.Get(OptionsName);
         _connectedWith = (current.ServerUri, current.Password, current.Format);
 
         try
@@ -135,6 +154,9 @@ public static class ObsWebSocketHostingExtensions
     /// </remarks>
     /// <param name="services">The service collection the client was added to.</param>
     /// <returns>The same collection, for chaining.</returns>
+    [Obsolete(
+        "Chain WithAutoConnect off AddObsWebSocketClient instead, which also works for a named client. This forwarder will be removed in a future release."
+    )]
     public static IServiceCollection WithAutoConnect(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
@@ -153,9 +175,9 @@ public static class ObsWebSocketHostingExtensions
     /// <param name="builder">The host application builder.</param>
     /// <param name="connectionName">The connection string name, also the key for the client.</param>
     /// <param name="configureOptions">An optional action to configure the remaining options.</param>
-    /// <returns>The same builder, for chaining.</returns>
+    /// <returns>A builder for configuring this client.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the connection string is missing.</exception>
-    public static IHostApplicationBuilder AddObsWebSocketClient(
+    public static IObsWebSocketClientBuilder AddObsWebSocketClient(
         this IHostApplicationBuilder builder,
         string connectionName,
         Action<ObsWebSocketClientOptions>? configureOptions = null
@@ -170,13 +192,11 @@ public static class ObsWebSocketHostingExtensions
                 $"No connection string named '{connectionName}' was found. Add ConnectionStrings:{connectionName}, for example ws://localhost:4455."
             );
 
-        _ = builder.Services.AddObsWebSocketClient(options =>
+        return builder.Services.AddObsWebSocketClient(options =>
         {
             ApplyConnectionString(options, connectionString);
             configureOptions?.Invoke(options);
         });
-
-        return builder;
     }
 
     /// <summary>

--- a/ObsWebSocket.Core/ObsWebSocketMetrics.cs
+++ b/ObsWebSocket.Core/ObsWebSocketMetrics.cs
@@ -22,14 +22,18 @@ public sealed class ObsWebSocketMetrics : IDisposable
         ArgumentNullException.ThrowIfNull(meterFactory);
         _meter = meterFactory.Create(ObsWebSocketDiagnostics.MeterName);
         _ownsMeter = false;
-        (RequestsSent, RequestsFailed, RequestDuration, EventsReceived, Reconnects) = Create(_meter);
+        (RequestsSent, RequestsFailed, RequestDuration, EventsReceived, Reconnects) = Create(
+            _meter
+        );
     }
 
     private ObsWebSocketMetrics()
     {
         _meter = new Meter(ObsWebSocketDiagnostics.MeterName);
         _ownsMeter = true;
-        (RequestsSent, RequestsFailed, RequestDuration, EventsReceived, Reconnects) = Create(_meter);
+        (RequestsSent, RequestsFailed, RequestDuration, EventsReceived, Reconnects) = Create(
+            _meter
+        );
     }
 
     /// <summary>Instruments for a client built outside dependency injection.</summary>

--- a/ObsWebSocket.Core/ObsWebSocketRequestException.cs
+++ b/ObsWebSocket.Core/ObsWebSocketRequestException.cs
@@ -1,5 +1,5 @@
 using ObsWebSocket.Core.Protocol;
-using ObsRequestStatus = ObsWebSocket.Core.Protocol.Generated.RequestStatus;
+using ObsWebSocket.Core.Protocol.Generated;
 
 namespace ObsWebSocket.Core;
 
@@ -56,18 +56,17 @@ public class ObsWebSocketRequestException : ObsWebSocketException
     public string? Comment { get; }
 
     /// <summary>
-    /// The status OBS reported as <see cref="ObsWebSocket.Core.Protocol.Generated.RequestStatus"/>,
-    /// so a handler can match on the reason rather than on the text of
-    /// <see cref="Exception.Message"/>. Note that the enum and the <see cref="Status"/> record
-    /// share the name <c>RequestStatus</c> in different namespaces.
+    /// The status OBS reported as
+    /// <see cref="ObsWebSocket.Core.Protocol.Generated.RequestStatusCode"/>, so a handler can
+    /// match on the reason rather than on the text of <see cref="Exception.Message"/>.
     /// </summary>
     /// <example>
     /// <code>
     /// catch (ObsWebSocketRequestException ex)
-    ///     when (ex.StatusCode is RequestStatus.ResourceNotFound) { }
+    ///     when (ex.StatusCode is RequestStatusCode.ResourceNotFound) { }
     /// </code>
     /// </example>
-    public ObsRequestStatus? StatusCode => Status is null ? null : (ObsRequestStatus)Status.Code;
+    public RequestStatusCode? StatusCode => Status is null ? null : (RequestStatusCode)Status.Code;
 }
 
 /// <summary>

--- a/ObsWebSocket.Core/ObsWebSocketRequestException.cs
+++ b/ObsWebSocket.Core/ObsWebSocketRequestException.cs
@@ -1,4 +1,5 @@
 using ObsWebSocket.Core.Protocol;
+using ObsRequestStatus = ObsWebSocket.Core.Protocol.Generated.RequestStatus;
 
 namespace ObsWebSocket.Core;
 
@@ -53,6 +54,20 @@ public class ObsWebSocketRequestException : ObsWebSocketException
 
     /// <summary>The comment OBS attached, if any.</summary>
     public string? Comment { get; }
+
+    /// <summary>
+    /// The status OBS reported as <see cref="ObsWebSocket.Core.Protocol.Generated.RequestStatus"/>,
+    /// so a handler can match on the reason rather than on the text of
+    /// <see cref="Exception.Message"/>. Note that the enum and the <see cref="Status"/> record
+    /// share the name <c>RequestStatus</c> in different namespaces.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// catch (ObsWebSocketRequestException ex)
+    ///     when (ex.StatusCode is RequestStatus.ResourceNotFound) { }
+    /// </code>
+    /// </example>
+    public ObsRequestStatus? StatusCode => Status is null ? null : (ObsRequestStatus)Status.Code;
 }
 
 /// <summary>

--- a/ObsWebSocket.Core/ObsWebSocketServiceCollectionExtensions.cs
+++ b/ObsWebSocket.Core/ObsWebSocketServiceCollectionExtensions.cs
@@ -18,9 +18,9 @@ public static class ObsWebSocketServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
     /// <param name="configureOptions">An optional action to configure the <see cref="ObsWebSocketClientOptions"/>.</param>
-    /// <returns>The original <see cref="IServiceCollection"/> for chaining.</returns>
+    /// <returns>A builder for configuring this client.</returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="services"/> is null.</exception>
-    public static IServiceCollection AddObsWebSocketClient(
+    public static IObsWebSocketClientBuilder AddObsWebSocketClient(
         this IServiceCollection services,
         Action<ObsWebSocketClientOptions>? configureOptions = null
     )
@@ -97,7 +97,7 @@ public static class ObsWebSocketServiceCollectionExtensions
             );
         });
 
-        return services;
+        return new ObsWebSocketClientBuilder(services, name: null);
     }
 
     /// <summary>
@@ -108,10 +108,10 @@ public static class ObsWebSocketServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
     /// <param name="name">The key identifying this client.</param>
     /// <param name="configureOptions">An optional action to configure this client's options.</param>
-    /// <returns>The original <see cref="IServiceCollection"/> for chaining.</returns>
+    /// <returns>A builder for configuring this client.</returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="services"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown if <paramref name="name"/> is null or empty.</exception>
-    public static IServiceCollection AddObsWebSocketClient(
+    public static IObsWebSocketClientBuilder AddObsWebSocketClient(
         this IServiceCollection services,
         string name,
         Action<ObsWebSocketClientOptions>? configureOptions = null
@@ -166,7 +166,7 @@ public static class ObsWebSocketServiceCollectionExtensions
             }
         );
 
-        return services;
+        return new ObsWebSocketClientBuilder(services, name);
     }
 }
 

--- a/ObsWebSocket.Core/ObsWebSocketServiceCollectionExtensions.cs
+++ b/ObsWebSocket.Core/ObsWebSocketServiceCollectionExtensions.cs
@@ -63,8 +63,10 @@ public static class ObsWebSocketServiceCollectionExtensions
 
         // Resolve options through the monitor, so a configuration change is picked up rather
         // than the values captured when the container was built.
-        _ = services.AddSingleton<IOptions<ObsWebSocketClientOptions>>(sp =>
-            new MonitorBackedOptions(sp.GetRequiredService<IOptionsMonitor<ObsWebSocketClientOptions>>())
+        _ = services.AddSingleton<IOptions<ObsWebSocketClientOptions>>(
+            sp => new MonitorBackedOptions(
+                sp.GetRequiredService<IOptionsMonitor<ObsWebSocketClientOptions>>()
+            )
         );
         _ = services.AddMetrics();
         services.TryAddSingleton<ObsWebSocketMetrics>();
@@ -143,11 +145,13 @@ public static class ObsWebSocketServiceCollectionExtensions
             {
                 ObsWebSocketClientOptions options = sp.GetRequiredService<
                     IOptionsMonitor<ObsWebSocketClientOptions>
-                >().Get((string)key!);
+                >()
+                    .Get((string)key!);
 
                 IWebSocketMessageSerializer serializer = options.Format switch
                 {
-                    SerializationFormat.MsgPack => sp.GetRequiredService<MsgPackMessageSerializer>(),
+                    SerializationFormat.MsgPack =>
+                        sp.GetRequiredService<MsgPackMessageSerializer>(),
                     SerializationFormat.Json or _ => sp.GetRequiredService<JsonMessageSerializer>(),
                 };
 

--- a/ObsWebSocket.Core/Protocol/Common/FilterSettings/CommonFilterSettings.cs
+++ b/ObsWebSocket.Core/Protocol/Common/FilterSettings/CommonFilterSettings.cs
@@ -25,9 +25,7 @@ public sealed record CropPadFilterSettings(
 );
 
 /// <summary>Settings for the 'gain_filter' filter.</summary>
-public sealed record GainFilterSettings(
-    [property: JsonPropertyName("db")] double? Db = null
-);
+public sealed record GainFilterSettings([property: JsonPropertyName("db")] double? Db = null);
 
 /// <summary>Settings for the 'basic_eq_filter' (3-Band EQ) filter.</summary>
 public sealed record BasicEqFilterSettings(
@@ -182,6 +180,7 @@ public sealed record ExpanderFilterSettings(
     {
         /// <summary>Root Mean Square level detection.</summary>
         public const string Rms = "RMS";
+
         /// <summary>Peak level detection.</summary>
         public const string Peak = "Peak";
     }
@@ -191,6 +190,7 @@ public sealed record ExpanderFilterSettings(
     {
         /// <summary>Expander — increases dynamic range below the threshold.</summary>
         public const string Expander = "expander";
+
         /// <summary>Gate — silences audio below the threshold.</summary>
         public const string Gate = "gate";
     }
@@ -212,6 +212,7 @@ public sealed record UpwardCompressorFilterSettings(
     {
         /// <summary>Root Mean Square level detection.</summary>
         public const string Rms = "RMS";
+
         /// <summary>Peak level detection.</summary>
         public const string Peak = "Peak";
     }

--- a/ObsWebSocket.Core/Protocol/Common/InputSettings/CommonInputSettings.cs
+++ b/ObsWebSocket.Core/Protocol/Common/InputSettings/CommonInputSettings.cs
@@ -47,8 +47,10 @@ public sealed record SlideshowSettings(
     {
         /// <summary>Always play regardless of scene visibility.</summary>
         public const string AlwaysPlay = "always_play";
+
         /// <summary>Pause when invisible, unpause when visible.</summary>
         public const string PauseUnpause = "pause_unpause";
+
         /// <summary>Stop and restart from the beginning when made visible.</summary>
         public const string StopRestart = "stop_restart";
     }
@@ -58,8 +60,10 @@ public sealed record SlideshowSettings(
     {
         /// <summary>Loop through slides continuously.</summary>
         public const string Loop = "loop";
+
         /// <summary>Bounce back and forth through slides.</summary>
         public const string Bounce = "bounce";
+
         /// <summary>Manual advance only.</summary>
         public const string Manual = "manual";
     }
@@ -129,8 +133,10 @@ public sealed record TextGdiPlusInputSettings(
     {
         /// <summary>Left-align text.</summary>
         public const string Left = "left";
+
         /// <summary>Center-align text.</summary>
         public const string Center = "center";
+
         /// <summary>Right-align text.</summary>
         public const string Right = "right";
     }
@@ -140,8 +146,10 @@ public sealed record TextGdiPlusInputSettings(
     {
         /// <summary>Align text to the top.</summary>
         public const string Top = "top";
+
         /// <summary>Align text to the center.</summary>
         public const string Center = "center";
+
         /// <summary>Align text to the bottom.</summary>
         public const string Bottom = "bottom";
     }
@@ -179,8 +187,10 @@ public sealed record VlcSourceSettings(
     {
         /// <summary>Stop and restart from the beginning when made visible.</summary>
         public const string StopRestart = "stop_restart";
+
         /// <summary>Pause when invisible, unpause when visible.</summary>
         public const string PauseUnpause = "pause_unpause";
+
         /// <summary>Always play regardless of scene visibility.</summary>
         public const string AlwaysPlay = "always_play";
     }
@@ -231,8 +241,10 @@ public sealed record GameCaptureSettings(
     {
         /// <summary>Capture any fullscreen application.</summary>
         public const string AnyFullscreen = "any_fullscreen";
+
         /// <summary>Capture a specific window.</summary>
         public const string Window = "window";
+
         /// <summary>Toggle capture with a hotkey.</summary>
         public const string Hotkey = "hotkey";
     }

--- a/ObsWebSocket.Core/Protocol/Common/StreamServiceSettings/CommonStreamServiceSettings.cs
+++ b/ObsWebSocket.Core/Protocol/Common/StreamServiceSettings/CommonStreamServiceSettings.cs
@@ -14,7 +14,8 @@ public sealed record RtmpCommonStreamServiceSettings(
     [property: JsonPropertyName("bwtest")] bool? BandwidthTest = null,
     [property: JsonPropertyName("stream_key_link")] string? StreamKeyLink = null,
     [property: JsonPropertyName("multitrack_video_name")] string? MultitrackVideoName = null,
-    [property: JsonPropertyName("multitrack_video_disclaimer")] string? MultitrackVideoDisclaimer = null
+    [property: JsonPropertyName("multitrack_video_disclaimer")]
+        string? MultitrackVideoDisclaimer = null
 );
 
 /// <summary>

--- a/ObsWebSocket.Core/Protocol/Common/StubTypes.cs
+++ b/ObsWebSocket.Core/Protocol/Common/StubTypes.cs
@@ -482,10 +482,3 @@ public sealed class PropertyItemStub
     [JsonConstructor]
     public PropertyItemStub() { }
 }
-
-
-
-
-
-
-

--- a/ObsWebSocket.Core/Protocol/Messages.cs
+++ b/ObsWebSocket.Core/Protocol/Messages.cs
@@ -179,5 +179,6 @@ internal record RequestBatchPayload(
 [MessagePackObject(AllowPrivate = true, SuppressSourceGeneration = true)]
 internal record RequestBatchResponsePayload<TData>(
     [property: JsonPropertyName("requestId"), Key("requestId")] string RequestId,
-    [property: JsonPropertyName("results"), Key("results")] List<RequestResponsePayload<TData>> Results
+    [property: JsonPropertyName("results"), Key("results")]
+        List<RequestResponsePayload<TData>> Results
 );

--- a/ObsWebSocket.Core/ReconnectDelays.cs
+++ b/ObsWebSocket.Core/ReconnectDelays.cs
@@ -67,7 +67,5 @@ internal sealed class ReconnectDelays
     /// recovering from one outage do not retry in lockstep.
     /// </summary>
     private static TimeSpan ApplyJitter(TimeSpan delay) =>
-        delay <= TimeSpan.Zero
-            ? delay
-            : delay * (0.75 + (Random.Shared.NextDouble() * 0.5));
+        delay <= TimeSpan.Zero ? delay : delay * (0.75 + (Random.Shared.NextDouble() * 0.5));
 }

--- a/ObsWebSocket.Core/Serialization/JsonMessageSerializer.cs
+++ b/ObsWebSocket.Core/Serialization/JsonMessageSerializer.cs
@@ -14,7 +14,9 @@ public class JsonMessageSerializer(ILogger<JsonMessageSerializer> logger)
     : IWebSocketMessageSerializer
 {
     private readonly ILogger _logger = logger;
-    private static readonly JsonSerializerOptions s_options = ObsWebSocketJsonContext.Default.Options;
+    private static readonly JsonSerializerOptions s_options = ObsWebSocketJsonContext
+        .Default
+        .Options;
 
     /// <inheritdoc/>
     public string ProtocolSubProtocol => "obswebsocket.json";
@@ -59,9 +61,8 @@ public class JsonMessageSerializer(ILogger<JsonMessageSerializer> logger)
         {
             // Deserialize into the generic IncomingMessage with JsonElement as the data type
             JsonTypeInfo<IncomingMessage<JsonElement>> typeInfo =
-                (JsonTypeInfo<IncomingMessage<JsonElement>>)s_options.GetTypeInfo(
-                    typeof(IncomingMessage<JsonElement>)
-                );
+                (JsonTypeInfo<IncomingMessage<JsonElement>>)
+                    s_options.GetTypeInfo(typeof(IncomingMessage<JsonElement>));
             IncomingMessage<JsonElement>? message = await JsonSerializer
                 .DeserializeAsync(messageStream, typeInfo, cancellationToken)
                 .ConfigureAwait(false);
@@ -89,7 +90,10 @@ public class JsonMessageSerializer(ILogger<JsonMessageSerializer> logger)
             messageStream.Position = 0;
             using StreamReader reader = new(messageStream, Encoding.UTF8, leaveOpen: true);
             string rawJson = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
-            _logger.LogJsonDeserializationFailedRawJson(ex, rawJson.Length > 1024 ? rawJson[..1024] + "..." : rawJson);
+            _logger.LogJsonDeserializationFailedRawJson(
+                ex,
+                rawJson.Length > 1024 ? rawJson[..1024] + "..." : rawJson
+            );
             return null;
         }
         catch (Exception ex)
@@ -114,7 +118,10 @@ public class JsonMessageSerializer(ILogger<JsonMessageSerializer> logger)
                     and not JsonElement { ValueKind: JsonValueKind.Null or JsonValueKind.Undefined }
             )
             {
-                _logger.LogJsonDeserializerExpectedJsonelementPayloadButReceived(rawPayloadData?.GetType().Name, typeof(TPayload).Name);
+                _logger.LogJsonDeserializerExpectedJsonelementPayloadButReceived(
+                    rawPayloadData?.GetType().Name,
+                    typeof(TPayload).Name
+                );
             }
 
             return default;
@@ -125,39 +132,40 @@ public class JsonMessageSerializer(ILogger<JsonMessageSerializer> logger)
             if (typeof(TPayload) == typeof(EventPayloadBase<object>))
             {
                 JsonTypeInfo<EventPayloadBase<JsonElement>> eventTypeInfo =
-                    (JsonTypeInfo<EventPayloadBase<JsonElement>>)s_options.GetTypeInfo(
-                        typeof(EventPayloadBase<JsonElement>)
-                    );
-                EventPayloadBase<JsonElement>? eventPayload = jsonElement.Deserialize(eventTypeInfo);
+                    (JsonTypeInfo<EventPayloadBase<JsonElement>>)
+                        s_options.GetTypeInfo(typeof(EventPayloadBase<JsonElement>));
+                EventPayloadBase<JsonElement>? eventPayload = jsonElement.Deserialize(
+                    eventTypeInfo
+                );
                 return eventPayload is null
                     ? default
                     : (TPayload)
-                    (object)
-                        new EventPayloadBase<object>(
-                            eventPayload.EventType,
-                            eventPayload.EventIntent,
-                            eventPayload.EventData
-                        );
+                        (object)
+                            new EventPayloadBase<object>(
+                                eventPayload.EventType,
+                                eventPayload.EventIntent,
+                                eventPayload.EventData
+                            );
             }
 
             if (typeof(TPayload) == typeof(RequestResponsePayload<object>))
             {
                 JsonTypeInfo<RequestResponsePayload<JsonElement>> responseTypeInfo =
-                    (JsonTypeInfo<RequestResponsePayload<JsonElement>>)s_options.GetTypeInfo(
-                        typeof(RequestResponsePayload<JsonElement>)
-                    );
-                RequestResponsePayload<JsonElement>? responsePayload =
-                    jsonElement.Deserialize(responseTypeInfo);
+                    (JsonTypeInfo<RequestResponsePayload<JsonElement>>)
+                        s_options.GetTypeInfo(typeof(RequestResponsePayload<JsonElement>));
+                RequestResponsePayload<JsonElement>? responsePayload = jsonElement.Deserialize(
+                    responseTypeInfo
+                );
                 return responsePayload is null
                     ? default
                     : (TPayload)
-                    (object)
-                        new RequestResponsePayload<object>(
-                            responsePayload.RequestType,
-                            responsePayload.RequestId,
-                            responsePayload.RequestStatus,
-                            responsePayload.ResponseData
-                        );
+                        (object)
+                            new RequestResponsePayload<object>(
+                                responsePayload.RequestType,
+                                responsePayload.RequestId,
+                                responsePayload.RequestStatus,
+                                responsePayload.ResponseData
+                            );
             }
 
             if (typeof(TPayload) == typeof(RequestBatchResponsePayload<object>))
@@ -165,9 +173,8 @@ public class JsonMessageSerializer(ILogger<JsonMessageSerializer> logger)
                 // Each result is deserialized on its own, because deserializing the batch in
                 // one pass paired every responseData with the following request.
                 JsonTypeInfo<RequestResponsePayload<JsonElement>> itemTypeInfo =
-                    (JsonTypeInfo<RequestResponsePayload<JsonElement>>)s_options.GetTypeInfo(
-                        typeof(RequestResponsePayload<JsonElement>)
-                    );
+                    (JsonTypeInfo<RequestResponsePayload<JsonElement>>)
+                        s_options.GetTypeInfo(typeof(RequestResponsePayload<JsonElement>));
 
                 string batchRequestId =
                     jsonElement.TryGetProperty("requestId", out JsonElement idElement)
@@ -191,10 +198,12 @@ public class JsonMessageSerializer(ILogger<JsonMessageSerializer> logger)
                             continue;
                         }
 
-                        JsonElement data =
-                            itemElement.TryGetProperty("responseData", out JsonElement dataElement)
-                                ? dataElement.Clone()
-                                : default;
+                        JsonElement data = itemElement.TryGetProperty(
+                            "responseData",
+                            out JsonElement dataElement
+                        )
+                            ? dataElement.Clone()
+                            : default;
 
                         mappedResults.Add(
                             new RequestResponsePayload<object>(
@@ -208,20 +217,20 @@ public class JsonMessageSerializer(ILogger<JsonMessageSerializer> logger)
                 }
 
                 return (TPayload)
-                    (object)new RequestBatchResponsePayload<object>(
-                        batchRequestId,
-                        mappedResults
-                    );
+                    (object)new RequestBatchResponsePayload<object>(batchRequestId, mappedResults);
             }
 
-            JsonTypeInfo<TPayload> typeInfo = (JsonTypeInfo<TPayload>)s_options.GetTypeInfo(
-                typeof(TPayload)
-            );
+            JsonTypeInfo<TPayload> typeInfo =
+                (JsonTypeInfo<TPayload>)s_options.GetTypeInfo(typeof(TPayload));
             return jsonElement.Deserialize(typeInfo);
         }
         catch (Exception ex)
         {
-            _logger.LogJsonFailedToDeserializePayloadToRaw(ex, typeof(TPayload).Name, jsonElement.GetRawText());
+            _logger.LogJsonFailedToDeserializePayloadToRaw(
+                ex,
+                typeof(TPayload).Name,
+                jsonElement.GetRawText()
+            );
             return default;
         }
     }
@@ -241,7 +250,10 @@ public class JsonMessageSerializer(ILogger<JsonMessageSerializer> logger)
                     and not JsonElement { ValueKind: JsonValueKind.Null or JsonValueKind.Undefined }
             )
             {
-                _logger.LogJsonDeserializerExpectedJsonelementPayloadButReceived2(rawPayloadData?.GetType().Name, typeof(TPayload).Name);
+                _logger.LogJsonDeserializerExpectedJsonelementPayloadButReceived2(
+                    rawPayloadData?.GetType().Name,
+                    typeof(TPayload).Name
+                );
             }
 
             return default;
@@ -251,14 +263,17 @@ public class JsonMessageSerializer(ILogger<JsonMessageSerializer> logger)
         {
             // Deserialize will return default(TPayload) if JSON is null, which is valid for nullable structs,
             // but might be undesirable for non-nullable ones (though caught earlier if JSON is explicitly null).
-            JsonTypeInfo<TPayload> typeInfo = (JsonTypeInfo<TPayload>)s_options.GetTypeInfo(
-                typeof(TPayload)
-            );
+            JsonTypeInfo<TPayload> typeInfo =
+                (JsonTypeInfo<TPayload>)s_options.GetTypeInfo(typeof(TPayload));
             return jsonElement.Deserialize(typeInfo);
         }
         catch (Exception ex)
         {
-            _logger.LogJsonFailedToDeserializePayloadToValue(ex, typeof(TPayload).Name, jsonElement.GetRawText());
+            _logger.LogJsonFailedToDeserializePayloadToValue(
+                ex,
+                typeof(TPayload).Name,
+                jsonElement.GetRawText()
+            );
             return default;
         }
     }

--- a/ObsWebSocket.Core/Serialization/MsgPackJsonElementResolver.cs
+++ b/ObsWebSocket.Core/Serialization/MsgPackJsonElementResolver.cs
@@ -11,11 +11,12 @@ internal sealed class MsgPackJsonElementResolver : IFormatterResolver
 
     private MsgPackJsonElementResolver() { }
 
-    public IMessagePackFormatter<T>? GetFormatter<T>() => typeof(T) == typeof(JsonElement)
+    public IMessagePackFormatter<T>? GetFormatter<T>() =>
+        typeof(T) == typeof(JsonElement)
             ? (IMessagePackFormatter<T>)(object)JsonElementFormatter.Instance
-            : typeof(T) == typeof(JsonElement?)
+        : typeof(T) == typeof(JsonElement?)
             ? (IMessagePackFormatter<T>)(object)NullableJsonElementFormatter.Instance
-            : null;
+        : null;
 
     internal sealed class JsonElementFormatter : IMessagePackFormatter<JsonElement>
     {
@@ -80,7 +81,10 @@ internal sealed class MsgPackJsonElementResolver : IFormatterResolver
             MessagePackSerializerOptions options
         )
         {
-            if (!value.HasValue || value.Value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+            if (
+                !value.HasValue
+                || value.Value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined
+            )
             {
                 writer.WriteNil();
                 return;
@@ -92,6 +96,9 @@ internal sealed class MsgPackJsonElementResolver : IFormatterResolver
         public JsonElement? Deserialize(
             ref MessagePackReader reader,
             MessagePackSerializerOptions options
-        ) => reader.TryReadNil() ? null : JsonElementFormatter.Instance.Deserialize(ref reader, options);
+        ) =>
+            reader.TryReadNil()
+                ? null
+                : JsonElementFormatter.Instance.Deserialize(ref reader, options);
     }
 }

--- a/ObsWebSocket.Core/Serialization/MsgPackMessageSerializer.cs
+++ b/ObsWebSocket.Core/Serialization/MsgPackMessageSerializer.cs
@@ -123,7 +123,11 @@ public class MsgPackMessageSerializer(ILogger<MsgPackMessageSerializer> logger)
         }
         catch (Exception ex)
         {
-            _logger.LogMessagepackFailedToDeserializePayloadObjectTo(ex, typeof(TPayload).Name, rawPayloadData.GetType().Name);
+            _logger.LogMessagepackFailedToDeserializePayloadObjectTo(
+                ex,
+                typeof(TPayload).Name,
+                rawPayloadData.GetType().Name
+            );
             return default;
         }
     }
@@ -143,7 +147,11 @@ public class MsgPackMessageSerializer(ILogger<MsgPackMessageSerializer> logger)
         }
         catch (Exception ex)
         {
-            _logger.LogMessagepackFailedToDeserializePayloadObjectTo2(ex, typeof(TPayload).Name, rawPayloadData.GetType().Name);
+            _logger.LogMessagepackFailedToDeserializePayloadObjectTo2(
+                ex,
+                typeof(TPayload).Name,
+                rawPayloadData.GetType().Name
+            );
             return default;
         }
     }
@@ -198,7 +206,11 @@ public class MsgPackMessageSerializer(ILogger<MsgPackMessageSerializer> logger)
             return [.. buffer.WrittenSpan];
         }
 
-        byte[] payloadBytes = MessagePackSerializer.Serialize(message.D, s_msgPackOptions, cancellationToken);
+        byte[] payloadBytes = MessagePackSerializer.Serialize(
+            message.D,
+            s_msgPackOptions,
+            cancellationToken
+        );
         writer.WriteRaw(payloadBytes);
         writer.Flush();
 
@@ -248,7 +260,8 @@ public class MsgPackMessageSerializer(ILogger<MsgPackMessageSerializer> logger)
         return new EventPayloadBase<object>(eventType ?? string.Empty, eventIntent, eventData);
     }
 
-    private static IFormatterResolver[] CreateResolverChain() => [
+    private static IFormatterResolver[] CreateResolverChain() =>
+        [
             MsgPackJsonElementResolver.Instance,
             MsgPackStubExtensionDataResolver.Instance,
             ObsWebSocketMsgPackResolver.Instance,

--- a/ObsWebSocket.Core/Serialization/MsgPackStubExtensionDataResolver.cs
+++ b/ObsWebSocket.Core/Serialization/MsgPackStubExtensionDataResolver.cs
@@ -23,13 +23,14 @@ internal sealed class MsgPackStubExtensionDataResolver : IFormatterResolver
 
         if (type == typeof(SceneItemTransformStub))
         {
-            return (IMessagePackFormatter<T>)(object)
-                new MsgPackJsonBridgeFormatter<SceneItemTransformStub>();
+            return (IMessagePackFormatter<T>)
+                (object)new MsgPackJsonBridgeFormatter<SceneItemTransformStub>();
         }
 
         if (type == typeof(SceneItemStub))
         {
-            return (IMessagePackFormatter<T>)(object)new MsgPackJsonBridgeFormatter<SceneItemStub>();
+            return (IMessagePackFormatter<T>)
+                (object)new MsgPackJsonBridgeFormatter<SceneItemStub>();
         }
 
         if (type == typeof(FilterStub))
@@ -44,40 +45,52 @@ internal sealed class MsgPackStubExtensionDataResolver : IFormatterResolver
 
         if (type == typeof(TransitionStub))
         {
-            return (IMessagePackFormatter<T>)(object)new MsgPackJsonBridgeFormatter<TransitionStub>();
+            return (IMessagePackFormatter<T>)
+                (object)new MsgPackJsonBridgeFormatter<TransitionStub>();
         }
 
         return type == typeof(List<SceneStub>)
-            ? (IMessagePackFormatter<T>)(object)new MsgPackJsonBridgeFormatter<List<SceneStub>>()
+                ? (IMessagePackFormatter<T>)
+                    (object)new MsgPackJsonBridgeFormatter<List<SceneStub>>()
             : type == typeof(List<SceneItemStub>)
-            ? (IMessagePackFormatter<T>)(object)new MsgPackJsonBridgeFormatter<List<SceneItemStub>>()
+                ? (IMessagePackFormatter<T>)
+                    (object)new MsgPackJsonBridgeFormatter<List<SceneItemStub>>()
             : type == typeof(List<FilterStub>)
-            ? (IMessagePackFormatter<T>)(object)new MsgPackJsonBridgeFormatter<List<FilterStub>>()
+                ? (IMessagePackFormatter<T>)
+                    (object)new MsgPackJsonBridgeFormatter<List<FilterStub>>()
             : type == typeof(List<InputStub>)
-            ? (IMessagePackFormatter<T>)(object)new MsgPackJsonBridgeFormatter<List<InputStub>>()
+                ? (IMessagePackFormatter<T>)
+                    (object)new MsgPackJsonBridgeFormatter<List<InputStub>>()
             : type == typeof(List<TransitionStub>)
-            ? (IMessagePackFormatter<T>)(object)new MsgPackJsonBridgeFormatter<List<TransitionStub>>()
+                ? (IMessagePackFormatter<T>)
+                    (object)new MsgPackJsonBridgeFormatter<List<TransitionStub>>()
             : type == typeof(List<OutputStub>)
-            ? (IMessagePackFormatter<T>)(object)new MsgPackJsonBridgeFormatter<List<OutputStub>>()
+                ? (IMessagePackFormatter<T>)
+                    (object)new MsgPackJsonBridgeFormatter<List<OutputStub>>()
             : type == typeof(List<MonitorStub>)
-            ? (IMessagePackFormatter<T>)(object)new MsgPackJsonBridgeFormatter<List<MonitorStub>>()
+                ? (IMessagePackFormatter<T>)
+                    (object)new MsgPackJsonBridgeFormatter<List<MonitorStub>>()
             : type == typeof(List<PropertyItemStub>)
-            ? (IMessagePackFormatter<T>)(object)
-                new MsgPackJsonBridgeFormatter<List<PropertyItemStub>>()
+                ? (IMessagePackFormatter<T>)
+                    (object)new MsgPackJsonBridgeFormatter<List<PropertyItemStub>>()
             : type == typeof(OutputStub)
-            ? (IMessagePackFormatter<T>)(object)new MsgPackJsonBridgeFormatter<OutputStub>()
+                ? (IMessagePackFormatter<T>)(object)new MsgPackJsonBridgeFormatter<OutputStub>()
             : type == typeof(MonitorStub)
-            ? (IMessagePackFormatter<T>)(object)new MsgPackJsonBridgeFormatter<MonitorStub>()
+                ? (IMessagePackFormatter<T>)(object)new MsgPackJsonBridgeFormatter<MonitorStub>()
             : type == typeof(PropertyItemStub)
-            ? (IMessagePackFormatter<T>)(object)
-                new MsgPackJsonBridgeFormatter<PropertyItemStub>()
+                ? (IMessagePackFormatter<T>)
+                    (object)new MsgPackJsonBridgeFormatter<PropertyItemStub>()
             : null;
     }
 
     private sealed class MsgPackJsonBridgeFormatter<T> : IMessagePackFormatter<T?>
         where T : class
     {
-        public void Serialize(ref MessagePackWriter writer, T? value, MessagePackSerializerOptions options)
+        public void Serialize(
+            ref MessagePackWriter writer,
+            T? value,
+            MessagePackSerializerOptions options
+        )
         {
             if (value is null)
             {
@@ -85,8 +98,8 @@ internal sealed class MsgPackStubExtensionDataResolver : IFormatterResolver
                 return;
             }
 
-            JsonTypeInfo<T> typeInfo = (JsonTypeInfo<T>)
-                ObsWebSocketJsonContext.Default.Options.GetTypeInfo(typeof(T));
+            JsonTypeInfo<T> typeInfo =
+                (JsonTypeInfo<T>)ObsWebSocketJsonContext.Default.Options.GetTypeInfo(typeof(T));
             string json = JsonSerializer.Serialize(value, typeInfo);
             byte[] raw = MessagePackSerializer.ConvertFromJson(json);
             writer.WriteRaw(raw);
@@ -104,8 +117,8 @@ internal sealed class MsgPackStubExtensionDataResolver : IFormatterResolver
             byte[] raw = ReadRawValue(ref reader);
             string json = MessagePackSerializer.ConvertToJson(raw);
 
-            JsonTypeInfo<T> typeInfo = (JsonTypeInfo<T>)
-                ObsWebSocketJsonContext.Default.Options.GetTypeInfo(typeof(T));
+            JsonTypeInfo<T> typeInfo =
+                (JsonTypeInfo<T>)ObsWebSocketJsonContext.Default.Options.GetTypeInfo(typeof(T));
             T? result = JsonSerializer.Deserialize(json, typeInfo);
 
             reader.Depth--;

--- a/ObsWebSocket.Core/Serialization/ObsWebSocketJsonContext.Settings.cs
+++ b/ObsWebSocket.Core/Serialization/ObsWebSocketJsonContext.Settings.cs
@@ -56,5 +56,6 @@ namespace ObsWebSocket.Core.Serialization;
 [JsonSerializable(typeof(RtmpCustomStreamServiceSettings))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
-    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+)]
 internal sealed partial class ObsWebSocketSettingsJsonContext : JsonSerializerContext { }

--- a/ObsWebSocket.Core/Serialization/SerializerLog.cs
+++ b/ObsWebSocket.Core/Serialization/SerializerLog.cs
@@ -8,36 +8,171 @@ namespace ObsWebSocket.Core.Serialization;
 /// <summary>Source-generated log messages for the message serializers.</summary>
 internal static partial class SerializerLog
 {
-    [LoggerMessage(EventId = 1, Level = LogLevel.Error, Message = "JSON serialization failed for message with OpCode {OpCode}")]
-    public static partial void LogJsonSerializationFailedForMessageWithOpcode(this ILogger logger, Exception exception, WebSocketOpCode opCode);
-    [LoggerMessage(EventId = 2, Level = LogLevel.Warning, Message = "Attempted to deserialize an empty message stream.")]
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Error,
+        Message = "JSON serialization failed for message with OpCode {OpCode}"
+    )]
+    public static partial void LogJsonSerializationFailedForMessageWithOpcode(
+        this ILogger logger,
+        Exception exception,
+        WebSocketOpCode opCode
+    );
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Warning,
+        Message = "Attempted to deserialize an empty message stream."
+    )]
     public static partial void LogAttemptedToDeserializeAnEmptyMessageStream(this ILogger logger);
-    [LoggerMessage(EventId = 3, Level = LogLevel.Warning, Message = "JSON deserialization resulted in null.")]
+
+    [LoggerMessage(
+        EventId = 3,
+        Level = LogLevel.Warning,
+        Message = "JSON deserialization resulted in null."
+    )]
     public static partial void LogJsonDeserializationResultedInNull(this ILogger logger);
-    [LoggerMessage(EventId = 4, Level = LogLevel.Trace, Message = "Deserialized JSON message: Op={Op}")]
-    public static partial void LogDeserializedJsonMessageOp(this ILogger logger, WebSocketOpCode op);
-    [LoggerMessage(EventId = 5, Level = LogLevel.Error, Message = "JSON deserialization failed. Raw JSON: {RawJson}")]
-    public static partial void LogJsonDeserializationFailedRawJson(this ILogger logger, Exception exception, string rawJson);
-    [LoggerMessage(EventId = 6, Level = LogLevel.Error, Message = "Failed to deserialize message from stream.")]
-    public static partial void LogFailedToDeserializeMessageFromStream(this ILogger logger, Exception exception);
-    [LoggerMessage(EventId = 7, Level = LogLevel.Warning, Message = "JSON Deserializer expected JsonElement payload but received {DataType} for {TargetType}.")]
-    public static partial void LogJsonDeserializerExpectedJsonelementPayloadButReceived(this ILogger logger, string? dataType, string targetType);
-    [LoggerMessage(EventId = 8, Level = LogLevel.Error, Message = "JSON failed to deserialize payload to {TargetType}. Raw JSON: {Json}")]
-    public static partial void LogJsonFailedToDeserializePayloadToRaw(this ILogger logger, Exception exception, string targetType, string json);
-    [LoggerMessage(EventId = 9, Level = LogLevel.Warning, Message = "JSON Deserializer expected JsonElement payload but received {DataType} for value type {TargetType}.")]
-    public static partial void LogJsonDeserializerExpectedJsonelementPayloadButReceived2(this ILogger logger, string? dataType, string targetType);
-    [LoggerMessage(EventId = 10, Level = LogLevel.Error, Message = "JSON failed to deserialize payload to value type {TargetType}. Raw JSON: {Json}")]
-    public static partial void LogJsonFailedToDeserializePayloadToValue(this ILogger logger, Exception exception, string targetType, string json);
-    [LoggerMessage(EventId = 11, Level = LogLevel.Error, Message = "MessagePack serialization failed for message with OpCode {OpCode}")]
-    public static partial void LogMessagepackSerializationFailedForMessageWithOpcode(this ILogger logger, Exception exception, WebSocketOpCode opCode);
-    [LoggerMessage(EventId = 12, Level = LogLevel.Error, Message = "Unexpected error during MessagePack serialization for OpCode {OpCode}")]
-    public static partial void LogUnexpectedErrorDuringMessagepackSerializationForOpcode(this ILogger logger, Exception exception, WebSocketOpCode opCode);
-    [LoggerMessage(EventId = 13, Level = LogLevel.Trace, Message = "Deserialized MessagePack message: Op={Op}")]
-    public static partial void LogDeserializedMessagepackMessageOp(this ILogger logger, WebSocketOpCode op);
-    [LoggerMessage(EventId = 14, Level = LogLevel.Error, Message = "MessagePack deserialization failed.")]
-    public static partial void LogMessagepackDeserializationFailed(this ILogger logger, Exception exception);
-    [LoggerMessage(EventId = 15, Level = LogLevel.Error, Message = "MessagePack failed to deserialize payload object to {TargetType}. Object Type: {ObjectType}")]
-    public static partial void LogMessagepackFailedToDeserializePayloadObjectTo(this ILogger logger, Exception exception, string targetType, string objectType);
-    [LoggerMessage(EventId = 16, Level = LogLevel.Error, Message = "MessagePack failed to deserialize payload object to value type {TargetType}. Object Type: {ObjectType}")]
-    public static partial void LogMessagepackFailedToDeserializePayloadObjectTo2(this ILogger logger, Exception exception, string targetType, string objectType);
+
+    [LoggerMessage(
+        EventId = 4,
+        Level = LogLevel.Trace,
+        Message = "Deserialized JSON message: Op={Op}"
+    )]
+    public static partial void LogDeserializedJsonMessageOp(
+        this ILogger logger,
+        WebSocketOpCode op
+    );
+
+    [LoggerMessage(
+        EventId = 5,
+        Level = LogLevel.Error,
+        Message = "JSON deserialization failed. Raw JSON: {RawJson}"
+    )]
+    public static partial void LogJsonDeserializationFailedRawJson(
+        this ILogger logger,
+        Exception exception,
+        string rawJson
+    );
+
+    [LoggerMessage(
+        EventId = 6,
+        Level = LogLevel.Error,
+        Message = "Failed to deserialize message from stream."
+    )]
+    public static partial void LogFailedToDeserializeMessageFromStream(
+        this ILogger logger,
+        Exception exception
+    );
+
+    [LoggerMessage(
+        EventId = 7,
+        Level = LogLevel.Warning,
+        Message = "JSON Deserializer expected JsonElement payload but received {DataType} for {TargetType}."
+    )]
+    public static partial void LogJsonDeserializerExpectedJsonelementPayloadButReceived(
+        this ILogger logger,
+        string? dataType,
+        string targetType
+    );
+
+    [LoggerMessage(
+        EventId = 8,
+        Level = LogLevel.Error,
+        Message = "JSON failed to deserialize payload to {TargetType}. Raw JSON: {Json}"
+    )]
+    public static partial void LogJsonFailedToDeserializePayloadToRaw(
+        this ILogger logger,
+        Exception exception,
+        string targetType,
+        string json
+    );
+
+    [LoggerMessage(
+        EventId = 9,
+        Level = LogLevel.Warning,
+        Message = "JSON Deserializer expected JsonElement payload but received {DataType} for value type {TargetType}."
+    )]
+    public static partial void LogJsonDeserializerExpectedJsonelementPayloadButReceived2(
+        this ILogger logger,
+        string? dataType,
+        string targetType
+    );
+
+    [LoggerMessage(
+        EventId = 10,
+        Level = LogLevel.Error,
+        Message = "JSON failed to deserialize payload to value type {TargetType}. Raw JSON: {Json}"
+    )]
+    public static partial void LogJsonFailedToDeserializePayloadToValue(
+        this ILogger logger,
+        Exception exception,
+        string targetType,
+        string json
+    );
+
+    [LoggerMessage(
+        EventId = 11,
+        Level = LogLevel.Error,
+        Message = "MessagePack serialization failed for message with OpCode {OpCode}"
+    )]
+    public static partial void LogMessagepackSerializationFailedForMessageWithOpcode(
+        this ILogger logger,
+        Exception exception,
+        WebSocketOpCode opCode
+    );
+
+    [LoggerMessage(
+        EventId = 12,
+        Level = LogLevel.Error,
+        Message = "Unexpected error during MessagePack serialization for OpCode {OpCode}"
+    )]
+    public static partial void LogUnexpectedErrorDuringMessagepackSerializationForOpcode(
+        this ILogger logger,
+        Exception exception,
+        WebSocketOpCode opCode
+    );
+
+    [LoggerMessage(
+        EventId = 13,
+        Level = LogLevel.Trace,
+        Message = "Deserialized MessagePack message: Op={Op}"
+    )]
+    public static partial void LogDeserializedMessagepackMessageOp(
+        this ILogger logger,
+        WebSocketOpCode op
+    );
+
+    [LoggerMessage(
+        EventId = 14,
+        Level = LogLevel.Error,
+        Message = "MessagePack deserialization failed."
+    )]
+    public static partial void LogMessagepackDeserializationFailed(
+        this ILogger logger,
+        Exception exception
+    );
+
+    [LoggerMessage(
+        EventId = 15,
+        Level = LogLevel.Error,
+        Message = "MessagePack failed to deserialize payload object to {TargetType}. Object Type: {ObjectType}"
+    )]
+    public static partial void LogMessagepackFailedToDeserializePayloadObjectTo(
+        this ILogger logger,
+        Exception exception,
+        string targetType,
+        string objectType
+    );
+
+    [LoggerMessage(
+        EventId = 16,
+        Level = LogLevel.Error,
+        Message = "MessagePack failed to deserialize payload object to value type {TargetType}. Object Type: {ObjectType}"
+    )]
+    public static partial void LogMessagepackFailedToDeserializePayloadObjectTo2(
+        this ILogger logger,
+        Exception exception,
+        string targetType,
+        string objectType
+    );
 }

--- a/ObsWebSocket.Example/ObsWebSocket.Example.csproj
+++ b/ObsWebSocket.Example/ObsWebSocket.Example.csproj
@@ -7,7 +7,8 @@
     <PublishAot>true</PublishAot>
     <!-- PublishAot puts the runtime pack in the dependency graph, where the SDK baseline resolves to
          an unpatched 10.0.x. Pin the patched one so security scanning sees what actually ships. -->
-    <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'net10.0'">10.0.11</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'net10.0'"
+      >10.0.11</RuntimeFrameworkVersion>
     <IsAotCompatible>true</IsAotCompatible>
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>

--- a/ObsWebSocket.Example/Program.cs
+++ b/ObsWebSocket.Example/Program.cs
@@ -7,12 +7,7 @@ using ObsWebSocket.Example;
 using Spectre.Console;
 
 HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
-AnsiConsole.Write(
-    new Rule("[cyan]ObsWebSocket Example Tool[/]")
-    {
-        Justification = Justify.Left,
-    }
-);
+AnsiConsole.Write(new Rule("[cyan]ObsWebSocket Example Tool[/]") { Justification = Justify.Left });
 
 // Reads appsettings.json, environment variables, command-line args
 builder

--- a/ObsWebSocket.Example/Program.cs
+++ b/ObsWebSocket.Example/Program.cs
@@ -34,8 +34,7 @@ builder.Services.AddSingleton(
 // Add the ObsWebSocketClient and its dependencies. The Worker drives the connection itself so
 // that it can demonstrate connect and disconnect, which is why WithAutoConnect is not used here;
 // an ordinary application would call it and skip the ceremony.
-builder.Services.AddObsWebSocketClient();
-builder.Services.AddHealthChecks().AddObsWebSocket();
+builder.Services.AddObsWebSocketClient().WithHealthCheck();
 
 // Add our background service
 builder.Services.AddHostedService<Worker>();

--- a/ObsWebSocket.Example/Worker.cs
+++ b/ObsWebSocket.Example/Worker.cs
@@ -345,7 +345,7 @@ internal sealed partial class Worker(
                 try
                 {
                     // First, find the scene item ID within the specified scene
-                    double sceneItemId = await GetSceneItemIdAsync(
+                    int sceneItemId = await GetSceneItemIdAsync(
                         sceneForGetSettings,
                         inputForGetSettings,
                         cancellationToken
@@ -392,7 +392,7 @@ internal sealed partial class Worker(
                 try
                 {
                     // Find the scene item ID first (optional but good practice)
-                    double sceneItemId = await GetSceneItemIdAsync(
+                    int sceneItemId = await GetSceneItemIdAsync(
                         sceneForSetText,
                         inputForSetText,
                         cancellationToken
@@ -2207,44 +2207,48 @@ internal sealed partial class Worker(
                     .ConfigureAwait(false)
             );
 
-            results.Add(
-                await TrySettingsCheckAsync(
-                        "Virtual camera toggle",
-                        async () =>
-                        {
-                            bool before = await client
-                                .Outputs.IsVirtualCamActiveAsync(cancellationToken)
-                                .ConfigureAwait(false);
+            // Disabled: toggling the virtual camera takes down this OBS install. The fault is in
+            // the Stream Deck plugin (streamdeckpluginobs32.dll appears at the fault address and
+            // in every frame above it), not in OBS or in this library. Re-enable once that plugin
+            // is removed.
+            // results.Add(
+            // await TrySettingsCheckAsync(
+            // "Virtual camera toggle",
+            // async () =>
+            // {
+            // bool before = await client
+            // .Outputs.IsVirtualCamActiveAsync(cancellationToken)
+            // .ConfigureAwait(false);
 
-                            bool? turnedOn = await client
-                                .Outputs.SetVirtualCamActiveAndWaitAsync(
-                                    !before,
-                                    cancellationToken: cancellationToken
-                                )
-                                .ConfigureAwait(false);
-                            bool observed = await client
-                                .Outputs.IsVirtualCamActiveAsync(cancellationToken)
-                                .ConfigureAwait(false);
+            // bool? turnedOn = await client
+            // .Outputs.SetVirtualCamActiveAndWaitAsync(
+            // !before,
+            // cancellationToken: cancellationToken
+            // )
+            // .ConfigureAwait(false);
+            // bool observed = await client
+            // .Outputs.IsVirtualCamActiveAsync(cancellationToken)
+            // .ConfigureAwait(false);
 
-                            // Put it back the way it was found.
-                            _ = await client
-                                .Outputs.SetVirtualCamActiveAndWaitAsync(
-                                    before,
-                                    cancellationToken: cancellationToken
-                                )
-                                .ConfigureAwait(false);
-                            bool restored = await client
-                                .Outputs.IsVirtualCamActiveAsync(cancellationToken)
-                                .ConfigureAwait(false);
+            // // Put it back the way it was found.
+            // _ = await client
+            // .Outputs.SetVirtualCamActiveAndWaitAsync(
+            // before,
+            // cancellationToken: cancellationToken
+            // )
+            // .ConfigureAwait(false);
+            // bool restored = await client
+            // .Outputs.IsVirtualCamActiveAsync(cancellationToken)
+            // .ConfigureAwait(false);
 
-                            return (
-                                turnedOn == !before && observed == !before && restored == before,
-                                $"{before} -> {observed} -> {restored}"
-                            );
-                        }
-                    )
-                    .ConfigureAwait(false)
-            );
+            // return (
+            // turnedOn == !before && observed == !before && restored == before,
+            // $"{before} -> {observed} -> {restored}"
+            // );
+            // }
+            // )
+            // .ConfigureAwait(false)
+            // );
 
             results.Add(
                 await TrySettingsCheckAsync(
@@ -2593,7 +2597,7 @@ internal sealed partial class Worker(
         };
 
     // --- Helper to find Scene Item ID ---
-    private async Task<double> GetSceneItemIdAsync(
+    private async Task<int> GetSceneItemIdAsync(
         string sceneName,
         string sourceName,
         CancellationToken cancellationToken
@@ -2989,7 +2993,7 @@ internal sealed partial class Worker(
             RestartWhenActive: true
         );
 
-        double sceneItemId;
+        int sceneItemId;
 
         // Step 8: Create new input or update existing source settings
         if (isNewSource)

--- a/ObsWebSocket.Example/Worker.cs
+++ b/ObsWebSocket.Example/Worker.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -16,7 +17,6 @@ using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
 using ObsWebSocket.Core.Protocol.Requests;
 using ObsWebSocket.Core.Protocol.Responses;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
 using ObsWebSocket.Core.Serialization;
 using Spectre.Console;
 
@@ -89,10 +89,7 @@ internal sealed partial class Worker(
             )
             {
                 string startupCommand = _startupCommandOptions.Command!;
-                _logger.LogInformation(
-                    "Running startup command: {Command}",
-                    startupCommand
-                );
+                _logger.LogInformation("Running startup command: {Command}", startupCommand);
                 _ = await ProcessCommandAsync(
                         startupCommand,
                         _startupCommandOptions.Arguments,
@@ -112,10 +109,7 @@ internal sealed partial class Worker(
                 if (!string.IsNullOrWhiteSpace(_startupCommandOptions.Command))
                 {
                     string startupCommand = _startupCommandOptions.Command!;
-                    _logger.LogInformation(
-                        "Running startup command: {Command}",
-                        startupCommand
-                    );
+                    _logger.LogInformation("Running startup command: {Command}", startupCommand);
                     _ = await ProcessCommandAsync(
                             startupCommand,
                             _startupCommandOptions.Arguments,
@@ -322,10 +316,11 @@ internal sealed partial class Worker(
 
                 string inputNameToMute = string.Join(" ", args);
                 _logger.LogInformation("Toggling mute for input: {InputName}", inputNameToMute);
-                ToggleInputMuteResponseData? muteState = await _obsClient.Inputs.ToggleInputMuteAsync(
-                    new ToggleInputMuteRequestData(inputNameToMute),
-                    cancellationToken: cancellationToken
-                );
+                ToggleInputMuteResponseData? muteState =
+                    await _obsClient.Inputs.ToggleInputMuteAsync(
+                        new ToggleInputMuteRequestData(inputNameToMute),
+                        cancellationToken: cancellationToken
+                    );
                 if (muteState is null)
                 {
                     UiWarn($"Could not toggle mute state for {inputNameToMute}. Does it exist?");
@@ -357,9 +352,11 @@ internal sealed partial class Worker(
                     );
 
                     // Now get the input settings using the *source name* (not the scene item ID)
-                    GetInputSettingsResponseData? settings = await _obsClient.Inputs.GetInputSettingsAsync(new GetInputSettingsRequestData(inputForGetSettings),
-                        cancellationToken: cancellationToken
-                    );
+                    GetInputSettingsResponseData? settings =
+                        await _obsClient.Inputs.GetInputSettingsAsync(
+                            new GetInputSettingsRequestData(inputForGetSettings),
+                            cancellationToken: cancellationToken
+                        );
 
                     if (settings?.InputSettings is JsonElement inputSettingsElement)
                     {
@@ -385,9 +382,7 @@ internal sealed partial class Worker(
             case "set-text":
                 if (args.Length < 3)
                 {
-                    UiWarn(
-                        "Usage: set-text [scene name] [text source name] [new text...]"
-                    );
+                    UiWarn("Usage: set-text [scene name] [text source name] [new text...]");
                     return false;
                 }
 
@@ -410,7 +405,11 @@ internal sealed partial class Worker(
                     );
 
                     // Uses SetInputTextAsync helper which serializes TextGdiPlusInputSettings internally.
-                    await _obsClient.Inputs.SetInputTextAsync(inputForSetText, newText, cancellationToken);
+                    await _obsClient.Inputs.SetInputTextAsync(
+                        inputForSetText,
+                        newText,
+                        cancellationToken
+                    );
                     UiSuccess($"Successfully set text for '{inputForSetText}' to: '{newText}'");
                 }
                 catch (SceneItemNotFoundException ex)
@@ -445,7 +444,10 @@ internal sealed partial class Worker(
                     );
                 if (filterList?.Filters is not null && filterList.Filters.Count > 0)
                 {
-                    Table table = new() { Title = new TableTitle($"Filters for '{sourceForFilters}'") };
+                    Table table = new()
+                    {
+                        Title = new TableTitle($"Filters for '{sourceForFilters}'"),
+                    };
                     _ = table.AddColumn("Index");
                     _ = table.AddColumn("Name");
                     _ = table.AddColumn("Kind");
@@ -453,8 +455,10 @@ internal sealed partial class Worker(
                     foreach (Core.Protocol.Common.FilterStub filterElement in filterList.Filters)
                     {
                         string filterIndex = filterElement.FilterIndex?.ToString() ?? "N/A";
-                        string filterName = Markup.Escape(filterElement.FilterName ?? "N/A") ?? "N/A";
-                        string filterKind = Markup.Escape(filterElement.FilterKind ?? "N/A") ?? "N/A";
+                        string filterName =
+                            Markup.Escape(filterElement.FilterName ?? "N/A") ?? "N/A";
+                        string filterKind =
+                            Markup.Escape(filterElement.FilterKind ?? "N/A") ?? "N/A";
                         _ = table.AddRow(
                             filterIndex,
                             filterName,
@@ -523,12 +527,12 @@ internal sealed partial class Worker(
                 // Streams are the ergonomic way to observe events: subscribe for the lifetime
                 // of the loop, no handler bookkeeping, and cancellation ends it cleanly. The
                 // classic events on the client are untouched and still work alongside this.
-                int seconds = args.Length > 0 && int.TryParse(args[0], out int parsed) ? parsed : 15;
+                int seconds =
+                    args.Length > 0 && int.TryParse(args[0], out int parsed) ? parsed : 15;
                 UiInfo($"Watching scene changes for {seconds}s. Switch scenes in OBS.");
 
-                using CancellationTokenSource watchCts = CancellationTokenSource.CreateLinkedTokenSource(
-                    cancellationToken
-                );
+                using CancellationTokenSource watchCts =
+                    CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 watchCts.CancelAfter(TimeSpan.FromSeconds(seconds));
 
                 try
@@ -574,7 +578,9 @@ internal sealed partial class Worker(
                 ObsBatchBuilder exampleBatch = new();
                 _ = exampleBatch.General.GetVersion();
                 _ = exampleBatch.Scenes.GetCurrentProgramScene();
-                _ = exampleBatch.Inputs.GetInputList(new GetInputListRequestData("text_gdiplus_v3"));
+                _ = exampleBatch.Inputs.GetInputList(
+                    new GetInputListRequestData("text_gdiplus_v3")
+                );
                 _ = exampleBatch.General.Sleep(new SleepRequestData(sleepMillis: 100));
                 _ = exampleBatch.Inputs.SetInputSettings(
                     new SetInputSettingsRequestData(
@@ -587,14 +593,19 @@ internal sealed partial class Worker(
                 // Add remains for anything the generated methods do not cover.
                 _ = exampleBatch.Add("GetStats");
 
-                List<RequestResponsePayload<object>> batchResults = (await _obsClient.CallBatchAsync(
-                    exampleBatch,
-                    executionType: RequestBatchExecutionType.SerialRealtime,
-                    haltOnFailure: false, // Continue even if one fails
-                    cancellationToken: cancellationToken
-                )).Raw.ToList();
+                List<RequestResponsePayload<object>> batchResults = (
+                    await _obsClient.CallBatchAsync(
+                        exampleBatch,
+                        executionType: RequestBatchExecutionType.SerialRealtime,
+                        haltOnFailure: false, // Continue even if one fails
+                        cancellationToken: cancellationToken
+                    )
+                ).Raw.ToList();
 
-                Table batchTable = new() { Title = new TableTitle($"Batch Results ({batchResults.Count} items)") };
+                Table batchTable = new()
+                {
+                    Title = new TableTitle($"Batch Results ({batchResults.Count} items)"),
+                };
                 _ = batchTable.AddColumn("Request");
                 _ = batchTable.AddColumn("Status");
                 _ = batchTable.AddColumn("Code");
@@ -602,7 +613,9 @@ internal sealed partial class Worker(
                 foreach (RequestResponsePayload<object> result in batchResults)
                 {
                     string shortId = result.RequestId[(result.RequestId.LastIndexOf('_') + 1)..];
-                    string status = result.RequestStatus.Result ? "[green]Success[/]" : "[red]Failed[/]";
+                    string status = result.RequestStatus.Result
+                        ? "[green]Success[/]"
+                        : "[red]Failed[/]";
                     string details = string.Empty;
                     if (!result.RequestStatus.Result)
                     {
@@ -613,10 +626,9 @@ internal sealed partial class Worker(
                         string responseJson = "Could not serialize response data";
                         try
                         {
-                            responseJson =
-                                result.ResponseData is JsonElement jsonElement
-                                    ? jsonElement.GetRawText()
-                                    : result.ResponseData.ToString() ?? string.Empty;
+                            responseJson = result.ResponseData is JsonElement jsonElement
+                                ? jsonElement.GetRawText()
+                                : result.ResponseData.ToString() ?? string.Empty;
                         }
                         catch
                         { /* Ignore serialization errors for logging */
@@ -653,10 +665,7 @@ internal sealed partial class Worker(
                             "Current Intended Flags",
                             $"{_currentSubscriptionFlags} ({(EventSubscription)_currentSubscriptionFlags})"
                         ),
-                        (
-                            "Note",
-                            "Reflects last requested flags, not server-acknowledged state."
-                        ),
+                        ("Note", "Reflects last requested flags, not server-acknowledged state."),
                     ]
                 );
                 return false;
@@ -664,8 +673,11 @@ internal sealed partial class Worker(
             case "media":
             {
                 // Typed enum rather than a protocol string constant.
-                if (args.Length < 2 || MediaInputActionExtensions.FromWireValue(args[1]) is null
-                    && !Enum.TryParse(args[1], ignoreCase: true, out MediaInputAction _))
+                if (
+                    args.Length < 2
+                    || MediaInputActionExtensions.FromWireValue(args[1]) is null
+                        && !Enum.TryParse(args[1], ignoreCase: true, out MediaInputAction _)
+                )
                 {
                     UiWarn("Usage: media <inputName> <play|pause|stop|restart|next|previous>");
                     return false;
@@ -679,13 +691,19 @@ internal sealed partial class Worker(
 
                 try
                 {
-                    await _obsClient.MediaInputs.TriggerMediaActionAsync(args[0], action, cancellationToken);
+                    await _obsClient.MediaInputs.TriggerMediaActionAsync(
+                        args[0],
+                        action,
+                        cancellationToken
+                    );
                     UiSuccess($"Sent {action} ({action.ToWireValue()}) to '{args[0]}'.");
                 }
                 catch (ObsWebSocketRequestException ex)
                 {
                     // Typed failure carries the protocol status, so no message matching.
-                    UiWarn($"OBS rejected {ex.RequestType} with code {ex.Status?.Code}: {ex.Comment}");
+                    UiWarn(
+                        $"OBS rejected {ex.RequestType} with code {ex.Status?.Code}: {ex.Comment}"
+                    );
                 }
 
                 return false;
@@ -695,12 +713,8 @@ internal sealed partial class Worker(
                 if (args.Length == 0 || !uint.TryParse(args[0], out uint newFlags))
                 {
                     UiWarn("Usage: set-subs <numeric_flags>");
-                    UiInfo(
-                        "Example: set-subs 65 (General | Scenes | Inputs, 1 | 4 | 8 = 13)"
-                    );
-                    UiInfo(
-                        "See ObsWebSocket.Core.Protocol.Generated.EventSubscription for flags."
-                    );
+                    UiInfo("Example: set-subs 65 (General | Scenes | Inputs, 1 | 4 | 8 = 13)");
+                    UiInfo("See ObsWebSocket.Core.Protocol.Generated.EventSubscription for flags.");
                     return false;
                 }
 
@@ -709,10 +723,7 @@ internal sealed partial class Worker(
                     newFlags,
                     (EventSubscription)newFlags
                 );
-                await _obsClient.ReidentifyAsync(
-                    newFlags,
-                    cancellationToken: cancellationToken
-                );
+                await _obsClient.ReidentifyAsync(newFlags, cancellationToken: cancellationToken);
                 _currentSubscriptionFlags = (EventSubscription)newFlags;
                 UiSuccess(
                     $"Re-identified successfully. Intended subscriptions set to: {_currentSubscriptionFlags}"
@@ -737,10 +748,7 @@ internal sealed partial class Worker(
     private async Task RunTransportValidationSuiteAsync(CancellationToken cancellationToken)
     {
         int iterations = Math.Max(1, _validationOptions.ValidationIterations);
-        Rule rule = new("[cyan]Transport Validation[/]")
-        {
-            Justification = Justify.Left
-        };
+        Rule rule = new("[cyan]Transport Validation[/]") { Justification = Justify.Left };
         AnsiConsole.Write(rule);
         for (int i = 0; i < iterations; i++)
         {
@@ -804,9 +812,7 @@ internal sealed partial class Worker(
                 .ConfigureAwait(false);
             if (scenes?.Scenes is null || scenes.Scenes.Count == 0)
             {
-                throw new InvalidOperationException(
-                    $"[{format}] GetSceneList returned no scenes."
-                );
+                throw new InvalidOperationException($"[{format}] GetSceneList returned no scenes.");
             }
 
             _logger.LogInformation(
@@ -821,9 +827,7 @@ internal sealed partial class Worker(
                 .ConfigureAwait(false);
             if (inputs?.Inputs is null || inputs.Inputs.Count == 0)
             {
-                throw new InvalidOperationException(
-                    $"[{format}] GetInputList returned no inputs."
-                );
+                throw new InvalidOperationException($"[{format}] GetInputList returned no inputs.");
             }
 
             _logger.LogInformation(
@@ -899,13 +903,12 @@ internal sealed partial class Worker(
                 )
                 .RootElement.Clone();
 
-            Task<CustomEventEventArgs> waitForCustomEvent = cycleClient.WaitForEventAsync<
-                CustomEventEventArgs
-            >(
-                predicate: _ => true,
-                timeout: TimeSpan.FromSeconds(2),
-                cancellationToken: cancellationToken
-            );
+            Task<CustomEventEventArgs> waitForCustomEvent =
+                cycleClient.WaitForEventAsync<CustomEventEventArgs>(
+                    predicate: _ => true,
+                    timeout: TimeSpan.FromSeconds(2),
+                    cancellationToken: cancellationToken
+                );
 
             await cycleClient
                 .General.BroadcastCustomEventAsync(
@@ -933,7 +936,8 @@ internal sealed partial class Worker(
                 )
                 && actualCustomData.GetProperty("testId").GetString() == testId
                 && actualCustomData.GetProperty("nested").GetProperty("enabled").GetBoolean()
-                && actualCustomData.GetProperty("nested").GetProperty("levels").GetArrayLength() == 3
+                && actualCustomData.GetProperty("nested").GetProperty("levels").GetArrayLength()
+                    == 3
             )
             {
                 customEventVerified = true;
@@ -967,14 +971,19 @@ internal sealed partial class Worker(
                 );
             }
 
-            _logger.LogInformation("[{Format}] Batch call results: {ResultCount}", format, batch.Count);
+            _logger.LogInformation(
+                "[{Format}] Batch call results: {ResultCount}",
+                format,
+                batch.Count
+            );
 
             List<(string Label, bool Pass, string Detail)> settingsResults =
                 await ValidateSettingsModesAsync(cycleClient, inputs, cancellationToken)
                     .ConfigureAwait(false);
 
             List<(string Label, bool Pass, string Detail)> modernResults =
-                await ValidateModernApisAsync(cycleClient, healthChecks, cancellationToken).ConfigureAwait(false);
+                await ValidateModernApisAsync(cycleClient, healthChecks, cancellationToken)
+                    .ConfigureAwait(false);
 
             Table summary = new() { Title = new TableTitle($"{format} Validation Summary") };
             _ = summary.AddColumn("Check");
@@ -991,7 +1000,10 @@ internal sealed partial class Worker(
                     ? $"[green]Pass[/] ({extensionBagCount} bag(s), {extensionEntryCount} entries)"
                     : "[yellow]Unverified[/]"
             );
-            _ = summary.AddRow("CustomEvent", customEventVerified ? "[green]Pass[/]" : "[yellow]Unverified[/]");
+            _ = summary.AddRow(
+                "CustomEvent",
+                customEventVerified ? "[green]Pass[/]" : "[yellow]Unverified[/]"
+            );
             _ = summary.AddRow("Batch", $"{batch.Count} result(s)");
             foreach ((string label, bool pass, string detail) in settingsResults)
             {
@@ -1017,7 +1029,8 @@ internal sealed partial class Worker(
         {
             if (cycleClient.IsConnected)
             {
-                await cycleClient.DisconnectAsync(cancellationToken: CancellationToken.None)
+                await cycleClient
+                    .DisconnectAsync(cancellationToken: CancellationToken.None)
                     .ConfigureAwait(false);
             }
         }
@@ -1028,10 +1041,13 @@ internal sealed partial class Worker(
     /// All operations are read-then-write-back (overlay:true) so they are non-destructive.
     /// Requires at least one browser_source and one input with a gain_filter in OBS.
     /// </summary>
-    private static async Task<List<(string Label, bool Pass, string Detail)>> ValidateSettingsModesAsync(
+    private static async Task<
+        List<(string Label, bool Pass, string Detail)>
+    > ValidateSettingsModesAsync(
         ObsWebSocketClient client,
         GetInputListResponseData? inputs,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken
+    )
     {
         List<(string Label, bool Pass, string Detail)> results = [];
         if (inputs is null)
@@ -1041,72 +1057,130 @@ internal sealed partial class Worker(
         }
 
         // ── InputSettings ─────────────────────────────────────────────────────
-        string? browserInputName = inputs.Inputs
-            ?.FirstOrDefault(i => string.Equals(i.InputKind, "browser_source", StringComparison.OrdinalIgnoreCase))
+        string? browserInputName = inputs
+            .Inputs?.FirstOrDefault(i =>
+                string.Equals(i.InputKind, "browser_source", StringComparison.OrdinalIgnoreCase)
+            )
             ?.InputName;
 
         if (string.IsNullOrEmpty(browserInputName))
         {
-            results.Add(("InputSettings [all modes]", false, "No browser_source in OBS — add one to test"));
+            results.Add(
+                ("InputSettings [all modes]", false, "No browser_source in OBS — add one to test")
+            );
         }
         else
         {
             // Mode 1: raw JsonElement via protocol-level call
-            results.Add(await TrySettingsCheckAsync("InputSettings Mode1 (raw JsonElement)", async () =>
-            {
-                GetInputSettingsResponseData? r = await client.Inputs.GetInputSettingsAsync(new GetInputSettingsRequestData(browserInputName), cancellationToken);
-                if (r?.InputSettings is not JsonElement el)
-                {
-                    return (false, "null InputSettings in response");
-                }
+            results.Add(
+                await TrySettingsCheckAsync(
+                    "InputSettings Mode1 (raw JsonElement)",
+                    async () =>
+                    {
+                        GetInputSettingsResponseData? r = await client.Inputs.GetInputSettingsAsync(
+                            new GetInputSettingsRequestData(browserInputName),
+                            cancellationToken
+                        );
+                        if (r?.InputSettings is not JsonElement el)
+                        {
+                            return (false, "null InputSettings in response");
+                        }
 
-                await client.Inputs.SetInputSettingsAsync(new SetInputSettingsRequestData(el, inputName: browserInputName, overlay: true),
-                    cancellationToken);
-                string url = el.TryGetProperty("url", out JsonElement p) ? p.GetString() ?? "(no url)" : "(no url key)";
-                return (true, $"'{browserInputName}' url={url}");
-            }));
+                        await client.Inputs.SetInputSettingsAsync(
+                            new SetInputSettingsRequestData(
+                                el,
+                                inputName: browserInputName,
+                                overlay: true
+                            ),
+                            cancellationToken
+                        );
+                        string url = el.TryGetProperty("url", out JsonElement p)
+                            ? p.GetString() ?? "(no url)"
+                            : "(no url key)";
+                        return (true, $"'{browserInputName}' url={url}");
+                    }
+                )
+            );
 
             // Mode 2: library-registered type via implicit GetTypeInfo lookup
-            results.Add(await TrySettingsCheckAsync("InputSettings Mode2 (BrowserSourceSettings)", async () =>
-            {
-                BrowserSourceSettings? s = await client.Inputs.GetInputSettingsAsync<BrowserSourceSettings>(
-                    browserInputName, cancellationToken);
-                if (s is null)
-                {
-                    return (false, "null result");
-                }
+            results.Add(
+                await TrySettingsCheckAsync(
+                    "InputSettings Mode2 (BrowserSourceSettings)",
+                    async () =>
+                    {
+                        BrowserSourceSettings? s =
+                            await client.Inputs.GetInputSettingsAsync<BrowserSourceSettings>(
+                                browserInputName,
+                                cancellationToken
+                            );
+                        if (s is null)
+                        {
+                            return (false, "null result");
+                        }
 
-                await client.Inputs.SetInputSettingsAsync(browserInputName, s, overlay: true, cancellationToken: cancellationToken);
-                return (true, $"'{browserInputName}' url={s.Url ?? "(null)"}");
-            }));
+                        await client.Inputs.SetInputSettingsAsync(
+                            browserInputName,
+                            s,
+                            overlay: true,
+                            cancellationToken: cancellationToken
+                        );
+                        return (true, $"'{browserInputName}' url={s.Url ?? "(null)"}");
+                    }
+                )
+            );
 
             // Mode 3: consumer-defined type with explicit JsonTypeInfo<T>
-            results.Add(await TrySettingsCheckAsync("InputSettings Mode3 (consumer JsonTypeInfo)", async () =>
-            {
-                JsonTypeInfo<WorkerBrowserUrlSettings> typeInfo = WorkerSettingsJsonContext.Default.WorkerBrowserUrlSettings;
-                WorkerBrowserUrlSettings? s = await client.Inputs.GetInputSettingsAsync(browserInputName, typeInfo, cancellationToken);
-                if (s is null)
-                {
-                    return (false, "null result");
-                }
+            results.Add(
+                await TrySettingsCheckAsync(
+                    "InputSettings Mode3 (consumer JsonTypeInfo)",
+                    async () =>
+                    {
+                        JsonTypeInfo<WorkerBrowserUrlSettings> typeInfo = WorkerSettingsJsonContext
+                            .Default
+                            .WorkerBrowserUrlSettings;
+                        WorkerBrowserUrlSettings? s = await client.Inputs.GetInputSettingsAsync(
+                            browserInputName,
+                            typeInfo,
+                            cancellationToken
+                        );
+                        if (s is null)
+                        {
+                            return (false, "null result");
+                        }
 
-                await client.Inputs.SetInputSettingsAsync(browserInputName, s, typeInfo, overlay: true, cancellationToken: cancellationToken);
-                return (true, $"'{browserInputName}' url={s.Url ?? "(null)"}");
-            }));
+                        await client.Inputs.SetInputSettingsAsync(
+                            browserInputName,
+                            s,
+                            typeInfo,
+                            overlay: true,
+                            cancellationToken: cancellationToken
+                        );
+                        return (true, $"'{browserInputName}' url={s.Url ?? "(null)"}");
+                    }
+                )
+            );
         }
 
         // ── FilterSettings ────────────────────────────────────────────────────
         // Find first gain_filter across the first 5 inputs.
         string? filterSourceName = null;
         string? gainFilterName = null;
-        foreach (Core.Protocol.Common.InputStub input in inputs.Inputs?.Where(i => !string.IsNullOrEmpty(i.InputName)).Take(5) ?? [])
+        foreach (
+            Core.Protocol.Common.InputStub input in inputs
+                .Inputs?.Where(i => !string.IsNullOrEmpty(i.InputName))
+                .Take(5)
+                ?? []
+        )
         {
             try
             {
                 GetSourceFilterListResponseData? fl = await client.Filters.GetSourceFilterListAsync(
-                    new GetSourceFilterListRequestData(sourceName: input.InputName!), cancellationToken);
+                    new GetSourceFilterListRequestData(sourceName: input.InputName!),
+                    cancellationToken
+                );
                 Core.Protocol.Common.FilterStub? gain = fl?.Filters?.FirstOrDefault(f =>
-                    string.Equals(f.FilterKind, "gain_filter", StringComparison.OrdinalIgnoreCase));
+                    string.Equals(f.FilterKind, "gain_filter", StringComparison.OrdinalIgnoreCase)
+                );
                 if (gain?.FilterName is not null)
                 {
                     filterSourceName = input.InputName;
@@ -1114,60 +1188,126 @@ internal sealed partial class Worker(
                     break;
                 }
             }
-            catch { /* skip inputs we can't query */ }
+            catch
+            { /* skip inputs we can't query */
+            }
         }
 
         if (string.IsNullOrEmpty(filterSourceName) || string.IsNullOrEmpty(gainFilterName))
         {
-            results.Add(("FilterSettings [all modes]", false, "No gain_filter found — add one to an input in OBS"));
+            results.Add(
+                (
+                    "FilterSettings [all modes]",
+                    false,
+                    "No gain_filter found — add one to an input in OBS"
+                )
+            );
         }
         else
         {
             // Mode 1: raw JsonElement via protocol-level call
-            results.Add(await TrySettingsCheckAsync("FilterSettings Mode1 (raw JsonElement)", async () =>
-            {
-                GetSourceFilterResponseData? r = await client.Filters.GetSourceFilterAsync(
-                    new GetSourceFilterRequestData { SourceName = filterSourceName, FilterName = gainFilterName },
-                    cancellationToken);
-                if (r?.FilterSettings is not JsonElement el)
-                {
-                    return (false, "null FilterSettings in response");
-                }
+            results.Add(
+                await TrySettingsCheckAsync(
+                    "FilterSettings Mode1 (raw JsonElement)",
+                    async () =>
+                    {
+                        GetSourceFilterResponseData? r = await client.Filters.GetSourceFilterAsync(
+                            new GetSourceFilterRequestData
+                            {
+                                SourceName = filterSourceName,
+                                FilterName = gainFilterName,
+                            },
+                            cancellationToken
+                        );
+                        if (r?.FilterSettings is not JsonElement el)
+                        {
+                            return (false, "null FilterSettings in response");
+                        }
 
-                await client.Filters.SetSourceFilterSettingsAsync(new SetSourceFilterSettingsRequestData(gainFilterName, el, sourceName: filterSourceName, overlay: true),
-                    cancellationToken);
-                string db = el.TryGetProperty("db", out JsonElement p) ? p.GetDouble().ToString("F1") : "(no db key)";
-                return (true, $"'{filterSourceName}/{gainFilterName}' db={db}");
-            }));
+                        await client.Filters.SetSourceFilterSettingsAsync(
+                            new SetSourceFilterSettingsRequestData(
+                                gainFilterName,
+                                el,
+                                sourceName: filterSourceName,
+                                overlay: true
+                            ),
+                            cancellationToken
+                        );
+                        string db = el.TryGetProperty("db", out JsonElement p)
+                            ? p.GetDouble().ToString("F1")
+                            : "(no db key)";
+                        return (true, $"'{filterSourceName}/{gainFilterName}' db={db}");
+                    }
+                )
+            );
 
             // Mode 2: library-registered type via implicit GetTypeInfo lookup
-            results.Add(await TrySettingsCheckAsync("FilterSettings Mode2 (GainFilterSettings)", async () =>
-            {
-                GainFilterSettings? s = await client.Filters.GetSourceFilterSettingsAsync<GainFilterSettings>(
-                    filterSourceName, gainFilterName, cancellationToken);
-                if (s is null)
-                {
-                    return (false, "null result");
-                }
+            results.Add(
+                await TrySettingsCheckAsync(
+                    "FilterSettings Mode2 (GainFilterSettings)",
+                    async () =>
+                    {
+                        GainFilterSettings? s =
+                            await client.Filters.GetSourceFilterSettingsAsync<GainFilterSettings>(
+                                filterSourceName,
+                                gainFilterName,
+                                cancellationToken
+                            );
+                        if (s is null)
+                        {
+                            return (false, "null result");
+                        }
 
-                await client.Filters.SetSourceFilterSettingsAsync(filterSourceName, gainFilterName, s, overlay: true, cancellationToken: cancellationToken);
-                return (true, $"'{filterSourceName}/{gainFilterName}' db={s.Db?.ToString("F1") ?? "(null)"}");
-            }));
+                        await client.Filters.SetSourceFilterSettingsAsync(
+                            filterSourceName,
+                            gainFilterName,
+                            s,
+                            overlay: true,
+                            cancellationToken: cancellationToken
+                        );
+                        return (
+                            true,
+                            $"'{filterSourceName}/{gainFilterName}' db={s.Db?.ToString("F1") ?? "(null)"}"
+                        );
+                    }
+                )
+            );
 
             // Mode 3: consumer-defined type with explicit JsonTypeInfo<T>
-            results.Add(await TrySettingsCheckAsync("FilterSettings Mode3 (consumer JsonTypeInfo)", async () =>
-            {
-                JsonTypeInfo<WorkerGainDbSettings> typeInfo = WorkerSettingsJsonContext.Default.WorkerGainDbSettings;
-                WorkerGainDbSettings? s = await client.Filters.GetSourceFilterSettingsAsync(
-                    filterSourceName, gainFilterName, typeInfo, cancellationToken);
-                if (s is null)
-                {
-                    return (false, "null result");
-                }
+            results.Add(
+                await TrySettingsCheckAsync(
+                    "FilterSettings Mode3 (consumer JsonTypeInfo)",
+                    async () =>
+                    {
+                        JsonTypeInfo<WorkerGainDbSettings> typeInfo = WorkerSettingsJsonContext
+                            .Default
+                            .WorkerGainDbSettings;
+                        WorkerGainDbSettings? s = await client.Filters.GetSourceFilterSettingsAsync(
+                            filterSourceName,
+                            gainFilterName,
+                            typeInfo,
+                            cancellationToken
+                        );
+                        if (s is null)
+                        {
+                            return (false, "null result");
+                        }
 
-                await client.Filters.SetSourceFilterSettingsAsync(filterSourceName, gainFilterName, s, typeInfo, overlay: true, cancellationToken: cancellationToken);
-                return (true, $"'{filterSourceName}/{gainFilterName}' db={s.Db?.ToString("F1") ?? "(null)"}");
-            }));
+                        await client.Filters.SetSourceFilterSettingsAsync(
+                            filterSourceName,
+                            gainFilterName,
+                            s,
+                            typeInfo,
+                            overlay: true,
+                            cancellationToken: cancellationToken
+                        );
+                        return (
+                            true,
+                            $"'{filterSourceName}/{gainFilterName}' db={s.Db?.ToString("F1") ?? "(null)"}"
+                        );
+                    }
+                )
+            );
         }
 
         return results;
@@ -1178,10 +1318,13 @@ internal sealed partial class Worker(
     /// so the run does not depend on any particular OBS layout. Everything it makes is removed
     /// again, whether the checks pass or not.
     /// </summary>
-    private static async Task<List<(string Label, bool Pass, string Detail)>> ValidateModernApisAsync(
+    private static async Task<
+        List<(string Label, bool Pass, string Detail)>
+    > ValidateModernApisAsync(
         ObsWebSocketClient client,
         HealthCheckService healthChecks,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken
+    )
     {
         List<(string Label, bool Pass, string Detail)> results = [];
 
@@ -1204,584 +1347,973 @@ internal sealed partial class Worker(
                 .ConfigureAwait(false);
             sceneCreated = true;
 
-            results.Add(await TrySettingsCheckAsync("SceneExistsAsync", async () =>
-            {
-                bool present = await client.Scenes.SceneExistsAsync(sceneName, cancellationToken).ConfigureAwait(false);
-                bool absent = await client.Scenes.SceneExistsAsync(sceneName + "__nope", cancellationToken).ConfigureAwait(false);
-                return (present && !absent, $"present={present}, absent={!absent}");
-            }).ConfigureAwait(false));
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "SceneExistsAsync",
+                        async () =>
+                        {
+                            bool present = await client
+                                .Scenes.SceneExistsAsync(sceneName, cancellationToken)
+                                .ConfigureAwait(false);
+                            bool absent = await client
+                                .Scenes.SceneExistsAsync(sceneName + "__nope", cancellationToken)
+                                .ConfigureAwait(false);
+                            return (present && !absent, $"present={present}, absent={!absent}");
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
 
             // A media source carries audio, so the volume and media transport helpers apply.
             _ = await client
-                .Inputs.CreateInputAsync("ffmpeg_source",
+                .Inputs.CreateInputAsync(
+                    "ffmpeg_source",
                     inputName,
                     new MediaSourceSettings(IsLocalFile: true),
                     sceneName: sceneName,
-                    cancellationToken: cancellationToken)
+                    cancellationToken: cancellationToken
+                )
                 .ConfigureAwait(false);
             inputCreated = true;
 
-            results.Add(await TrySettingsCheckAsync("FindSceneItemIdAsync", async () =>
-            {
-                double? hit = await client.SceneItems.FindSceneItemIdAsync(sceneName, inputName, cancellationToken).ConfigureAwait(false);
-                double? miss = await client.SceneItems.FindSceneItemIdAsync(sceneName, "__not_here__", cancellationToken).ConfigureAwait(false);
-                return (hit is not null && miss is null, $"hit={hit}, miss={(miss is null ? "null" : "unexpected")}");
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("SetSceneItemEnabledAsync (toggle)", async () =>
-            {
-                bool off = await client.SceneItems.SetSceneItemEnabledAsync(sceneName, inputName, false, cancellationToken).ConfigureAwait(false);
-                bool toggled = await client.SceneItems.SetSceneItemEnabledAsync(sceneName, inputName, null, cancellationToken).ConfigureAwait(false);
-                return (!off && toggled, $"set false -> {off}, toggled -> {toggled}");
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("SetInputVolumeDbAsync", async () =>
-            {
-                await client.Inputs.SetInputVolumeDbAsync(inputName, -6, cancellationToken).ConfigureAwait(false);
-                GetInputVolumeResponseData? volume = await client
-                    .Inputs.GetInputVolumeAsync(new GetInputVolumeRequestData(inputName: inputName), cancellationToken)
-                    .ConfigureAwait(false);
-                double db = volume?.InputVolumeDb ?? double.NaN;
-                return (Math.Abs(db + 6) < 0.5, $"db={db:0.##}");
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("Media transport (typed enum)", async () =>
-            {
-                await client
-                    .MediaInputs.TriggerMediaActionAsync(inputName, MediaInputAction.Stop, cancellationToken)
-                    .ConfigureAwait(false);
-
-                // Read the state back, so this proves the action landed rather than only that
-                // the request was accepted.
-                GetMediaInputStatusResponseData? status = await client
-                    .MediaInputs.GetMediaInputStatusAsync(
-                        new GetMediaInputStatusRequestData(inputName: inputName),
-                        cancellationToken)
-                    .ConfigureAwait(false);
-
-                string? state = status?.MediaState;
-                bool stopped =
-                    state is not null
-                    && state.Contains("STOPPED", StringComparison.Ordinal)
-                        || state is not null && state.Contains("NONE", StringComparison.Ordinal);
-
-                return (stopped, $"sent {MediaInputAction.Stop.ToWireValue()}, state={state}");
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("Event stream (await foreach)", async () =>
-            {
-                using CancellationTokenSource streamCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                streamCts.CancelAfter(TimeSpan.FromSeconds(10));
-
-                List<string> observed = [];
-                Task consume = Task.Run(async () =>
-                {
-                    try
-                    {
-                        await foreach (CurrentProgramSceneChangedEventArgs sceneEvent
-                            in client.Scenes.CurrentProgramSceneChangedStream(cancellationToken: streamCts.Token)
-                            .ConfigureAwait(false))
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "FindSceneItemIdAsync",
+                        async () =>
                         {
-                            observed.Add(sceneEvent.EventData.SceneName ?? string.Empty);
-                            if (observed.Count >= 2)
+                            double? hit = await client
+                                .SceneItems.FindSceneItemIdAsync(
+                                    sceneName,
+                                    inputName,
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            double? miss = await client
+                                .SceneItems.FindSceneItemIdAsync(
+                                    sceneName,
+                                    "__not_here__",
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            return (
+                                hit is not null && miss is null,
+                                $"hit={hit}, miss={(miss is null ? "null" : "unexpected")}"
+                            );
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "SetSceneItemEnabledAsync (toggle)",
+                        async () =>
+                        {
+                            bool off = await client
+                                .SceneItems.SetSceneItemEnabledAsync(
+                                    sceneName,
+                                    inputName,
+                                    false,
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            bool toggled = await client
+                                .SceneItems.SetSceneItemEnabledAsync(
+                                    sceneName,
+                                    inputName,
+                                    null,
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            return (!off && toggled, $"set false -> {off}, toggled -> {toggled}");
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "SetInputVolumeDbAsync",
+                        async () =>
+                        {
+                            await client
+                                .Inputs.SetInputVolumeDbAsync(inputName, -6, cancellationToken)
+                                .ConfigureAwait(false);
+                            GetInputVolumeResponseData? volume = await client
+                                .Inputs.GetInputVolumeAsync(
+                                    new GetInputVolumeRequestData(inputName: inputName),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            double db = volume?.InputVolumeDb ?? double.NaN;
+                            return (Math.Abs(db + 6) < 0.5, $"db={db:0.##}");
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "Media transport (typed enum)",
+                        async () =>
+                        {
+                            await client
+                                .MediaInputs.TriggerMediaActionAsync(
+                                    inputName,
+                                    MediaInputAction.Stop,
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            // Read the state back, so this proves the action landed rather than only that
+                            // the request was accepted.
+                            GetMediaInputStatusResponseData? status = await client
+                                .MediaInputs.GetMediaInputStatusAsync(
+                                    new GetMediaInputStatusRequestData(inputName: inputName),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            string? state = status?.MediaState;
+                            bool stopped =
+                                state is not null
+                                    && state.Contains("STOPPED", StringComparison.Ordinal)
+                                || state is not null
+                                    && state.Contains("NONE", StringComparison.Ordinal);
+
+                            return (
+                                stopped,
+                                $"sent {MediaInputAction.Stop.ToWireValue()}, state={state}"
+                            );
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "Event stream (await foreach)",
+                        async () =>
+                        {
+                            using CancellationTokenSource streamCts =
+                                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                            streamCts.CancelAfter(TimeSpan.FromSeconds(10));
+
+                            List<string> observed = [];
+                            Task consume = Task.Run(
+                                async () =>
+                                {
+                                    try
+                                    {
+                                        await foreach (
+                                            CurrentProgramSceneChangedEventArgs sceneEvent in client
+                                                .Scenes.CurrentProgramSceneChangedStream(
+                                                    cancellationToken: streamCts.Token
+                                                )
+                                                .ConfigureAwait(false)
+                                        )
+                                        {
+                                            observed.Add(
+                                                sceneEvent.EventData.SceneName ?? string.Empty
+                                            );
+                                            if (observed.Count >= 2)
+                                            {
+                                                await streamCts.CancelAsync().ConfigureAwait(false);
+                                            }
+                                        }
+                                    }
+                                    catch (OperationCanceledException)
+                                    {
+                                        // Expected once both switches are seen or the window elapses.
+                                    }
+                                },
+                                CancellationToken.None
+                            );
+
+                            await Task.Delay(250, cancellationToken).ConfigureAwait(false);
+                            await client
+                                .Scenes.SwitchSceneAsync(
+                                    sceneName,
+                                    cancellationToken: cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            await Task.Delay(400, cancellationToken).ConfigureAwait(false);
+                            if (!string.IsNullOrEmpty(originalScene))
                             {
-                                await streamCts.CancelAsync().ConfigureAwait(false);
+                                await client
+                                    .Scenes.SwitchSceneAsync(
+                                        originalScene,
+                                        cancellationToken: cancellationToken
+                                    )
+                                    .ConfigureAwait(false);
+                            }
+
+                            await consume.ConfigureAwait(false);
+                            return (
+                                observed.Count >= 2,
+                                $"observed {observed.Count}: {string.Join(" -> ", observed)}"
+                            );
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "WaitForEventAsync (timeout overload)",
+                        async () =>
+                        {
+                            Task<SceneItemEnableStateChangedEventArgs> wait =
+                                client.WaitForEventAsync<SceneItemEnableStateChangedEventArgs>(
+                                    TimeSpan.FromSeconds(5),
+                                    cancellationToken
+                                );
+                            _ = await client
+                                .SceneItems.SetSceneItemEnabledAsync(
+                                    sceneName,
+                                    inputName,
+                                    false,
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            try
+                            {
+                                SceneItemEnableStateChangedEventArgs observed =
+                                    await wait.ConfigureAwait(false);
+                                return (true, $"enabled={observed.EventData.SceneItemEnabled}");
+                            }
+                            catch (TimeoutException)
+                            {
+                                return (false, "timed out");
                             }
                         }
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // Expected once both switches are seen or the window elapses.
-                    }
-                }, CancellationToken.None);
-
-                await Task.Delay(250, cancellationToken).ConfigureAwait(false);
-                await client.Scenes.SwitchSceneAsync(sceneName, cancellationToken: cancellationToken).ConfigureAwait(false);
-                await Task.Delay(400, cancellationToken).ConfigureAwait(false);
-                if (!string.IsNullOrEmpty(originalScene))
-                {
-                    await client.Scenes.SwitchSceneAsync(originalScene, cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
-
-                await consume.ConfigureAwait(false);
-                return (observed.Count >= 2, $"observed {observed.Count}: {string.Join(" -> ", observed)}");
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("WaitForEventAsync (timeout overload)", async () =>
-            {
-                Task<SceneItemEnableStateChangedEventArgs> wait = client
-                    .WaitForEventAsync<SceneItemEnableStateChangedEventArgs>(TimeSpan.FromSeconds(5), cancellationToken);
-                _ = await client.SceneItems.SetSceneItemEnabledAsync(sceneName, inputName, false, cancellationToken).ConfigureAwait(false);
-                try
-                {
-                    SceneItemEnableStateChangedEventArgs observed = await wait.ConfigureAwait(false);
-                    return (true, $"enabled={observed.EventData.SceneItemEnabled}");
-                }
-                catch (TimeoutException)
-                {
-                    return (false, "timed out");
-                }
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("Typed batch builder", async () =>
-            {
-                ObsBatchBuilder batch = new();
-                BatchRef<GetVersionResponseData> versionRef = batch.General.GetVersion();
-                _ = batch.General.Sleep(new SleepRequestData(sleepMillis: 25));
-                BatchRef<GetSceneListResponseData> scenesRef = batch.Scenes.GetSceneList(
-                    new GetSceneListRequestData()
-                );
-                BatchRef<GetStatsResponseData> statsRef = batch.General.GetStats();
-
-                BatchResults typedBatch = await client
-                    .CallBatchAsync(
-                        batch,
-                        executionType: RequestBatchExecutionType.SerialRealtime,
-                        haltOnFailure: false,
-                        cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
-
-                // Each result is read through the reference its request handed back, so neither
-                // the position nor the response type is restated here.
-                GetVersionResponseData version = typedBatch.Get(versionRef);
-                GetSceneListResponseData scenes = typedBatch.Get(scenesRef);
-                GetStatsResponseData stats = typedBatch.Get(statsRef);
-
-                return (
-                    typedBatch.Count == 4
-                        && typedBatch.AllSucceeded()
-                        && version.ObsVersion is not null
-                        && scenes.Scenes is not null,
-                    $"{typedBatch.Count} result(s), OBS {version.ObsVersion}, {scenes.Scenes?.Count} scene(s), {stats.ActiveFps:0} fps"
-                );
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("Batch order and duplicates", async () =>
-            {
-                // Repeats one request type with different payloads and interleaves others, so a
-                // result can only be matched to its request by position.
-                GetSceneListResponseData? allScenes = await client
-                    .Scenes.GetSceneListAsync(new GetSceneListRequestData(), cancellationToken)
-                    .ConfigureAwait(false);
-                string otherScene = allScenes!
-                    .Scenes!.Select(scene => scene.SceneName!)
-                    .First(name => !string.Equals(name, sceneName, StringComparison.Ordinal));
-
-                // The same request type appears three times with two different payloads, so a
-                // result can only be matched to its request through the reference it returned.
-                ObsBatchBuilder mixedBatch = new();
-                BatchRef<GetSceneItemListResponseData> firstRef = mixedBatch.SceneItems.GetSceneItemList(
-                    new GetSceneItemListRequestData(sceneName: sceneName)
-                );
-                BatchRef<GetVersionResponseData> versionRef = mixedBatch.General.GetVersion();
-                BatchRef<GetSceneItemListResponseData> secondRef = mixedBatch.SceneItems.GetSceneItemList(
-                    new GetSceneItemListRequestData(sceneName: otherScene)
-                );
-                BatchRef<GetSceneItemListResponseData> thirdRef = mixedBatch.SceneItems.GetSceneItemList(
-                    new GetSceneItemListRequestData(sceneName: sceneName)
-                );
-                _ = mixedBatch.General.GetStats();
-
-                BatchResults mixed = await client
-                    .CallBatchAsync(
-                        mixedBatch,
-                        executionType: RequestBatchExecutionType.SerialRealtime,
-                        haltOnFailure: false,
-                        cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
-
-                if (mixed.Count != 5 || !mixed.AllSucceeded())
-                {
-                    return (false, $"expected 5 successes, got {mixed.Count} with {mixed.GetFailures().Count()} failure(s)");
-                }
-
-                GetSceneItemListResponseData first = mixed.Get(firstRef);
-                GetVersionResponseData version = mixed.Get(versionRef);
-                GetSceneItemListResponseData second = mixed.Get(secondRef);
-                GetSceneItemListResponseData third = mixed.Get(thirdRef);
-
-                // The two lookups of the same scene must agree, and differ from the other scene.
-                int firstCount = first.SceneItems?.Count ?? -1;
-                int secondCount = second.SceneItems?.Count ?? -1;
-                int thirdCount = third.SceneItems?.Count ?? -1;
-                bool repeatsAgree = firstCount == thirdCount;
-                bool distinguishable = firstCount != secondCount || !string.Equals(sceneName, otherScene, StringComparison.Ordinal);
-
-                return (
-                    repeatsAgree && distinguishable && version.ObsVersion is not null,
-                    $"[{firstCount}, v{version.ObsVersion}, {secondCount}, {thirdCount}] repeats agree = {repeatsAgree}"
-                );
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("Batch partial failure", async () =>
-            {
-                // haltOnFailure false, so the good requests either side of a bad one still run.
-                ObsBatchBuilder partialBatch = new();
-                BatchRef<GetVersionResponseData> goodRef = partialBatch.General.GetVersion();
-                BatchRef<GetSceneItemListResponseData> badRef = partialBatch.SceneItems.GetSceneItemList(
-                    new GetSceneItemListRequestData(sceneName: "__no_such_scene__")
-                );
-                _ = partialBatch.General.GetStats();
-
-                BatchResults partial = await client
-                    .CallBatchAsync(
-                        partialBatch,
-                        executionType: RequestBatchExecutionType.SerialRealtime,
-                        haltOnFailure: false,
-                        cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
-
-                RequestResponsePayload<object>[] failures = [.. partial.GetFailures()];
-                if (partial.Count != 3 || failures.Length != 1)
-                {
-                    return (false, $"{partial.Count} result(s), {failures.Length} failure(s)");
-                }
-
-                // GetRequiredData surfaces the OBS status rather than a null payload.
-                string caught;
-                try
-                {
-                    _ = partial.Get(badRef);
-                    caught = "no exception";
-                }
-                catch (ObsWebSocketRequestException ex)
-                {
-                    caught = $"code {ex.Status?.Code}";
-                }
-
-                // TryGet reports the failure without throwing.
-                bool tryGetReportedFailure = !partial.TryGet(badRef, out _);
-                bool neighboursOk =
-                    tryGetReportedFailure && partial.Get(goodRef).ObsVersion is not null;
-
-                return (
-                    neighboursOk && caught.StartsWith("code ", StringComparison.Ordinal),
-                    $"1 failed ({caught}), neighbours ran"
-                );
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("Event stream buffering", async () =>
-            {
-                // A stream keeps the newest events when a consumer falls behind rather than
-                // stalling the receive loop, so a small capacity drops the oldest.
-                using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(
-                    cancellationToken
-                );
-                cts.CancelAfter(TimeSpan.FromSeconds(10));
-
-                IAsyncEnumerator<SceneItemEnableStateChangedEventArgs> enumerator = client
-                    .SceneItems.SceneItemEnableStateChangedStream(capacity: 2, cancellationToken: cts.Token)
-                    .GetAsyncEnumerator(cts.Token);
-
-                try
-                {
-                    ValueTask<bool> pending = enumerator.MoveNextAsync();
-
-                    // Toggle more times than the buffer holds.
-                    for (int i = 0; i < 4; i++)
-                    {
-                        _ = await client
-                            .SceneItems.SetSceneItemEnabledAsync(sceneName, inputName, i % 2 == 0, cancellationToken)
-                            .ConfigureAwait(false);
-                    }
-
-                    bool first = await pending.ConfigureAwait(false);
-                    return (first, first ? "buffered and delivered under capacity pressure" : "no event");
-                }
-                finally
-                {
-                    await enumerator.DisposeAsync().ConfigureAwait(false);
-                }
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("Single-request values (non-batch)", async () =>
-            {
-                // The same response types that come back empty inside a batch, fetched singly.
-                GetSceneItemListResponseData? items = await client
-                    .SceneItems.GetSceneItemListAsync(new GetSceneItemListRequestData(sceneName: sceneName), cancellationToken)
-                    .ConfigureAwait(false);
-                GetStatsResponseData? st = await client.General.GetStatsAsync(cancellationToken).ConfigureAwait(false);
-                GetVersionResponseData? ver = await client.General.GetVersionAsync(cancellationToken).ConfigureAwait(false);
-
-                int itemCount = items?.SceneItems?.Count ?? -1;
-                double fps = st?.ActiveFps ?? 0;
-
-                return (
-                    itemCount >= 0 && fps > 0 && ver?.ObsVersion is not null,
-                    $"items={itemCount}, {fps:0} fps, v={ver?.ObsVersion}"
-                );
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("Batch parallel execution", async () =>
-            {
-                // OBS pairs each result with another request's response data under parallel
-                // execution, so reading by reference must refuse rather than return the wrong
-                // request's payload.
-                ObsBatchBuilder par = new();
-                BatchRef<GetVersionResponseData> v = par.General.GetVersion();
-                _ = par.SceneItems.GetSceneItemList(
-                    new GetSceneItemListRequestData(sceneName: sceneName)
-                );
-
-                BatchResults r = await client
-                    .CallBatchAsync(
-                        par,
-                        executionType: RequestBatchExecutionType.Parallel,
-                        haltOnFailure: false,
-                        cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
-
-                string guarded;
-                try
-                {
-                    _ = r.Get(v);
-                    guarded = "returned data";
-                }
-                catch (ObsWebSocketException ex)
-                {
-                    guarded = ex.Message.Contains("Parallel", StringComparison.Ordinal)
-                        ? "refused"
-                        : "threw: " + ex.Message;
-                }
-
-                return (
-                    r.Count == 2 && guarded == "refused" && !r.TryGet(v, out GetVersionResponseData? _),
-                    $"{r.Count} raw result(s), reference {guarded}"
-                );
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("Batch halt on failure", async () =>
-            {
-                ObsBatchBuilder halt = new();
-                BatchRef<GetVersionResponseData> first = halt.General.GetVersion();
-                BatchRef<GetSceneItemListResponseData> bad = halt.SceneItems.GetSceneItemList(
-                    new GetSceneItemListRequestData(sceneName: "__no_such_scene__")
-                );
-                BatchRef<GetStatsResponseData> never = halt.General.GetStats();
-
-                BatchResults r = await client
-                    .CallBatchAsync(
-                        halt,
-                        executionType: RequestBatchExecutionType.SerialRealtime,
-                        haltOnFailure: true,
-                        cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
-
-                bool firstOk = r.Get(first).ObsVersion is not null;
-                bool badRejected = !r.TryGet(bad, out GetSceneItemListResponseData? _);
-
-                // The third request never ran, so reading it explains itself rather than
-                // returning someone else's result.
-                string neverMsg;
-                try
-                {
-                    _ = r.Get(never);
-                    neverMsg = "returned a result";
-                }
-                catch (ObsWebSocketException ex)
-                {
-                    neverMsg = ex.Message.Contains("never ran", StringComparison.Ordinal)
-                        ? "explained"
-                        : "threw: " + ex.Message;
-                }
-
-                return (
-                    firstOk && badRejected && neverMsg == "explained",
-                    $"{r.Count} result(s), unrun request {neverMsg}"
-                );
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("SetInputVolumeMulAsync", async () =>
-            {
-                GetInputVolumeResponseData? before = await client
-                    .Inputs.GetInputVolumeAsync(new GetInputVolumeRequestData(inputName: inputName), cancellationToken)
-                    .ConfigureAwait(false);
-                double original = before!.InputVolumeMul;
-
-                await client.Inputs.SetInputVolumeMulAsync(inputName, 0.5, cancellationToken).ConfigureAwait(false);
-                GetInputVolumeResponseData? after = await client
-                    .Inputs.GetInputVolumeAsync(new GetInputVolumeRequestData(inputName: inputName), cancellationToken)
-                    .ConfigureAwait(false);
-                double mul = after!.InputVolumeMul;
-
-                await client.Inputs.SetInputVolumeMulAsync(inputName, original, cancellationToken).ConfigureAwait(false);
-                return (Math.Abs(mul - 0.5) < 0.01, $"mul={mul:0.###}");
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("SwitchProgramSceneAsync", async () =>
-            {
-                await client.Scenes.SwitchProgramSceneAsync(sceneName, cancellationToken: cancellationToken).ConfigureAwait(false);
-                GetSceneListResponseData? mid = await client
-                    .Scenes.GetSceneListAsync(new GetSceneListRequestData(), cancellationToken)
-                    .ConfigureAwait(false);
-                bool switched = string.Equals(mid?.CurrentProgramSceneName, sceneName, StringComparison.Ordinal);
-
-                await client.Scenes.SwitchProgramSceneAsync(originalScene, cancellationToken: cancellationToken).ConfigureAwait(false);
-                GetSceneListResponseData? restored = await client
-                    .Scenes.GetSceneListAsync(new GetSceneListRequestData(), cancellationToken)
-                    .ConfigureAwait(false);
-
-                return (
-                    switched && string.Equals(restored?.CurrentProgramSceneName, originalScene, StringComparison.Ordinal),
-                    $"switched={switched}, restored to '{restored?.CurrentProgramSceneName}'"
-                );
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("FindSceneItemIdInt32Async", async () =>
-            {
-                int? id = await client
-                    .SceneItems.FindSceneItemIdInt32Async(sceneName, inputName, cancellationToken)
-                    .ConfigureAwait(false);
-                int? miss = await client
-                    .SceneItems.FindSceneItemIdInt32Async(sceneName, "__absent__", cancellationToken)
-                    .ConfigureAwait(false);
-
-                return (id is not null && miss is null, $"id={id}, miss={(miss is null ? "null" : "unexpected")}");
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("Screenshot helpers", async () =>
-            {
-                byte[]? bytes = await client
-                    .Sources.GetSourceScreenshotBytesAsync(sceneName, "png", cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
-
-                string path = Path.Combine(Path.GetTempPath(), $"obsws_{Guid.NewGuid():N}.png");
-                try
-                {
-                    await client
-                        .Sources.SaveSourceScreenshotToFileAsync(sceneName, path, "png", cancellationToken: cancellationToken)
-                        .ConfigureAwait(false);
-
-                    // A PNG starts with the eight byte signature, so this checks real image data
-                    // rather than merely that the call returned.
-                    byte[] written = await File.ReadAllBytesAsync(path, cancellationToken).ConfigureAwait(false);
-                    bool pngOnDisk =
-                        written.Length > 8
-                        && written[0] == 0x89 && written[1] == 0x50 && written[2] == 0x4E && written[3] == 0x47;
-                    bool pngInMemory =
-                        bytes is { Length: > 8 }
-                        && bytes[0] == 0x89 && bytes[1] == 0x50 && bytes[2] == 0x4E && bytes[3] == 0x47;
-
-                    return (pngInMemory && pngOnDisk, $"{bytes?.Length ?? 0} bytes in memory, {written.Length} on disk");
-                }
-                finally
-                {
-                    if (File.Exists(path))
-                    {
-                        File.Delete(path);
-                    }
-                }
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("Ensure profile and scene collection", async () =>
-            {
-                // Asking for the one already active proves the check without disrupting OBS,
-                // since switching either of these reloads the whole configuration.
-                GetProfileListResponseData? profiles = await client
-                    .Config.GetProfileListAsync(cancellationToken)
-                    .ConfigureAwait(false);
-                GetSceneCollectionListResponseData? collections = await client
-                    .Config.GetSceneCollectionListAsync(cancellationToken)
-                    .ConfigureAwait(false);
-
-                bool profileOk = await client
-                    .Config.EnsureProfileActiveAsync(profiles!.CurrentProfileName!, cancellationToken)
-                    .ConfigureAwait(false);
-                bool collectionOk = await client
-                    .Config.EnsureSceneCollectionActiveAsync(collections!.CurrentSceneCollectionName!, cancellationToken)
-                    .ConfigureAwait(false);
-                bool absent = await client
-                    .Config.EnsureProfileActiveAsync("__no_such_profile__", cancellationToken)
-                    .ConfigureAwait(false);
-
-                return (
-                    profileOk && collectionOk && !absent,
-                    $"profile={profiles.CurrentProfileName}, collection={collections.CurrentSceneCollectionName}, absent reported {absent}"
-                );
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("Media transport shorthands", async () =>
-            {
-                await client.MediaInputs.PlayMediaAsync(inputName, cancellationToken).ConfigureAwait(false);
-                await client.MediaInputs.PauseMediaAsync(inputName, cancellationToken).ConfigureAwait(false);
-                await client.MediaInputs.RestartMediaAsync(inputName, cancellationToken).ConfigureAwait(false);
-                await client.MediaInputs.StopMediaAsync(inputName, cancellationToken).ConfigureAwait(false);
-
-                GetMediaInputStatusResponseData? status = await client
-                    .MediaInputs.GetMediaInputStatusAsync(
-                        new GetMediaInputStatusRequestData(inputName: inputName), cancellationToken)
-                    .ConfigureAwait(false);
-
-                return (status is not null, $"state={status?.MediaState}");
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("Virtual camera toggle", async () =>
-            {
-                bool before = await client.Outputs.IsVirtualCamActiveAsync(cancellationToken).ConfigureAwait(false);
-
-                bool? turnedOn = await client
-                    .Outputs.SetVirtualCamActiveAndWaitAsync(!before, cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
-                bool observed = await client.Outputs.IsVirtualCamActiveAsync(cancellationToken).ConfigureAwait(false);
-
-                // Put it back the way it was found.
-                _ = await client
-                    .Outputs.SetVirtualCamActiveAndWaitAsync(before, cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
-                bool restored = await client.Outputs.IsVirtualCamActiveAsync(cancellationToken).ConfigureAwait(false);
-
-                return (
-                    turnedOn == !before && observed == !before && restored == before,
-                    $"{before} -> {observed} -> {restored}"
-                );
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("Typed exception on a rejected request", async () =>
-            {
-                try
-                {
-                    _ = await client
-                        .SceneItems.GetSceneItemListAsync(
-                            new GetSceneItemListRequestData(sceneName: "__no_such_scene__"), cancellationToken)
-                        .ConfigureAwait(false);
-                    return (false, "no exception");
-                }
-                catch (ObsWebSocketRequestException ex)
-                {
-                    return (
-                        ex.Status?.Code == 600 && ex.RequestType == "GetSceneItemList",
-                        $"{ex.RequestType} code {ex.Status?.Code}"
-                    );
-                }
-            }).ConfigureAwait(false));
-
-            results.Add(await TrySettingsCheckAsync("Output state helpers", async () =>
-            {
-                bool recording = await client.Record.IsRecordActiveAsync(cancellationToken).ConfigureAwait(false);
-                bool streaming = await client.Stream.IsStreamActiveAsync(cancellationToken).ConfigureAwait(false);
-                bool virtualCam = await client.Outputs.IsVirtualCamActiveAsync(cancellationToken).ConfigureAwait(false);
-
-                // Each helper has to agree with the request it wraps.
-                GetRecordStatusResponseData? recordStatus = await client
-                    .Record.GetRecordStatusAsync(cancellationToken)
-                    .ConfigureAwait(false);
-                GetStreamStatusResponseData? streamStatus = await client
-                    .Stream.GetStreamStatusAsync(cancellationToken)
-                    .ConfigureAwait(false);
-                GetVirtualCamStatusResponseData? camStatus = await client
-                    .Outputs.GetVirtualCamStatusAsync(cancellationToken)
-                    .ConfigureAwait(false);
-
-                bool agrees =
-                    recording == recordStatus?.OutputActive
-                    && streaming == streamStatus?.OutputActive
-                    && virtualCam == camStatus?.OutputActive;
-
-                return (
-                    agrees,
-                    $"record={recording}, stream={streaming}, virtualCam={virtualCam}, agrees={agrees}"
-                );
-            }).ConfigureAwait(false));
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "Typed batch builder",
+                        async () =>
+                        {
+                            ObsBatchBuilder batch = new();
+                            BatchRef<GetVersionResponseData> versionRef =
+                                batch.General.GetVersion();
+                            _ = batch.General.Sleep(new SleepRequestData(sleepMillis: 25));
+                            BatchRef<GetSceneListResponseData> scenesRef =
+                                batch.Scenes.GetSceneList(new GetSceneListRequestData());
+                            BatchRef<GetStatsResponseData> statsRef = batch.General.GetStats();
+
+                            BatchResults typedBatch = await client
+                                .CallBatchAsync(
+                                    batch,
+                                    executionType: RequestBatchExecutionType.SerialRealtime,
+                                    haltOnFailure: false,
+                                    cancellationToken: cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            // Each result is read through the reference its request handed back, so neither
+                            // the position nor the response type is restated here.
+                            GetVersionResponseData version = typedBatch.Get(versionRef);
+                            GetSceneListResponseData scenes = typedBatch.Get(scenesRef);
+                            GetStatsResponseData stats = typedBatch.Get(statsRef);
+
+                            return (
+                                typedBatch.Count == 4
+                                    && typedBatch.AllSucceeded()
+                                    && version.ObsVersion is not null
+                                    && scenes.Scenes is not null,
+                                $"{typedBatch.Count} result(s), OBS {version.ObsVersion}, {scenes.Scenes?.Count} scene(s), {stats.ActiveFps:0} fps"
+                            );
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "Batch order and duplicates",
+                        async () =>
+                        {
+                            // Repeats one request type with different payloads and interleaves others, so a
+                            // result can only be matched to its request by position.
+                            GetSceneListResponseData? allScenes = await client
+                                .Scenes.GetSceneListAsync(
+                                    new GetSceneListRequestData(),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            string otherScene = allScenes!
+                                .Scenes!.Select(scene => scene.SceneName!)
+                                .First(name =>
+                                    !string.Equals(name, sceneName, StringComparison.Ordinal)
+                                );
+
+                            // The same request type appears three times with two different payloads, so a
+                            // result can only be matched to its request through the reference it returned.
+                            ObsBatchBuilder mixedBatch = new();
+                            BatchRef<GetSceneItemListResponseData> firstRef =
+                                mixedBatch.SceneItems.GetSceneItemList(
+                                    new GetSceneItemListRequestData(sceneName: sceneName)
+                                );
+                            BatchRef<GetVersionResponseData> versionRef =
+                                mixedBatch.General.GetVersion();
+                            BatchRef<GetSceneItemListResponseData> secondRef =
+                                mixedBatch.SceneItems.GetSceneItemList(
+                                    new GetSceneItemListRequestData(sceneName: otherScene)
+                                );
+                            BatchRef<GetSceneItemListResponseData> thirdRef =
+                                mixedBatch.SceneItems.GetSceneItemList(
+                                    new GetSceneItemListRequestData(sceneName: sceneName)
+                                );
+                            _ = mixedBatch.General.GetStats();
+
+                            BatchResults mixed = await client
+                                .CallBatchAsync(
+                                    mixedBatch,
+                                    executionType: RequestBatchExecutionType.SerialRealtime,
+                                    haltOnFailure: false,
+                                    cancellationToken: cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            if (mixed.Count != 5 || !mixed.AllSucceeded())
+                            {
+                                return (
+                                    false,
+                                    $"expected 5 successes, got {mixed.Count} with {mixed.GetFailures().Count()} failure(s)"
+                                );
+                            }
+
+                            GetSceneItemListResponseData first = mixed.Get(firstRef);
+                            GetVersionResponseData version = mixed.Get(versionRef);
+                            GetSceneItemListResponseData second = mixed.Get(secondRef);
+                            GetSceneItemListResponseData third = mixed.Get(thirdRef);
+
+                            // The two lookups of the same scene must agree, and differ from the other scene.
+                            int firstCount = first.SceneItems?.Count ?? -1;
+                            int secondCount = second.SceneItems?.Count ?? -1;
+                            int thirdCount = third.SceneItems?.Count ?? -1;
+                            bool repeatsAgree = firstCount == thirdCount;
+                            bool distinguishable =
+                                firstCount != secondCount
+                                || !string.Equals(sceneName, otherScene, StringComparison.Ordinal);
+
+                            return (
+                                repeatsAgree && distinguishable && version.ObsVersion is not null,
+                                $"[{firstCount}, v{version.ObsVersion}, {secondCount}, {thirdCount}] repeats agree = {repeatsAgree}"
+                            );
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "Batch partial failure",
+                        async () =>
+                        {
+                            // haltOnFailure false, so the good requests either side of a bad one still run.
+                            ObsBatchBuilder partialBatch = new();
+                            BatchRef<GetVersionResponseData> goodRef =
+                                partialBatch.General.GetVersion();
+                            BatchRef<GetSceneItemListResponseData> badRef =
+                                partialBatch.SceneItems.GetSceneItemList(
+                                    new GetSceneItemListRequestData(sceneName: "__no_such_scene__")
+                                );
+                            _ = partialBatch.General.GetStats();
+
+                            BatchResults partial = await client
+                                .CallBatchAsync(
+                                    partialBatch,
+                                    executionType: RequestBatchExecutionType.SerialRealtime,
+                                    haltOnFailure: false,
+                                    cancellationToken: cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            RequestResponsePayload<object>[] failures = [.. partial.GetFailures()];
+                            if (partial.Count != 3 || failures.Length != 1)
+                            {
+                                return (
+                                    false,
+                                    $"{partial.Count} result(s), {failures.Length} failure(s)"
+                                );
+                            }
+
+                            // GetRequiredData surfaces the OBS status rather than a null payload.
+                            string caught;
+                            try
+                            {
+                                _ = partial.Get(badRef);
+                                caught = "no exception";
+                            }
+                            catch (ObsWebSocketRequestException ex)
+                            {
+                                caught = $"code {ex.Status?.Code}";
+                            }
+
+                            // TryGet reports the failure without throwing.
+                            bool tryGetReportedFailure = !partial.TryGet(badRef, out _);
+                            bool neighboursOk =
+                                tryGetReportedFailure
+                                && partial.Get(goodRef).ObsVersion is not null;
+
+                            return (
+                                neighboursOk
+                                    && caught.StartsWith("code ", StringComparison.Ordinal),
+                                $"1 failed ({caught}), neighbours ran"
+                            );
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "Event stream buffering",
+                        async () =>
+                        {
+                            // A stream keeps the newest events when a consumer falls behind rather than
+                            // stalling the receive loop, so a small capacity drops the oldest.
+                            using CancellationTokenSource cts =
+                                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                            cts.CancelAfter(TimeSpan.FromSeconds(10));
+
+                            IAsyncEnumerator<SceneItemEnableStateChangedEventArgs> enumerator =
+                                client
+                                    .SceneItems.SceneItemEnableStateChangedStream(
+                                        capacity: 2,
+                                        cancellationToken: cts.Token
+                                    )
+                                    .GetAsyncEnumerator(cts.Token);
+
+                            try
+                            {
+                                ValueTask<bool> pending = enumerator.MoveNextAsync();
+
+                                // Toggle more times than the buffer holds.
+                                for (int i = 0; i < 4; i++)
+                                {
+                                    _ = await client
+                                        .SceneItems.SetSceneItemEnabledAsync(
+                                            sceneName,
+                                            inputName,
+                                            i % 2 == 0,
+                                            cancellationToken
+                                        )
+                                        .ConfigureAwait(false);
+                                }
+
+                                bool first = await pending.ConfigureAwait(false);
+                                return (
+                                    first,
+                                    first
+                                        ? "buffered and delivered under capacity pressure"
+                                        : "no event"
+                                );
+                            }
+                            finally
+                            {
+                                await enumerator.DisposeAsync().ConfigureAwait(false);
+                            }
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "Single-request values (non-batch)",
+                        async () =>
+                        {
+                            // The same response types that come back empty inside a batch, fetched singly.
+                            GetSceneItemListResponseData? items = await client
+                                .SceneItems.GetSceneItemListAsync(
+                                    new GetSceneItemListRequestData(sceneName: sceneName),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            GetStatsResponseData? st = await client
+                                .General.GetStatsAsync(cancellationToken)
+                                .ConfigureAwait(false);
+                            GetVersionResponseData? ver = await client
+                                .General.GetVersionAsync(cancellationToken)
+                                .ConfigureAwait(false);
+
+                            int itemCount = items?.SceneItems?.Count ?? -1;
+                            double fps = st?.ActiveFps ?? 0;
+
+                            return (
+                                itemCount >= 0 && fps > 0 && ver?.ObsVersion is not null,
+                                $"items={itemCount}, {fps:0} fps, v={ver?.ObsVersion}"
+                            );
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "Batch parallel execution",
+                        async () =>
+                        {
+                            // OBS pairs each result with another request's response data under parallel
+                            // execution, so reading by reference must refuse rather than return the wrong
+                            // request's payload.
+                            ObsBatchBuilder par = new();
+                            BatchRef<GetVersionResponseData> v = par.General.GetVersion();
+                            _ = par.SceneItems.GetSceneItemList(
+                                new GetSceneItemListRequestData(sceneName: sceneName)
+                            );
+
+                            BatchResults r = await client
+                                .CallBatchAsync(
+                                    par,
+                                    executionType: RequestBatchExecutionType.Parallel,
+                                    haltOnFailure: false,
+                                    cancellationToken: cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            string guarded;
+                            try
+                            {
+                                _ = r.Get(v);
+                                guarded = "returned data";
+                            }
+                            catch (ObsWebSocketException ex)
+                            {
+                                guarded = ex.Message.Contains("Parallel", StringComparison.Ordinal)
+                                    ? "refused"
+                                    : "threw: " + ex.Message;
+                            }
+
+                            return (
+                                r.Count == 2
+                                    && guarded == "refused"
+                                    && !r.TryGet(v, out GetVersionResponseData? _),
+                                $"{r.Count} raw result(s), reference {guarded}"
+                            );
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "Batch halt on failure",
+                        async () =>
+                        {
+                            ObsBatchBuilder halt = new();
+                            BatchRef<GetVersionResponseData> first = halt.General.GetVersion();
+                            BatchRef<GetSceneItemListResponseData> bad =
+                                halt.SceneItems.GetSceneItemList(
+                                    new GetSceneItemListRequestData(sceneName: "__no_such_scene__")
+                                );
+                            BatchRef<GetStatsResponseData> never = halt.General.GetStats();
+
+                            BatchResults r = await client
+                                .CallBatchAsync(
+                                    halt,
+                                    executionType: RequestBatchExecutionType.SerialRealtime,
+                                    haltOnFailure: true,
+                                    cancellationToken: cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            bool firstOk = r.Get(first).ObsVersion is not null;
+                            bool badRejected = !r.TryGet(bad, out GetSceneItemListResponseData? _);
+
+                            // The third request never ran, so reading it explains itself rather than
+                            // returning someone else's result.
+                            string neverMsg;
+                            try
+                            {
+                                _ = r.Get(never);
+                                neverMsg = "returned a result";
+                            }
+                            catch (ObsWebSocketException ex)
+                            {
+                                neverMsg = ex.Message.Contains(
+                                    "never ran",
+                                    StringComparison.Ordinal
+                                )
+                                    ? "explained"
+                                    : "threw: " + ex.Message;
+                            }
+
+                            return (
+                                firstOk && badRejected && neverMsg == "explained",
+                                $"{r.Count} result(s), unrun request {neverMsg}"
+                            );
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "SetInputVolumeMulAsync",
+                        async () =>
+                        {
+                            GetInputVolumeResponseData? before = await client
+                                .Inputs.GetInputVolumeAsync(
+                                    new GetInputVolumeRequestData(inputName: inputName),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            double original = before!.InputVolumeMul;
+
+                            await client
+                                .Inputs.SetInputVolumeMulAsync(inputName, 0.5, cancellationToken)
+                                .ConfigureAwait(false);
+                            GetInputVolumeResponseData? after = await client
+                                .Inputs.GetInputVolumeAsync(
+                                    new GetInputVolumeRequestData(inputName: inputName),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            double mul = after!.InputVolumeMul;
+
+                            await client
+                                .Inputs.SetInputVolumeMulAsync(
+                                    inputName,
+                                    original,
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            return (Math.Abs(mul - 0.5) < 0.01, $"mul={mul:0.###}");
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "SwitchProgramSceneAsync",
+                        async () =>
+                        {
+                            await client
+                                .Scenes.SwitchProgramSceneAsync(
+                                    sceneName,
+                                    cancellationToken: cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            GetSceneListResponseData? mid = await client
+                                .Scenes.GetSceneListAsync(
+                                    new GetSceneListRequestData(),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            bool switched = string.Equals(
+                                mid?.CurrentProgramSceneName,
+                                sceneName,
+                                StringComparison.Ordinal
+                            );
+
+                            await client
+                                .Scenes.SwitchProgramSceneAsync(
+                                    originalScene,
+                                    cancellationToken: cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            GetSceneListResponseData? restored = await client
+                                .Scenes.GetSceneListAsync(
+                                    new GetSceneListRequestData(),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            return (
+                                switched
+                                    && string.Equals(
+                                        restored?.CurrentProgramSceneName,
+                                        originalScene,
+                                        StringComparison.Ordinal
+                                    ),
+                                $"switched={switched}, restored to '{restored?.CurrentProgramSceneName}'"
+                            );
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "FindSceneItemIdInt32Async",
+                        async () =>
+                        {
+                            int? id = await client
+                                .SceneItems.FindSceneItemIdInt32Async(
+                                    sceneName,
+                                    inputName,
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            int? miss = await client
+                                .SceneItems.FindSceneItemIdInt32Async(
+                                    sceneName,
+                                    "__absent__",
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            return (
+                                id is not null && miss is null,
+                                $"id={id}, miss={(miss is null ? "null" : "unexpected")}"
+                            );
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "Screenshot helpers",
+                        async () =>
+                        {
+                            byte[]? bytes = await client
+                                .Sources.GetSourceScreenshotBytesAsync(
+                                    sceneName,
+                                    "png",
+                                    cancellationToken: cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            string path = Path.Combine(
+                                Path.GetTempPath(),
+                                $"obsws_{Guid.NewGuid():N}.png"
+                            );
+                            try
+                            {
+                                await client
+                                    .Sources.SaveSourceScreenshotToFileAsync(
+                                        sceneName,
+                                        path,
+                                        "png",
+                                        cancellationToken: cancellationToken
+                                    )
+                                    .ConfigureAwait(false);
+
+                                // A PNG starts with the eight byte signature, so this checks real image data
+                                // rather than merely that the call returned.
+                                byte[] written = await File.ReadAllBytesAsync(
+                                        path,
+                                        cancellationToken
+                                    )
+                                    .ConfigureAwait(false);
+                                bool pngOnDisk =
+                                    written.Length > 8
+                                    && written[0] == 0x89
+                                    && written[1] == 0x50
+                                    && written[2] == 0x4E
+                                    && written[3] == 0x47;
+                                bool pngInMemory =
+                                    bytes is { Length: > 8 }
+                                    && bytes[0] == 0x89
+                                    && bytes[1] == 0x50
+                                    && bytes[2] == 0x4E
+                                    && bytes[3] == 0x47;
+
+                                return (
+                                    pngInMemory && pngOnDisk,
+                                    $"{bytes?.Length ?? 0} bytes in memory, {written.Length} on disk"
+                                );
+                            }
+                            finally
+                            {
+                                if (File.Exists(path))
+                                {
+                                    File.Delete(path);
+                                }
+                            }
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "Ensure profile and scene collection",
+                        async () =>
+                        {
+                            // Asking for the one already active proves the check without disrupting OBS,
+                            // since switching either of these reloads the whole configuration.
+                            GetProfileListResponseData? profiles = await client
+                                .Config.GetProfileListAsync(cancellationToken)
+                                .ConfigureAwait(false);
+                            GetSceneCollectionListResponseData? collections = await client
+                                .Config.GetSceneCollectionListAsync(cancellationToken)
+                                .ConfigureAwait(false);
+
+                            bool profileOk = await client
+                                .Config.EnsureProfileActiveAsync(
+                                    profiles!.CurrentProfileName!,
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            bool collectionOk = await client
+                                .Config.EnsureSceneCollectionActiveAsync(
+                                    collections!.CurrentSceneCollectionName!,
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            bool absent = await client
+                                .Config.EnsureProfileActiveAsync(
+                                    "__no_such_profile__",
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            return (
+                                profileOk && collectionOk && !absent,
+                                $"profile={profiles.CurrentProfileName}, collection={collections.CurrentSceneCollectionName}, absent reported {absent}"
+                            );
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "Media transport shorthands",
+                        async () =>
+                        {
+                            await client
+                                .MediaInputs.PlayMediaAsync(inputName, cancellationToken)
+                                .ConfigureAwait(false);
+                            await client
+                                .MediaInputs.PauseMediaAsync(inputName, cancellationToken)
+                                .ConfigureAwait(false);
+                            await client
+                                .MediaInputs.RestartMediaAsync(inputName, cancellationToken)
+                                .ConfigureAwait(false);
+                            await client
+                                .MediaInputs.StopMediaAsync(inputName, cancellationToken)
+                                .ConfigureAwait(false);
+
+                            GetMediaInputStatusResponseData? status = await client
+                                .MediaInputs.GetMediaInputStatusAsync(
+                                    new GetMediaInputStatusRequestData(inputName: inputName),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            return (status is not null, $"state={status?.MediaState}");
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "Virtual camera toggle",
+                        async () =>
+                        {
+                            bool before = await client
+                                .Outputs.IsVirtualCamActiveAsync(cancellationToken)
+                                .ConfigureAwait(false);
+
+                            bool? turnedOn = await client
+                                .Outputs.SetVirtualCamActiveAndWaitAsync(
+                                    !before,
+                                    cancellationToken: cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            bool observed = await client
+                                .Outputs.IsVirtualCamActiveAsync(cancellationToken)
+                                .ConfigureAwait(false);
+
+                            // Put it back the way it was found.
+                            _ = await client
+                                .Outputs.SetVirtualCamActiveAndWaitAsync(
+                                    before,
+                                    cancellationToken: cancellationToken
+                                )
+                                .ConfigureAwait(false);
+                            bool restored = await client
+                                .Outputs.IsVirtualCamActiveAsync(cancellationToken)
+                                .ConfigureAwait(false);
+
+                            return (
+                                turnedOn == !before && observed == !before && restored == before,
+                                $"{before} -> {observed} -> {restored}"
+                            );
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "Typed exception on a rejected request",
+                        async () =>
+                        {
+                            try
+                            {
+                                _ = await client
+                                    .SceneItems.GetSceneItemListAsync(
+                                        new GetSceneItemListRequestData(
+                                            sceneName: "__no_such_scene__"
+                                        ),
+                                        cancellationToken
+                                    )
+                                    .ConfigureAwait(false);
+                                return (false, "no exception");
+                            }
+                            catch (ObsWebSocketRequestException ex)
+                            {
+                                return (
+                                    ex.Status?.Code == 600 && ex.RequestType == "GetSceneItemList",
+                                    $"{ex.RequestType} code {ex.Status?.Code}"
+                                );
+                            }
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
+                        "Output state helpers",
+                        async () =>
+                        {
+                            bool recording = await client
+                                .Record.IsRecordActiveAsync(cancellationToken)
+                                .ConfigureAwait(false);
+                            bool streaming = await client
+                                .Stream.IsStreamActiveAsync(cancellationToken)
+                                .ConfigureAwait(false);
+                            bool virtualCam = await client
+                                .Outputs.IsVirtualCamActiveAsync(cancellationToken)
+                                .ConfigureAwait(false);
+
+                            // Each helper has to agree with the request it wraps.
+                            GetRecordStatusResponseData? recordStatus = await client
+                                .Record.GetRecordStatusAsync(cancellationToken)
+                                .ConfigureAwait(false);
+                            GetStreamStatusResponseData? streamStatus = await client
+                                .Stream.GetStreamStatusAsync(cancellationToken)
+                                .ConfigureAwait(false);
+                            GetVirtualCamStatusResponseData? camStatus = await client
+                                .Outputs.GetVirtualCamStatusAsync(cancellationToken)
+                                .ConfigureAwait(false);
+
+                            bool agrees =
+                                recording == recordStatus?.OutputActive
+                                && streaming == streamStatus?.OutputActive
+                                && virtualCam == camStatus?.OutputActive;
+
+                            return (
+                                agrees,
+                                $"record={recording}, stream={streaming}, virtualCam={virtualCam}, agrees={agrees}"
+                            );
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
         }
         finally
         {
@@ -1790,20 +2322,31 @@ internal sealed partial class Worker(
             {
                 if (!string.IsNullOrEmpty(originalScene))
                 {
-                    await client.Scenes.SwitchSceneAsync(originalScene, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+                    await client
+                        .Scenes.SwitchSceneAsync(
+                            originalScene,
+                            cancellationToken: CancellationToken.None
+                        )
+                        .ConfigureAwait(false);
                 }
 
                 if (inputCreated)
                 {
                     await client
-                        .Inputs.RemoveInputAsync(new RemoveInputRequestData(inputName: inputName), CancellationToken.None)
+                        .Inputs.RemoveInputAsync(
+                            new RemoveInputRequestData(inputName: inputName),
+                            CancellationToken.None
+                        )
                         .ConfigureAwait(false);
                 }
 
                 if (sceneCreated)
                 {
                     await client
-                        .Scenes.RemoveSceneAsync(new RemoveSceneRequestData(sceneName: sceneName), CancellationToken.None)
+                        .Scenes.RemoveSceneAsync(
+                            new RemoveSceneRequestData(sceneName: sceneName),
+                            CancellationToken.None
+                        )
                         .ConfigureAwait(false);
                 }
             }
@@ -1818,7 +2361,8 @@ internal sealed partial class Worker(
 
     private static async Task<(string Label, bool Pass, string Detail)> TrySettingsCheckAsync(
         string label,
-        Func<Task<(bool Pass, string Detail)>> action)
+        Func<Task<(bool Pass, string Detail)>> action
+    )
     {
         try
         {
@@ -1855,8 +2399,8 @@ internal sealed partial class Worker(
     {
         List<Dictionary<string, JsonElement>?> extensionBags =
         [
-            ..(scenes?.Scenes ?? []).Select(scene => scene.ExtensionData),
-            ..(inputs?.Inputs ?? []).Select(input => input.ExtensionData),
+            .. (scenes?.Scenes ?? []).Select(scene => scene.ExtensionData),
+            .. (inputs?.Inputs ?? []).Select(input => input.ExtensionData),
         ];
 
         int extensionBagCount = extensionBags.Count(bag => bag is { Count: > 0 });
@@ -1865,7 +2409,11 @@ internal sealed partial class Worker(
             .Sum(bag => bag!.Count);
 
         bool valid = true;
-        foreach (Dictionary<string, JsonElement>? bag in extensionBags.Where(bag => bag is { Count: > 0 }))
+        foreach (
+            Dictionary<string, JsonElement>? bag in extensionBags.Where(bag =>
+                bag is { Count: > 0 }
+            )
+        )
         {
             foreach ((string _, JsonElement value) in bag!)
             {
@@ -1978,7 +2526,12 @@ internal sealed partial class Worker(
                 foreach (JsonElement element in source.EnumerateArray())
                 {
                     if (
-                        TryFindCustomEventPayloadByTestIdCore(element, testId, depth + 1, out payload)
+                        TryFindCustomEventPayloadByTestIdCore(
+                            element,
+                            testId,
+                            depth + 1,
+                            out payload
+                        )
                     )
                     {
                         return true;
@@ -2066,14 +2619,17 @@ internal sealed partial class Worker(
             "Filter Kind Defaults",
             async ct =>
             {
-                GetSourceFilterKindListResponseData? r = await _obsClient.Filters.GetSourceFilterKindListAsync(cancellationToken: ct);
+                GetSourceFilterKindListResponseData? r =
+                    await _obsClient.Filters.GetSourceFilterKindListAsync(cancellationToken: ct);
                 return r?.SourceFilterKinds ?? [];
             },
             async (kind, ct) =>
             {
-                GetSourceFilterDefaultSettingsResponseData? r = await _obsClient.Filters.GetSourceFilterDefaultSettingsAsync(new GetSourceFilterDefaultSettingsRequestData(kind),
-                    cancellationToken: ct
-                );
+                GetSourceFilterDefaultSettingsResponseData? r =
+                    await _obsClient.Filters.GetSourceFilterDefaultSettingsAsync(
+                        new GetSourceFilterDefaultSettingsRequestData(kind),
+                        cancellationToken: ct
+                    );
                 return r?.DefaultFilterSettings;
             },
             cancellationToken
@@ -2091,9 +2647,11 @@ internal sealed partial class Worker(
             },
             async (kind, ct) =>
             {
-                GetInputDefaultSettingsResponseData? r = await _obsClient.Inputs.GetInputDefaultSettingsAsync(new GetInputDefaultSettingsRequestData(kind),
-                    cancellationToken: ct
-                );
+                GetInputDefaultSettingsResponseData? r =
+                    await _obsClient.Inputs.GetInputDefaultSettingsAsync(
+                        new GetInputDefaultSettingsRequestData(kind),
+                        cancellationToken: ct
+                    );
                 return r?.DefaultInputSettings;
             },
             cancellationToken
@@ -2128,7 +2686,11 @@ internal sealed partial class Worker(
             return;
         }
 
-        _logger.LogInformation("Found {Count} kinds for '{Panel}'. Fetching defaults...", kinds.Count, panelTitle);
+        _logger.LogInformation(
+            "Found {Count} kinds for '{Panel}'. Fetching defaults...",
+            kinds.Count,
+            panelTitle
+        );
 
         Dictionary<string, JsonElement?> results = new(StringComparer.OrdinalIgnoreCase);
         foreach (string kind in kinds)
@@ -2186,19 +2748,28 @@ internal sealed partial class Worker(
             string key = output.OutputKind is { } kind ? $"{name} ({kind})" : name;
             try
             {
-                GetOutputSettingsResponseData? r = await _obsClient.Outputs.GetOutputSettingsAsync(new GetOutputSettingsRequestData(outputName: name),
+                GetOutputSettingsResponseData? r = await _obsClient.Outputs.GetOutputSettingsAsync(
+                    new GetOutputSettingsRequestData(outputName: name),
                     cancellationToken: cancellationToken
                 );
                 results[key] = r?.OutputSettings;
             }
             catch (ObsWebSocketException ex)
             {
-                _logger.LogWarning("Could not get settings for output '{Name}': {Msg}", name, ex.Message);
+                _logger.LogWarning(
+                    "Could not get settings for output '{Name}': {Msg}",
+                    name,
+                    ex.Message
+                );
                 results[key] = null;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Unexpected error getting settings for output '{Name}'.", name);
+                _logger.LogError(
+                    ex,
+                    "Unexpected error getting settings for output '{Name}'.",
+                    name
+                );
                 results[key] = null;
             }
         }
@@ -2210,8 +2781,10 @@ internal sealed partial class Worker(
     {
         try
         {
-            GetStreamServiceSettingsResponseData? response = await _obsClient.Config.GetStreamServiceSettingsAsync(cancellationToken: cancellationToken
-            );
+            GetStreamServiceSettingsResponseData? response =
+                await _obsClient.Config.GetStreamServiceSettingsAsync(
+                    cancellationToken: cancellationToken
+                );
 
             ArrayBufferWriter<byte> buf = new();
             using (Utf8JsonWriter w = new(buf, new JsonWriterOptions { Indented = true }))
@@ -2232,7 +2805,10 @@ internal sealed partial class Worker(
                 w.Flush();
             }
 
-            RenderJsonPanel("Stream Service Settings", System.Text.Encoding.UTF8.GetString(buf.WrittenSpan));
+            RenderJsonPanel(
+                "Stream Service Settings",
+                System.Text.Encoding.UTF8.GetString(buf.WrittenSpan)
+            );
         }
         catch (Exception ex)
         {
@@ -2279,19 +2855,21 @@ internal sealed partial class Worker(
 
         string currentProgramScene = sceneList.CurrentProgramSceneName ?? string.Empty;
 
-        List<string> sceneNames = [
-            ..sceneList.Scenes
-                .Select(s => s.SceneName)
+        List<string> sceneNames =
+        [
+            .. sceneList
+                .Scenes.Select(s => s.SceneName)
                 .Where(n => !string.IsNullOrEmpty(n))
                 .Select(n => n!),
         ];
 
         // Place current program scene first, then alphabetically
         List<string> orderedSceneNames = !string.IsNullOrEmpty(currentProgramScene)
-            ? [
-                ..sceneNames.Where(n => n == currentProgramScene),
-                ..sceneNames.Where(n => n != currentProgramScene).OrderBy(n => n),
-              ]
+            ?
+            [
+                .. sceneNames.Where(n => n == currentProgramScene),
+                .. sceneNames.Where(n => n != currentProgramScene).OrderBy(n => n),
+            ]
             : [.. sceneNames.OrderBy(n => n)];
 
         if (orderedSceneNames.Count == 0)
@@ -2317,10 +2895,11 @@ internal sealed partial class Worker(
         string selectedScene = displayToSceneName[selectedSceneDisplay];
 
         // Step 3: Fetch scene items and all global browser_source inputs in parallel
-        Task<GetSceneItemListResponseData> sceneItemsTask = _obsClient.SceneItems.GetSceneItemListAsync(
-            new GetSceneItemListRequestData(sceneName: selectedScene),
-            cancellationToken: cancellationToken
-        );
+        Task<GetSceneItemListResponseData> sceneItemsTask =
+            _obsClient.SceneItems.GetSceneItemListAsync(
+                new GetSceneItemListRequestData(sceneName: selectedScene),
+                cancellationToken: cancellationToken
+            );
         Task<GetInputListResponseData> browserInputsTask = _obsClient.Inputs.GetInputListAsync(
             new GetInputListRequestData("browser_source"),
             cancellationToken: cancellationToken
@@ -2332,17 +2911,21 @@ internal sealed partial class Worker(
         GetInputListResponseData? browserInputList = await browserInputsTask;
 
         // Find browser sources that already exist in the selected scene
-        HashSet<string> sceneSourceNames = sceneItemList?.SceneItems?
-            .Select(si => si.SourceName ?? string.Empty)
-            .Where(n => !string.IsNullOrEmpty(n))
-            .ToHashSet(StringComparer.OrdinalIgnoreCase) ?? [];
+        HashSet<string> sceneSourceNames =
+            sceneItemList
+                ?.SceneItems?.Select(si => si.SourceName ?? string.Empty)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase)
+            ?? [];
 
-        List<string> existingBrowserSourcesInScene = browserInputList?.Inputs?
-            .Where(i => sceneSourceNames.Contains(i.InputName ?? string.Empty))
-            .Select(i => i.InputName!)
-            .Where(n => !string.IsNullOrEmpty(n))
-            .OrderBy(n => n)
-            .ToList() ?? [];
+        List<string> existingBrowserSourcesInScene =
+            browserInputList
+                ?.Inputs?.Where(i => sceneSourceNames.Contains(i.InputName ?? string.Empty))
+                .Select(i => i.InputName!)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .OrderBy(n => n)
+                .ToList()
+            ?? [];
 
         // Step 4: Prompt — create new source or update an existing browser source
         const string CreateNewChoice = "+ Create new browser source";
@@ -2358,12 +2941,11 @@ internal sealed partial class Worker(
         bool isNewSource = selectedSourceChoice == CreateNewChoice;
         string sourceName = isNewSource
             ? AnsiConsole.Prompt(
-                new TextPrompt<string>("New browser source [cyan]name[/]:")
-                    .Validate(s =>
-                        !string.IsNullOrWhiteSpace(s)
-                            ? ValidationResult.Success()
-                            : ValidationResult.Error("[red]Name cannot be empty.[/]")
-                    )
+                new TextPrompt<string>("New browser source [cyan]name[/]:").Validate(s =>
+                    !string.IsNullOrWhiteSpace(s)
+                        ? ValidationResult.Success()
+                        : ValidationResult.Error("[red]Name cannot be empty.[/]")
+                )
             )
             : selectedSourceChoice;
 
@@ -2384,12 +2966,11 @@ internal sealed partial class Worker(
 
         // Step 6: Prompt for the overlay URL
         string url = AnsiConsole.Prompt(
-            new TextPrompt<string>("Browser source [cyan]URL[/]:")
-                .Validate(s =>
-                    !string.IsNullOrWhiteSpace(s)
-                        ? ValidationResult.Success()
-                        : ValidationResult.Error("[red]URL cannot be empty.[/]")
-                )
+            new TextPrompt<string>("Browser source [cyan]URL[/]:").Validate(s =>
+                !string.IsNullOrWhiteSpace(s)
+                    ? ValidationResult.Success()
+                    : ValidationResult.Error("[red]URL cannot be empty.[/]")
+            )
         );
 
         // Step 7: Build the browser source settings payload
@@ -2415,7 +2996,8 @@ internal sealed partial class Worker(
         {
             UiInfo($"Creating browser source '{sourceName}' in scene '{selectedScene}'...");
 
-            CreateInputResponseData? createResult = await _obsClient.Inputs.CreateInputAsync(inputKind: "browser_source",
+            CreateInputResponseData? createResult = await _obsClient.Inputs.CreateInputAsync(
+                inputKind: "browser_source",
                 inputName: sourceName,
                 settings: browserSettings,
                 sceneName: selectedScene,
@@ -2437,7 +3019,8 @@ internal sealed partial class Worker(
             UiInfo($"Updating browser source '{sourceName}' settings...");
 
             // overlay: false — reset to defaults then apply all new settings cleanly
-            await _obsClient.Inputs.SetInputSettingsAsync(inputName: sourceName,
+            await _obsClient.Inputs.SetInputSettingsAsync(
+                inputName: sourceName,
                 settings: browserSettings,
                 overlay: false,
                 cancellationToken: cancellationToken
@@ -2496,15 +3079,15 @@ internal sealed partial class Worker(
             Markup.Escape("version"),
             Markup.Escape("Get OBS and WebSocket version info")
         );
-        _ = commandTable.AddRow(
-            Markup.Escape("scene"),
-            Markup.Escape("Get current program scene")
-        );
+        _ = commandTable.AddRow(Markup.Escape("scene"), Markup.Escape("Get current program scene"));
         _ = commandTable.AddRow(
             Markup.Escape("mute [input name]"),
             Markup.Escape("Toggle mute for audio input")
         );
-        _ = commandTable.AddRow(Markup.Escape("unmute [input name]"), Markup.Escape("Alias for mute"));
+        _ = commandTable.AddRow(
+            Markup.Escape("unmute [input name]"),
+            Markup.Escape("Alias for mute")
+        );
         _ = commandTable.AddRow(
             Markup.Escape("get-input-settings [scene] [input]"),
             Markup.Escape("Get settings for an input")
@@ -2535,7 +3118,9 @@ internal sealed partial class Worker(
         );
         _ = commandTable.AddRow(
             Markup.Escape("run-transport-tests"),
-            Markup.Escape("Run validation cycle for the configured transport (version, scenes, inputs, filters, custom event, batch, settings modes 1/2/3)")
+            Markup.Escape(
+                "Run validation cycle for the configured transport (version, scenes, inputs, filters, custom event, batch, settings modes 1/2/3)"
+            )
         );
         _ = commandTable.AddRow(
             Markup.Escape("list-subs"),
@@ -2547,7 +3132,9 @@ internal sealed partial class Worker(
         );
         _ = commandTable.AddRow(
             Markup.Escape("get-all-settings-types"),
-            Markup.Escape("Dump default settings for all filter kinds, input kinds, and current stream service")
+            Markup.Escape(
+                "Dump default settings for all filter kinds, input kinds, and current stream service"
+            )
         );
         _ = commandTable.AddRow(
             Markup.Escape("add-browser-source"),
@@ -2556,7 +3143,10 @@ internal sealed partial class Worker(
         AnsiConsole.Write(commandTable);
     }
 
-    private static void RenderKeyValueTable(string title, IReadOnlyList<(string Key, string Value)> rows)
+    private static void RenderKeyValueTable(
+        string title,
+        IReadOnlyList<(string Key, string Value)> rows
+    )
     {
         Table table = new() { Title = new TableTitle(title) };
         _ = table.AddColumn("Property");
@@ -2713,15 +3303,12 @@ internal sealed record WorkerBrowserUrlSettings(
     [property: JsonPropertyName("url")] string? Url = null
 );
 
-internal sealed record WorkerGainDbSettings(
-    [property: JsonPropertyName("db")] double? Db = null
-);
+internal sealed record WorkerGainDbSettings([property: JsonPropertyName("db")] double? Db = null);
 
 [JsonSerializable(typeof(WorkerBrowserUrlSettings))]
 [JsonSerializable(typeof(WorkerGainDbSettings))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
-    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault)]
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault
+)]
 internal sealed partial class WorkerSettingsJsonContext : JsonSerializerContext { }
-
-

--- a/ObsWebSocket.Example/Worker.cs
+++ b/ObsWebSocket.Example/Worker.cs
@@ -1532,7 +1532,7 @@ internal sealed partial class Worker(
 
                             await Task.Delay(250, cancellationToken).ConfigureAwait(false);
                             await client
-                                .Scenes.SwitchSceneAsync(
+                                .Scenes.SwitchProgramSceneAsync(
                                     sceneName,
                                     cancellationToken: cancellationToken
                                 )
@@ -1541,7 +1541,7 @@ internal sealed partial class Worker(
                             if (!string.IsNullOrEmpty(originalScene))
                             {
                                 await client
-                                    .Scenes.SwitchSceneAsync(
+                                    .Scenes.SwitchProgramSceneAsync(
                                         originalScene,
                                         cancellationToken: cancellationToken
                                     )
@@ -2437,7 +2437,7 @@ internal sealed partial class Worker(
                 if (!string.IsNullOrEmpty(originalScene))
                 {
                     await client
-                        .Scenes.SwitchSceneAsync(
+                        .Scenes.SwitchProgramSceneAsync(
                             originalScene,
                             cancellationToken: CancellationToken.None
                         )

--- a/ObsWebSocket.Example/Worker.cs
+++ b/ObsWebSocket.Example/Worker.cs
@@ -2252,6 +2252,116 @@ internal sealed partial class Worker(
 
             results.Add(
                 await TrySettingsCheckAsync(
+                        "Integer fields round trip",
+                        async () =>
+                        {
+                            // The protocol calls every number "Number", so these fields used to
+                            // arrive as double. Writing one and reading it back proves the
+                            // retype survives the wire in both directions, which matters most
+                            // for MessagePack, where an int and a float are different encodings.
+                            int itemId =
+                                await client
+                                    .SceneItems.FindSceneItemIdAsync(
+                                        sceneName,
+                                        inputName,
+                                        cancellationToken
+                                    )
+                                    .ConfigureAwait(false)
+                                ?? throw new InvalidOperationException(
+                                    $"'{inputName}' is not in '{sceneName}'."
+                                );
+
+                            GetSceneItemIndexResponseData originalIndex = await client
+                                .SceneItems.GetSceneItemIndexAsync(
+                                    new GetSceneItemIndexRequestData(
+                                        sceneItemId: itemId,
+                                        sceneName: sceneName
+                                    ),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            await client
+                                .SceneItems.SetSceneItemIndexAsync(
+                                    new SetSceneItemIndexRequestData(
+                                        sceneItemId: itemId,
+                                        sceneItemIndex: 0,
+                                        sceneName: sceneName
+                                    ),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            GetSceneItemIndexResponseData afterIndex = await client
+                                .SceneItems.GetSceneItemIndexAsync(
+                                    new GetSceneItemIndexRequestData(
+                                        sceneItemId: itemId,
+                                        sceneName: sceneName
+                                    ),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            await client
+                                .SceneItems.SetSceneItemIndexAsync(
+                                    new SetSceneItemIndexRequestData(
+                                        sceneItemId: itemId,
+                                        sceneItemIndex: originalIndex.SceneItemIndex,
+                                        sceneName: sceneName
+                                    ),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            // A negative value, since OBS accepts negative sync offsets and a
+                            // sign error would otherwise go unnoticed.
+                            GetInputAudioSyncOffsetResponseData originalOffset = await client
+                                .Inputs.GetInputAudioSyncOffsetAsync(
+                                    new GetInputAudioSyncOffsetRequestData(inputName: inputName),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            await client
+                                .Inputs.SetInputAudioSyncOffsetAsync(
+                                    new SetInputAudioSyncOffsetRequestData(
+                                        inputAudioSyncOffset: -125,
+                                        inputName: inputName
+                                    ),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            GetInputAudioSyncOffsetResponseData afterOffset = await client
+                                .Inputs.GetInputAudioSyncOffsetAsync(
+                                    new GetInputAudioSyncOffsetRequestData(inputName: inputName),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            await client
+                                .Inputs.SetInputAudioSyncOffsetAsync(
+                                    new SetInputAudioSyncOffsetRequestData(
+                                        inputAudioSyncOffset: originalOffset.InputAudioSyncOffset,
+                                        inputName: inputName
+                                    ),
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false);
+
+                            return (
+                                afterIndex.SceneItemIndex == 0
+                                    && afterOffset.InputAudioSyncOffset == -125,
+                                $"index {originalIndex.SceneItemIndex} -> {afterIndex.SceneItemIndex}, "
+                                    + $"syncOffset {originalOffset.InputAudioSyncOffset} -> {afterOffset.InputAudioSyncOffset}"
+                            );
+                        }
+                    )
+                    .ConfigureAwait(false)
+            );
+
+            results.Add(
+                await TrySettingsCheckAsync(
                         "Typed exception on a rejected request",
                         async () =>
                         {

--- a/ObsWebSocket.Example/Worker.cs
+++ b/ObsWebSocket.Example/Worker.cs
@@ -1591,6 +1591,149 @@ internal sealed partial class Worker(
                 );
             }).ConfigureAwait(false));
 
+            results.Add(await TrySettingsCheckAsync("SetInputVolumeMulAsync", async () =>
+            {
+                GetInputVolumeResponseData? before = await client
+                    .Inputs.GetInputVolumeAsync(new GetInputVolumeRequestData(inputName: inputName), cancellationToken)
+                    .ConfigureAwait(false);
+                double original = before!.InputVolumeMul;
+
+                await client.Inputs.SetInputVolumeMulAsync(inputName, 0.5, cancellationToken).ConfigureAwait(false);
+                GetInputVolumeResponseData? after = await client
+                    .Inputs.GetInputVolumeAsync(new GetInputVolumeRequestData(inputName: inputName), cancellationToken)
+                    .ConfigureAwait(false);
+                double mul = after!.InputVolumeMul;
+
+                await client.Inputs.SetInputVolumeMulAsync(inputName, original, cancellationToken).ConfigureAwait(false);
+                return (Math.Abs(mul - 0.5) < 0.01, $"mul={mul:0.###}");
+            }).ConfigureAwait(false));
+
+            results.Add(await TrySettingsCheckAsync("SwitchProgramSceneAsync", async () =>
+            {
+                await client.Scenes.SwitchProgramSceneAsync(sceneName, cancellationToken: cancellationToken).ConfigureAwait(false);
+                GetSceneListResponseData? mid = await client
+                    .Scenes.GetSceneListAsync(new GetSceneListRequestData(), cancellationToken)
+                    .ConfigureAwait(false);
+                bool switched = string.Equals(mid?.CurrentProgramSceneName, sceneName, StringComparison.Ordinal);
+
+                await client.Scenes.SwitchProgramSceneAsync(originalScene, cancellationToken: cancellationToken).ConfigureAwait(false);
+                GetSceneListResponseData? restored = await client
+                    .Scenes.GetSceneListAsync(new GetSceneListRequestData(), cancellationToken)
+                    .ConfigureAwait(false);
+
+                return (
+                    switched && string.Equals(restored?.CurrentProgramSceneName, originalScene, StringComparison.Ordinal),
+                    $"switched={switched}, restored to '{restored?.CurrentProgramSceneName}'"
+                );
+            }).ConfigureAwait(false));
+
+            results.Add(await TrySettingsCheckAsync("FindSceneItemIdInt32Async", async () =>
+            {
+                int? id = await client
+                    .SceneItems.FindSceneItemIdInt32Async(sceneName, inputName, cancellationToken)
+                    .ConfigureAwait(false);
+                int? miss = await client
+                    .SceneItems.FindSceneItemIdInt32Async(sceneName, "__absent__", cancellationToken)
+                    .ConfigureAwait(false);
+
+                return (id is not null && miss is null, $"id={id}, miss={(miss is null ? "null" : "unexpected")}");
+            }).ConfigureAwait(false));
+
+            results.Add(await TrySettingsCheckAsync("Screenshot helpers", async () =>
+            {
+                byte[]? bytes = await client
+                    .Sources.GetSourceScreenshotBytesAsync(sceneName, "png", cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+
+                string path = Path.Combine(Path.GetTempPath(), $"obsws_{Guid.NewGuid():N}.png");
+                try
+                {
+                    await client
+                        .Sources.SaveSourceScreenshotToFileAsync(sceneName, path, "png", cancellationToken: cancellationToken)
+                        .ConfigureAwait(false);
+
+                    // A PNG starts with the eight byte signature, so this checks real image data
+                    // rather than merely that the call returned.
+                    byte[] written = await File.ReadAllBytesAsync(path, cancellationToken).ConfigureAwait(false);
+                    bool pngOnDisk =
+                        written.Length > 8
+                        && written[0] == 0x89 && written[1] == 0x50 && written[2] == 0x4E && written[3] == 0x47;
+                    bool pngInMemory =
+                        bytes is { Length: > 8 }
+                        && bytes[0] == 0x89 && bytes[1] == 0x50 && bytes[2] == 0x4E && bytes[3] == 0x47;
+
+                    return (pngInMemory && pngOnDisk, $"{bytes?.Length ?? 0} bytes in memory, {written.Length} on disk");
+                }
+                finally
+                {
+                    if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                    }
+                }
+            }).ConfigureAwait(false));
+
+            results.Add(await TrySettingsCheckAsync("Ensure profile and scene collection", async () =>
+            {
+                // Asking for the one already active proves the check without disrupting OBS,
+                // since switching either of these reloads the whole configuration.
+                GetProfileListResponseData? profiles = await client
+                    .Config.GetProfileListAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                GetSceneCollectionListResponseData? collections = await client
+                    .Config.GetSceneCollectionListAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                bool profileOk = await client
+                    .Config.EnsureProfileActiveAsync(profiles!.CurrentProfileName!, cancellationToken)
+                    .ConfigureAwait(false);
+                bool collectionOk = await client
+                    .Config.EnsureSceneCollectionActiveAsync(collections!.CurrentSceneCollectionName!, cancellationToken)
+                    .ConfigureAwait(false);
+                bool absent = await client
+                    .Config.EnsureProfileActiveAsync("__no_such_profile__", cancellationToken)
+                    .ConfigureAwait(false);
+
+                return (
+                    profileOk && collectionOk && !absent,
+                    $"profile={profiles.CurrentProfileName}, collection={collections.CurrentSceneCollectionName}, absent reported {absent}"
+                );
+            }).ConfigureAwait(false));
+
+            results.Add(await TrySettingsCheckAsync("Media transport shorthands", async () =>
+            {
+                await client.MediaInputs.PlayMediaAsync(inputName, cancellationToken).ConfigureAwait(false);
+                await client.MediaInputs.PauseMediaAsync(inputName, cancellationToken).ConfigureAwait(false);
+                await client.MediaInputs.RestartMediaAsync(inputName, cancellationToken).ConfigureAwait(false);
+                await client.MediaInputs.StopMediaAsync(inputName, cancellationToken).ConfigureAwait(false);
+
+                GetMediaInputStatusResponseData? status = await client
+                    .MediaInputs.GetMediaInputStatusAsync(
+                        new GetMediaInputStatusRequestData(inputName: inputName), cancellationToken)
+                    .ConfigureAwait(false);
+
+                return (status is not null, $"state={status?.MediaState}");
+            }).ConfigureAwait(false));
+
+            results.Add(await TrySettingsCheckAsync("Typed exception on a rejected request", async () =>
+            {
+                try
+                {
+                    _ = await client
+                        .SceneItems.GetSceneItemListAsync(
+                            new GetSceneItemListRequestData(sceneName: "__no_such_scene__"), cancellationToken)
+                        .ConfigureAwait(false);
+                    return (false, "no exception");
+                }
+                catch (ObsWebSocketRequestException ex)
+                {
+                    return (
+                        ex.Status?.Code == 600 && ex.RequestType == "GetSceneItemList",
+                        $"{ex.RequestType} code {ex.Status?.Code}"
+                    );
+                }
+            }).ConfigureAwait(false));
+
             results.Add(await TrySettingsCheckAsync("Output state helpers", async () =>
             {
                 bool recording = await client.Record.IsRecordActiveAsync(cancellationToken).ConfigureAwait(false);

--- a/ObsWebSocket.Example/Worker.cs
+++ b/ObsWebSocket.Example/Worker.cs
@@ -2042,18 +2042,18 @@ internal sealed partial class Worker(
 
             results.Add(
                 await TrySettingsCheckAsync(
-                        "FindSceneItemIdInt32Async",
+                        "FindSceneItemIdAsync",
                         async () =>
                         {
                             int? id = await client
-                                .SceneItems.FindSceneItemIdInt32Async(
+                                .SceneItems.FindSceneItemIdAsync(
                                     sceneName,
                                     inputName,
                                     cancellationToken
                                 )
                                 .ConfigureAwait(false);
                             int? miss = await client
-                                .SceneItems.FindSceneItemIdInt32Async(
+                                .SceneItems.FindSceneItemIdAsync(
                                     sceneName,
                                     "__absent__",
                                     cancellationToken

--- a/ObsWebSocket.Example/Worker.cs
+++ b/ObsWebSocket.Example/Worker.cs
@@ -534,7 +534,7 @@ internal sealed partial class Worker(
                 try
                 {
                     await foreach (
-                        CurrentProgramSceneChangedEventArgs sceneEvent in _obsClient.CurrentProgramSceneChangedStream(
+                        CurrentProgramSceneChangedEventArgs sceneEvent in _obsClient.Scenes.CurrentProgramSceneChangedStream(
                             cancellationToken: watchCts.Token
                         )
                     )
@@ -1279,7 +1279,7 @@ internal sealed partial class Worker(
                     try
                     {
                         await foreach (CurrentProgramSceneChangedEventArgs sceneEvent
-                            in client.CurrentProgramSceneChangedStream(cancellationToken: streamCts.Token)
+                            in client.Scenes.CurrentProgramSceneChangedStream(cancellationToken: streamCts.Token)
                             .ConfigureAwait(false))
                         {
                             observed.Add(sceneEvent.EventData.SceneName ?? string.Empty);
@@ -1470,7 +1470,7 @@ internal sealed partial class Worker(
                 cts.CancelAfter(TimeSpan.FromSeconds(10));
 
                 IAsyncEnumerator<SceneItemEnableStateChangedEventArgs> enumerator = client
-                    .SceneItemEnableStateChangedStream(capacity: 2, cancellationToken: cts.Token)
+                    .SceneItems.SceneItemEnableStateChangedStream(capacity: 2, cancellationToken: cts.Token)
                     .GetAsyncEnumerator(cts.Token);
 
                 try

--- a/ObsWebSocket.Example/Worker.cs
+++ b/ObsWebSocket.Example/Worker.cs
@@ -1715,6 +1715,27 @@ internal sealed partial class Worker(
                 return (status is not null, $"state={status?.MediaState}");
             }).ConfigureAwait(false));
 
+            results.Add(await TrySettingsCheckAsync("Virtual camera toggle", async () =>
+            {
+                bool before = await client.Outputs.IsVirtualCamActiveAsync(cancellationToken).ConfigureAwait(false);
+
+                bool? turnedOn = await client
+                    .Outputs.SetVirtualCamActiveAndWaitAsync(!before, cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+                bool observed = await client.Outputs.IsVirtualCamActiveAsync(cancellationToken).ConfigureAwait(false);
+
+                // Put it back the way it was found.
+                _ = await client
+                    .Outputs.SetVirtualCamActiveAndWaitAsync(before, cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+                bool restored = await client.Outputs.IsVirtualCamActiveAsync(cancellationToken).ConfigureAwait(false);
+
+                return (
+                    turnedOn == !before && observed == !before && restored == before,
+                    $"{before} -> {observed} -> {restored}"
+                );
+            }).ConfigureAwait(false));
+
             results.Add(await TrySettingsCheckAsync("Typed exception on a rejected request", async () =>
             {
                 try

--- a/ObsWebSocket.Example/Worker.cs
+++ b/ObsWebSocket.Example/Worker.cs
@@ -593,14 +593,16 @@ internal sealed partial class Worker(
                 // Add remains for anything the generated methods do not cover.
                 _ = exampleBatch.Add("GetStats");
 
-                List<RequestResponsePayload<object>> batchResults = (
-                    await _obsClient.CallBatchAsync(
+                // BatchResults is itself the list of results, so there is no reason to drop to
+                // Raw here; keeping it means the typed references stay usable further down.
+                BatchResults batchResults = await _obsClient
+                    .CallBatchAsync(
                         exampleBatch,
                         executionType: RequestBatchExecutionType.SerialRealtime,
                         haltOnFailure: false, // Continue even if one fails
                         cancellationToken: cancellationToken
                     )
-                ).Raw.ToList();
+                    .ConfigureAwait(false);
 
                 Table batchTable = new()
                 {
@@ -956,6 +958,8 @@ internal sealed partial class Worker(
                 );
             }
 
+            // The low level path, on purpose: the raw overload takes request items rather than the
+            // typed builder, and still works for anyone who needs to hand roll a batch.
             List<RequestResponsePayload<object>> batch = await cycleClient
                 .CallBatchAsync(
                     [new("GetVersion", null), new("GetSceneList", null)],

--- a/ObsWebSocket.Tests/BatchBuilderAndEnumTests.cs
+++ b/ObsWebSocket.Tests/BatchBuilderAndEnumTests.cs
@@ -123,7 +123,11 @@ public sealed class ProtocolEnumTests
         foreach (OutputState value in Enum.GetValues<OutputState>())
         {
             string wire = value.ToWireValue();
-            Assert.AreEqual(value, OutputStateExtensions.FromWireValue(wire), $"round trip for {value}");
+            Assert.AreEqual(
+                value,
+                OutputStateExtensions.FromWireValue(wire),
+                $"round trip for {value}"
+            );
         }
     }
 
@@ -133,14 +137,21 @@ public sealed class ProtocolEnumTests
         foreach (MediaInputAction value in Enum.GetValues<MediaInputAction>())
         {
             string wire = value.ToWireValue();
-            Assert.AreEqual(value, MediaInputActionExtensions.FromWireValue(wire), $"round trip for {value}");
+            Assert.AreEqual(
+                value,
+                MediaInputActionExtensions.FromWireValue(wire),
+                $"round trip for {value}"
+            );
         }
     }
 
     [TestMethod]
     public void ToWireValue_MatchesTheProtocolConstants()
     {
-        Assert.AreEqual(ObsOutputState.OBS_WEBSOCKET_OUTPUT_STARTED, OutputState.Started.ToWireValue());
+        Assert.AreEqual(
+            ObsOutputState.OBS_WEBSOCKET_OUTPUT_STARTED,
+            OutputState.Started.ToWireValue()
+        );
         Assert.AreEqual(
             ObsMediaInputAction.OBS_WEBSOCKET_MEDIA_INPUT_ACTION_PLAY,
             MediaInputAction.Play.ToWireValue()

--- a/ObsWebSocket.Tests/BatchResultTests.cs
+++ b/ObsWebSocket.Tests/BatchResultTests.cs
@@ -18,13 +18,12 @@ public sealed class BatchResultTests
 
     private static RequestResponsePayload<object> JsonResult(string type, object? payload)
     {
-        JsonElement element =
-            payload is null
-                ? default
-                : JsonSerializer.SerializeToElement(
-                    payload,
-                    ObsWebSocketJsonContext.Default.Options.GetTypeInfo(payload.GetType())
-                );
+        JsonElement element = payload is null
+            ? default
+            : JsonSerializer.SerializeToElement(
+                payload,
+                ObsWebSocketJsonContext.Default.Options.GetTypeInfo(payload.GetType())
+            );
 
         return new RequestResponsePayload<object>(type, $"{type}_0", Ok, element);
     }
@@ -87,10 +86,9 @@ public sealed class BatchResultTests
             null
         );
 
-        ObsWebSocketRequestException ex =
-            Assert.ThrowsExactly<ObsWebSocketRequestException>(
-                () => result.GetRequiredData<GetSceneItemListResponseData>()
-            );
+        ObsWebSocketRequestException ex = Assert.ThrowsExactly<ObsWebSocketRequestException>(() =>
+            result.GetRequiredData<GetSceneItemListResponseData>()
+        );
 
         Assert.AreEqual(600, ex.Status?.Code);
         Assert.AreEqual("GetSceneItemList", ex.RequestType);
@@ -115,7 +113,10 @@ public sealed class BatchResultTests
     {
         List<RequestResponsePayload<object>> results =
         [
-            JsonResult("GetVersion", new GetVersionResponseData { ObsVersion = "1", RpcVersion = 1 }),
+            JsonResult(
+                "GetVersion",
+                new GetVersionResponseData { ObsVersion = "1", RpcVersion = 1 }
+            ),
             new("GetStats", "GetStats_1", new RequestStatus(false, 604, "nope"), null),
         ];
 

--- a/ObsWebSocket.Tests/EventStreamTests.cs
+++ b/ObsWebSocket.Tests/EventStreamTests.cs
@@ -59,10 +59,11 @@ public sealed class EventStreamTests
         List<string> seen = [];
 
         IAsyncEnumerator<CurrentProgramSceneChangedEventArgs> enumerator = StreamOf(
-            source,
-            capacity: 8,
-            cts.Token
-        ).GetAsyncEnumerator(cts.Token);
+                source,
+                capacity: 8,
+                cts.Token
+            )
+            .GetAsyncEnumerator(cts.Token);
 
         try
         {
@@ -91,10 +92,11 @@ public sealed class EventStreamTests
         using CancellationTokenSource cts = new(TimeSpan.FromSeconds(10));
 
         IAsyncEnumerator<CurrentProgramSceneChangedEventArgs> enumerator = StreamOf(
-            source,
-            capacity: 4,
-            cts.Token
-        ).GetAsyncEnumerator(cts.Token);
+                source,
+                capacity: 4,
+                cts.Token
+            )
+            .GetAsyncEnumerator(cts.Token);
 
         ValueTask<bool> pending = enumerator.MoveNextAsync();
         source.Raise("One");
@@ -112,10 +114,11 @@ public sealed class EventStreamTests
         using CancellationTokenSource cts = new(TimeSpan.FromSeconds(10));
 
         IAsyncEnumerator<CurrentProgramSceneChangedEventArgs> enumerator = StreamOf(
-            source,
-            capacity: 2,
-            cts.Token
-        ).GetAsyncEnumerator(cts.Token);
+                source,
+                capacity: 2,
+                cts.Token
+            )
+            .GetAsyncEnumerator(cts.Token);
 
         try
         {
@@ -148,10 +151,11 @@ public sealed class EventStreamTests
         using CancellationTokenSource cts = new();
 
         IAsyncEnumerator<CurrentProgramSceneChangedEventArgs> enumerator = StreamOf(
-            source,
-            capacity: 4,
-            cts.Token
-        ).GetAsyncEnumerator(cts.Token);
+                source,
+                capacity: 4,
+                cts.Token
+            )
+            .GetAsyncEnumerator(cts.Token);
 
         ValueTask<bool> pending = enumerator.MoveNextAsync();
         await cts.CancelAsync();
@@ -165,10 +169,6 @@ public sealed class EventStreamTests
     [TestMethod]
     public void Create_WithInvalidCapacity_Throws() =>
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-            EventStream.Create<CurrentProgramSceneChangedEventArgs>(
-                _ => { },
-                _ => { },
-                capacity: 0
-            )
+            EventStream.Create<CurrentProgramSceneChangedEventArgs>(_ => { }, _ => { }, capacity: 0)
         );
 }

--- a/ObsWebSocket.Tests/FalsyRequestFieldTests.cs
+++ b/ObsWebSocket.Tests/FalsyRequestFieldTests.cs
@@ -18,10 +18,12 @@ namespace ObsWebSocket.Tests;
 public sealed class FalsyRequestFieldTests
 {
     private static string Json(object data) =>
-        JsonSerializer.SerializeToElement(
-            data,
-            ObsWebSocketJsonContext.Default.Options.GetTypeInfo(data.GetType())
-        ).GetRawText();
+        JsonSerializer
+            .SerializeToElement(
+                data,
+                ObsWebSocketJsonContext.Default.Options.GetTypeInfo(data.GetType())
+            )
+            .GetRawText();
 
     [TestMethod]
     public void Serialize_RequiredFalseBool_KeepsField()

--- a/ObsWebSocket.Tests/HostingTests.cs
+++ b/ObsWebSocket.Tests/HostingTests.cs
@@ -96,13 +96,14 @@ public sealed class HostingTests
         // survivable rather than fatal.
         HostApplicationBuilder builder = Host.CreateApplicationBuilder();
         builder.Logging.SetMinimumLevel(LogLevel.Critical);
-        _ = builder.Services.AddObsWebSocketClient(o =>
-        {
-            o.ServerUri = new Uri("ws://127.0.0.1:59999");
-            o.AutoReconnectEnabled = false;
-            o.HandshakeTimeoutMs = 200;
-        });
-        _ = builder.Services.WithAutoConnect();
+        _ = builder
+            .Services.AddObsWebSocketClient(o =>
+            {
+                o.ServerUri = new Uri("ws://127.0.0.1:59999");
+                o.AutoReconnectEnabled = false;
+                o.HandshakeTimeoutMs = 200;
+            })
+            .WithAutoConnect();
 
         using IHost host = builder.Build();
 

--- a/ObsWebSocket.Tests/HostingTests.cs
+++ b/ObsWebSocket.Tests/HostingTests.cs
@@ -63,8 +63,8 @@ public sealed class HostingTests
     {
         HostApplicationBuilder builder = Host.CreateApplicationBuilder();
 
-        InvalidOperationException ex = Assert.ThrowsExactly<InvalidOperationException>(
-            () => builder.AddObsWebSocketClient("obs")
+        InvalidOperationException ex = Assert.ThrowsExactly<InvalidOperationException>(() =>
+            builder.AddObsWebSocketClient("obs")
         );
 
         StringAssert.Contains(ex.Message, "ConnectionStrings:obs");
@@ -81,7 +81,9 @@ public sealed class HostingTests
         await using ServiceProvider provider = services.BuildServiceProvider();
         HealthCheckService checks = provider.GetRequiredService<HealthCheckService>();
 
-        HealthReport report = await checks.CheckHealthAsync(TestContext.CancellationTokenSource.Token);
+        HealthReport report = await checks.CheckHealthAsync(
+            TestContext.CancellationTokenSource.Token
+        );
 
         Assert.AreEqual(HealthStatus.Unhealthy, report.Status);
         Assert.IsTrue(report.Entries.ContainsKey("obs-websocket"));

--- a/ObsWebSocket.Tests/JsonMessageSerializerTests.cs
+++ b/ObsWebSocket.Tests/JsonMessageSerializerTests.cs
@@ -32,9 +32,8 @@ public class JsonMessageSerializerTests
             )
             .RootElement.Clone();
 
-        EventPayloadBase<object>? result = CreateSerializer().DeserializePayload<
-            EventPayloadBase<object>
-        >(payload);
+        EventPayloadBase<object>? result = CreateSerializer()
+            .DeserializePayload<EventPayloadBase<object>>(payload);
 
         Assert.IsNotNull(result);
         Assert.AreEqual("SceneListChanged", result.EventType);
@@ -60,9 +59,8 @@ public class JsonMessageSerializerTests
             )
             .RootElement.Clone();
 
-        RequestResponsePayload<object>? result = CreateSerializer().DeserializePayload<
-            RequestResponsePayload<object>
-        >(payload);
+        RequestResponsePayload<object>? result = CreateSerializer()
+            .DeserializePayload<RequestResponsePayload<object>>(payload);
 
         Assert.IsNotNull(result);
         Assert.AreEqual("GetVersion", result.RequestType);
@@ -87,9 +85,8 @@ public class JsonMessageSerializerTests
             )
             .RootElement.Clone();
 
-        SceneListChangedPayload? result = CreateSerializer().DeserializePayload<SceneListChangedPayload>(
-            payload
-        );
+        SceneListChangedPayload? result = CreateSerializer()
+            .DeserializePayload<SceneListChangedPayload>(payload);
 
         Assert.IsNotNull(result);
         Assert.IsNotNull(result.Scenes);
@@ -122,9 +119,8 @@ public class JsonMessageSerializerTests
             )
             .RootElement.Clone();
 
-        RequestBatchResponsePayload<object>? result = CreateSerializer().DeserializePayload<
-            RequestBatchResponsePayload<object>
-        >(payload);
+        RequestBatchResponsePayload<object>? result = CreateSerializer()
+            .DeserializePayload<RequestBatchResponsePayload<object>>(payload);
 
         Assert.IsNotNull(result);
         Assert.AreEqual("batch-1", result.RequestId);
@@ -156,8 +152,7 @@ public class JsonMessageSerializerTests
     [TestMethod]
     public async Task DeserializeAsync_ValidIncomingEnvelope_ReturnsIncomingMessage()
     {
-        const string incomingJson =
-            """
+        const string incomingJson = """
             {
               "op": 5,
               "d": {
@@ -187,9 +182,8 @@ public class JsonMessageSerializerTests
     {
         JsonElement payload = JsonDocument.Parse("5").RootElement.Clone();
 
-        WebSocketOpCode? result = CreateSerializer().DeserializeValuePayload<WebSocketOpCode>(
-            payload
-        );
+        WebSocketOpCode? result = CreateSerializer()
+            .DeserializeValuePayload<WebSocketOpCode>(payload);
 
         Assert.IsTrue(result.HasValue);
         Assert.AreEqual(WebSocketOpCode.Event, result.Value);
@@ -210,9 +204,8 @@ public class JsonMessageSerializerTests
             )
             .RootElement.Clone();
 
-        ObsWebSocket.Core.Protocol.RequestStatus? result = CreateSerializer().DeserializePayload<
-            ObsWebSocket.Core.Protocol.RequestStatus
-        >(payload);
+        ObsWebSocket.Core.Protocol.RequestStatus? result = CreateSerializer()
+            .DeserializePayload<ObsWebSocket.Core.Protocol.RequestStatus>(payload);
 
         Assert.IsNotNull(result);
         Assert.IsTrue(result.Result);

--- a/ObsWebSocket.Tests/ObsWebSocket.Tests.csproj
+++ b/ObsWebSocket.Tests/ObsWebSocket.Tests.csproj
@@ -20,12 +20,17 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <!-- Removed Testing Platform Extensions for now - can add back if needed -->
-
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.9.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.11" />
+    <PackageReference
+      Include="Microsoft.Extensions.Configuration.EnvironmentVariables"
+      Version="10.0.11"
+    />
+    <PackageReference
+      Include="Microsoft.Extensions.Configuration.FileExtensions"
+      Version="10.0.11"
+    />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
     <PackageReference Include="Moq" Version="4.20.72" />

--- a/ObsWebSocket.Tests/ObsWebSocketClientConnectionTests.cs
+++ b/ObsWebSocket.Tests/ObsWebSocketClientConnectionTests.cs
@@ -213,7 +213,8 @@ public class ObsWebSocketClientConnectionTests
         // Mock WebSocket Connection
         _ = mockConnection
             .Setup(c => c.ConnectAsync(s_testServerUri, It.IsAny<CancellationToken>()))
-            .Callback(() => mockConnection.SetupGet(conn => conn.State).Returns(WebSocketState.Open)
+            .Callback(() =>
+                mockConnection.SetupGet(conn => conn.State).Returns(WebSocketState.Open)
             )
             .Returns(Task.CompletedTask);
 
@@ -665,7 +666,9 @@ public class ObsWebSocketClientConnectionTests
                 _ = mockConnFailing.SetupGet(c => c.State).Returns(WebSocketState.None);
                 _ = mockConnFailing.SetupGet(c => c.Options).Returns(new ClientWebSocket().Options);
                 _ = mockConnFailing.SetupGet(c => c.SubProtocol).Returns("obswebsocket.json");
-                _ = mockConnFailing.SetupGet(c => c.CloseStatus).Returns((WebSocketCloseStatus?)null);
+                _ = mockConnFailing
+                    .SetupGet(c => c.CloseStatus)
+                    .Returns((WebSocketCloseStatus?)null);
                 _ = mockConnFailing.SetupGet(c => c.CloseStatusDescription).Returns((string?)null);
                 _ = mockConnFailing
                     .Setup(c => c.ConnectAsync(s_testServerUri, It.IsAny<CancellationToken>()))
@@ -677,14 +680,16 @@ public class ObsWebSocketClientConnectionTests
 
         // Act & Assert
         ObsWebSocketException thrownException =
-            await Assert.ThrowsExactlyAsync<ObsWebSocketException>(
-                () => PumpAsync(client.ConnectAsync(), time)
+            await Assert.ThrowsExactlyAsync<ObsWebSocketException>(() =>
+                PumpAsync(client.ConnectAsync(), time)
             );
 
         Assert.IsTrue(
             thrownException.Message.Contains($"Failed to connect after {maxAttempts} attempts")
         );
-        _ = Assert.IsInstanceOfType<ConnectionAttemptFailedException>(thrownException.InnerException);
+        _ = Assert.IsInstanceOfType<ConnectionAttemptFailedException>(
+            thrownException.InnerException
+        );
         Assert.AreEqual(connectException, thrownException.InnerException!.InnerException);
 
         _ = await Task.WhenAny(disconnectedSignal.Task, Task.Delay(1000))
@@ -756,7 +761,9 @@ public class ObsWebSocketClientConnectionTests
                 _ = mockConnFailing.SetupGet(c => c.State).Returns(WebSocketState.None);
                 _ = mockConnFailing.SetupGet(c => c.Options).Returns(new ClientWebSocket().Options);
                 _ = mockConnFailing.SetupGet(c => c.SubProtocol).Returns("obswebsocket.json");
-                _ = mockConnFailing.SetupGet(c => c.CloseStatus).Returns((WebSocketCloseStatus?)null);
+                _ = mockConnFailing
+                    .SetupGet(c => c.CloseStatus)
+                    .Returns((WebSocketCloseStatus?)null);
                 _ = mockConnFailing.SetupGet(c => c.CloseStatusDescription).Returns((string?)null);
                 _ = mockConnFailing
                     .Setup(c => c.ConnectAsync(s_testServerUri, It.IsAny<CancellationToken>()))
@@ -839,7 +846,9 @@ public class ObsWebSocketClientConnectionTests
                 _ = mockConnFailing.SetupGet(c => c.State).Returns(WebSocketState.None);
                 _ = mockConnFailing.SetupGet(c => c.Options).Returns(new ClientWebSocket().Options);
                 _ = mockConnFailing.SetupGet(c => c.SubProtocol).Returns("obswebsocket.json");
-                _ = mockConnFailing.SetupGet(c => c.CloseStatus).Returns((WebSocketCloseStatus?)null);
+                _ = mockConnFailing
+                    .SetupGet(c => c.CloseStatus)
+                    .Returns((WebSocketCloseStatus?)null);
                 _ = mockConnFailing.SetupGet(c => c.CloseStatusDescription).Returns((string?)null);
                 _ = mockConnFailing
                     .Setup(c => c.ConnectAsync(s_testServerUri, It.IsAny<CancellationToken>()))

--- a/ObsWebSocket.Tests/ObsWebSocketClientConnectionTests.cs
+++ b/ObsWebSocket.Tests/ObsWebSocketClientConnectionTests.cs
@@ -720,13 +720,20 @@ public class ObsWebSocketClientConnectionTests
     {
         // Arrange
         WebSocketException connectException = new("Server unavailable");
+        // The retry delay comes from the fake clock, so the client is definitively still waiting
+        // it out when DisconnectAsync is called. Racing a real delay makes the condition this
+        // test is about depend on how loaded the machine is.
+        FakeTimeProvider time = new();
         (ObsWebSocketClient? client, _, _, Mock<IWebSocketConnectionFactory>? mockFactory) =
-            BuildMockedInfrastructure(opts =>
-            {
-                opts.AutoReconnectEnabled = true;
-                opts.MaxReconnectAttempts = 5; // Allow multiple retries
-                opts.InitialReconnectDelayMs = 300; // Longer delay to allow disconnect call
-            });
+            BuildMockedInfrastructure(
+                opts =>
+                {
+                    opts.AutoReconnectEnabled = true;
+                    opts.MaxReconnectAttempts = 5; // Allow multiple retries
+                    opts.InitialReconnectDelayMs = 300;
+                },
+                time
+            );
 
         List<string> eventLog = [];
         Exception? disconnectedReason = new("Placeholder"); // Start non-null for check later (Simplified 'new')
@@ -776,20 +783,21 @@ public class ObsWebSocketClientConnectionTests
         // Act
         Task connectTask = client.ConnectAsync(); // Start connection attempts in background
 
-        // Wait for the first connection attempt to fail
-        bool firstFailed =
-            await Task.WhenAny(firstFailSignal.Task, Task.Delay(TimeSpan.FromSeconds(2)))
-            == firstFailSignal.Task;
-        Assert.IsTrue(firstFailed, "First connection attempt did not fail within timeout.");
+        // Wait for the first connection attempt to fail. The attempt itself does not wait on the
+        // clock, so this completes without advancing it.
+        await firstFailSignal
+            .Task.WaitAsync(TimeSpan.FromSeconds(2))
+            .ConfigureAwait(ConfigureAwaitOptions.None);
 
-        // Request disconnect *while* the client is likely in the retry delay
+        // The clock has not moved, so the client is still inside the retry delay here.
         await client.DisconnectAsync();
 
-        // Wait for the Disconnected event
-        bool disconnected =
-            await Task.WhenAny(disconnectedSignal.Task, Task.Delay(TimeSpan.FromSeconds(3)))
-            == disconnectedSignal.Task;
-        Assert.IsTrue(disconnected, "Disconnect event did not fire after calling DisconnectAsync.");
+        // Wait for the Disconnected event. Disconnecting cancels the delay rather than waiting
+        // it out, so this also needs no clock advance; a regression that waits shows up as the
+        // timeout below rather than as a pass.
+        await disconnectedSignal
+            .Task.WaitAsync(TimeSpan.FromSeconds(3))
+            .ConfigureAwait(ConfigureAwaitOptions.None);
 
         // Allow original ConnectAsync task to complete/be observed (it should have been cancelled by DisconnectAsync)
         await connectTask

--- a/ObsWebSocket.Tests/ObsWebSocketClientConnectionTests.cs
+++ b/ObsWebSocket.Tests/ObsWebSocketClientConnectionTests.cs
@@ -808,7 +808,7 @@ public class ObsWebSocketClientConnectionTests
     }
 
     [TestMethod]
-    [Timeout(3000)] // Slightly increased timeout
+    [Timeout(TestTimeout)]
     public async Task ConnectAsync_InfiniteRetries_AttemptsMultipleTimes()
     {
         // Arrange
@@ -830,11 +830,18 @@ public class ObsWebSocketClientConnectionTests
 
         int attemptCounter = 0;
         object counterLock = new();
+        TaskCompletionSource attemptsReached = new(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
         client.Connecting += (_, _) =>
         {
             lock (counterLock)
             {
                 attemptCounter++;
+                if (attemptCounter >= minExpectedAttempts)
+                {
+                    _ = attemptsReached.TrySetResult();
+                }
             }
         };
 
@@ -861,12 +868,13 @@ public class ObsWebSocketClientConnectionTests
         // Act
         Task connectTask = client.ConnectAsync(cts.Token); // Pass the cancellation token
 
-        // Advance the fake clock until enough attempts have occurred or the task completes.
+        // Advance the fake clock until enough attempts have occurred, waiting on a signal rather
+        // than a fixed iteration count. The reconnect delay comes from the fake clock, but the
+        // continuation after it still needs the scheduler, so each advance is followed by a real
+        // yield. Bounded so a regression fails here with a count rather than hanging.
         for (
             int i = 0;
-            i < 2000
-                && Volatile.Read(ref attemptCounter) < minExpectedAttempts
-                && !connectTask.IsCompleted;
+            i < 200 && !attemptsReached.Task.IsCompleted && !connectTask.IsCompleted;
             i++
         )
         {

--- a/ObsWebSocket.Tests/ObsWebSocketClientIntegrationTests.cs
+++ b/ObsWebSocket.Tests/ObsWebSocketClientIntegrationTests.cs
@@ -445,7 +445,7 @@ public class ObsWebSocketClientIntegrationTests
             idResponse,
             $"Could not get SceneItemId for '{s_testOptions.TestInputName}' in scene '{s_testOptions.TestSceneName}'. Ensure it exists."
         );
-        double sceneItemId = idResponse.SceneItemId;
+        int sceneItemId = idResponse.SceneItemId;
 
         // Get the transform
         GetSceneItemTransformResponseData? transformResponse =

--- a/ObsWebSocket.Tests/ObsWebSocketClientIntegrationTests.cs
+++ b/ObsWebSocket.Tests/ObsWebSocketClientIntegrationTests.cs
@@ -49,7 +49,9 @@ public class ObsWebSocketClientIntegrationTests
         _ = services.AddLogging(builder => builder.AddConsole().SetMinimumLevel(minLogLevel));
 
         // Bind the "ObsIntegration" section from configuration to the options class
-        _ = services.Configure<ObsIntegrationTestOptions>(configuration.GetSection("ObsIntegration"));
+        _ = services.Configure<ObsIntegrationTestOptions>(
+            configuration.GetSection("ObsIntegration")
+        );
 
         // Configure ObsWebSocketClientOptions based on ObsIntegrationTestOptions
         _ = services
@@ -112,15 +114,13 @@ public class ObsWebSocketClientIntegrationTests
         ILogger<ObsWebSocketClient> logger = s_serviceProvider.GetRequiredService<
             ILogger<ObsWebSocketClient>
         >();
-        IWebSocketMessageSerializer serializer = s_serviceProvider.GetRequiredService<
-            IWebSocketMessageSerializer
-        >();
+        IWebSocketMessageSerializer serializer =
+            s_serviceProvider.GetRequiredService<IWebSocketMessageSerializer>();
         IOptions<ObsWebSocketClientOptions> options = s_serviceProvider.GetRequiredService<
             IOptions<ObsWebSocketClientOptions>
         >();
-        IWebSocketConnectionFactory connectionFactory = s_serviceProvider.GetRequiredService<
-            IWebSocketConnectionFactory
-        >();
+        IWebSocketConnectionFactory connectionFactory =
+            s_serviceProvider.GetRequiredService<IWebSocketConnectionFactory>();
 
         return new ObsWebSocketClient(logger, serializer, options, connectionFactory);
     }
@@ -450,7 +450,10 @@ public class ObsWebSocketClientIntegrationTests
         // Get the transform
         GetSceneItemTransformResponseData? transformResponse =
             await client.SceneItems.GetSceneItemTransformAsync(
-                new GetSceneItemTransformRequestData(sceneItemId, sceneName: s_testOptions.TestSceneName!)
+                new GetSceneItemTransformRequestData(
+                    sceneItemId,
+                    sceneName: s_testOptions.TestSceneName!
+                )
             );
 
         Assert.IsNotNull(transformResponse, "GetSceneItemTransform response was null.");
@@ -526,7 +529,8 @@ public class ObsWebSocketClientIntegrationTests
         GetInputSettingsResponseData? response;
         try
         {
-            response = await client.Inputs.GetInputSettingsAsync(new GetInputSettingsRequestData(s_testOptions.TestInputName!)
+            response = await client.Inputs.GetInputSettingsAsync(
+                new GetInputSettingsRequestData(s_testOptions.TestInputName!)
             );
         }
         catch (ObsWebSocketException ex) when (ex.Message.Contains("ResourceNotFound"))
@@ -636,7 +640,8 @@ public class ObsWebSocketClientIntegrationTests
         await client.ConnectAsync(TestContext.CancellationToken);
         Assert.IsTrue(client.IsConnected);
 
-        GetSceneTransitionListResponseData? response = await client.Transitions.GetSceneTransitionListAsync();
+        GetSceneTransitionListResponseData? response =
+            await client.Transitions.GetSceneTransitionListAsync();
 
         Assert.IsNotNull(response, "GetSceneTransitionList response was null.");
         Assert.IsNotNull(response.Transitions, "Transitions list was null.");
@@ -680,7 +685,10 @@ public class ObsWebSocketClientIntegrationTests
 
         Assert.IsNotNull(response, "GetOutputList response was null.");
         Assert.IsNotNull(response.Outputs, "Outputs list was null.");
-        Assert.IsNotEmpty(response.Outputs, "Expected at least one output (e.g., Simple Output or Advanced).");
+        Assert.IsNotEmpty(
+            response.Outputs,
+            "Expected at least one output (e.g., Simple Output or Advanced)."
+        );
 
         OutputStub? firstOutput = response.Outputs.FirstOrDefault();
         Assert.IsNotNull(firstOutput, "First output stub was null.");
@@ -812,7 +820,8 @@ public class ObsWebSocketClientIntegrationTests
         GetInputDefaultSettingsResponseData? response;
         try
         {
-            response = await client.Inputs.GetInputDefaultSettingsAsync(new GetInputDefaultSettingsRequestData(inputKind)
+            response = await client.Inputs.GetInputDefaultSettingsAsync(
+                new GetInputDefaultSettingsRequestData(inputKind)
             );
         }
         catch (ObsWebSocketException ex) when (ex.Message.Contains("InvalidInputKind"))
@@ -851,10 +860,7 @@ public class ObsWebSocketClientIntegrationTests
         );
 
         // Assert some known default properties for text_gdiplus_v3 exist
-        Assert.IsTrue(
-            defaultSettingsDict.ContainsKey("font"),
-            "Expected 'font' default setting."
-        );
+        Assert.IsTrue(defaultSettingsDict.ContainsKey("font"), "Expected 'font' default setting.");
         Assert.AreEqual(
             JsonValueKind.Object,
             defaultSettingsDict["font"].ValueKind,

--- a/ObsWebSocket.Tests/ObsWebSocketClientRequestTests.cs
+++ b/ObsWebSocket.Tests/ObsWebSocketClientRequestTests.cs
@@ -332,7 +332,9 @@ public class ObsWebSocketClientRequestTests
             .Returns(responseDto);
 
         // Act
-        GetInputMuteResponseData? actualResponseDto = await client.Inputs.GetInputMuteAsync(requestDto);
+        GetInputMuteResponseData? actualResponseDto = await client.Inputs.GetInputMuteAsync(
+            requestDto
+        );
 
         // Assert
         Assert.IsNotNull(actualResponseDto, "Response DTO should not be null.");
@@ -442,8 +444,8 @@ public class ObsWebSocketClientRequestTests
 
         // Act & Assert
         // Verify that calling the client method throws the correct exception
-        ObsWebSocketException ex = await Assert.ThrowsAsync<ObsWebSocketException>(
-            async () => await client.General.GetVersionAsync() // Call the specific extension method
+        ObsWebSocketException ex = await Assert.ThrowsAsync<ObsWebSocketException>(async () =>
+            await client.General.GetVersionAsync() // Call the specific extension method
         );
 
         // Check the exception details
@@ -626,4 +628,3 @@ public class ObsWebSocketClientRequestTests
         } // Ignore errors
     }
 }
-

--- a/ObsWebSocket.Tests/ObsWebSocketClientRequestTests.cs
+++ b/ObsWebSocket.Tests/ObsWebSocketClientRequestTests.cs
@@ -87,7 +87,7 @@ public class ObsWebSocketClientRequestTests
                             RequestId: capturedRequestId,
                             RequestStatus: new RequestStatus(
                                 Result: true,
-                                Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                Code: (int)Core.Protocol.Generated.RequestStatusCode.Success
                             ),
                             ResponseData: rawResponseData.Value // Pass the JsonElement payload
                         );
@@ -205,7 +205,7 @@ public class ObsWebSocketClientRequestTests
                             RequestId: capturedRequestId,
                             RequestStatus: new RequestStatus(
                                 Result: true,
-                                Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                Code: (int)Core.Protocol.Generated.RequestStatusCode.Success
                             ),
                             ResponseData: rawResponseData // null
                         );
@@ -308,7 +308,7 @@ public class ObsWebSocketClientRequestTests
                             RequestId: capturedRequestId,
                             RequestStatus: new RequestStatus(
                                 Result: true,
-                                Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                Code: (int)Core.Protocol.Generated.RequestStatusCode.Success
                             ),
                             ResponseData: rawResponseData.Value // Pass JsonElement payload
                         );
@@ -393,7 +393,7 @@ public class ObsWebSocketClientRequestTests
         string requestType = "GetVersion"; // Using GetVersion as an example request
         RequestStatus failureStatus = new(
             Result: false,
-            Code: (int)Core.Protocol.Generated.RequestStatus.ResourceNotFound,
+            Code: (int)Core.Protocol.Generated.RequestStatusCode.ResourceNotFound,
             Comment: "ResourceNotFound"
         );
         object? rawResponseData = null; // No data s_expectedFailNoRetryLog on failure

--- a/ObsWebSocket.Tests/ObsWebSocketClientTests.cs
+++ b/ObsWebSocket.Tests/ObsWebSocketClientTests.cs
@@ -86,11 +86,8 @@ public partial class ObsWebSocketClientTests
     public async Task CallBatchAsync_AnonymousRequestData_ThrowsObsWebSocketException()
     {
         // Arrange
-        (
-            ObsWebSocketClient client,
-            _,
-            Mock<IWebSocketConnection> mockWebSocket
-        ) = TestUtils.SetupConnectedClientForceState();
+        (ObsWebSocketClient client, _, Mock<IWebSocketConnection> mockWebSocket) =
+            TestUtils.SetupConnectedClientForceState();
 
         List<BatchRequestItem> requests =
         [
@@ -107,10 +104,11 @@ public partial class ObsWebSocketClientTests
             "Failed to serialize request data",
             StringComparison.Ordinal
         );
-        bool innerHasExpectedMessage = ex.InnerException?.Message.Contains(
-            "Failed to serialize request data",
-            StringComparison.Ordinal
-        ) == true;
+        bool innerHasExpectedMessage =
+            ex.InnerException?.Message.Contains(
+                "Failed to serialize request data",
+                StringComparison.Ordinal
+            ) == true;
         Assert.IsTrue(
             outerHasExpectedMessage || innerHasExpectedMessage,
             "Exception chain should indicate request data serialization failure."
@@ -367,8 +365,8 @@ public partial class ObsWebSocketClientTests
             .Returns(ValueTask.CompletedTask);
 
         // Act & Assert
-        ObsWebSocketException ex = await Assert.ThrowsAsync<ObsWebSocketException>(
-            async () => await client.CallBatchAsync(requests, timeoutMs: timeoutMs) // Use the timeout override
+        ObsWebSocketException ex = await Assert.ThrowsAsync<ObsWebSocketException>(async () =>
+            await client.CallBatchAsync(requests, timeoutMs: timeoutMs) // Use the timeout override
         );
 
         // Verify exception details
@@ -427,4 +425,3 @@ public partial class ObsWebSocketClientTests
         } // Ignore deserialization errors
     }
 }
-

--- a/ObsWebSocket.Tests/ObsWebSocketDiTests.cs
+++ b/ObsWebSocket.Tests/ObsWebSocketDiTests.cs
@@ -286,4 +286,3 @@ public class ObsWebSocketDiTests
         );
     }
 }
-

--- a/ObsWebSocket.Tests/ObsWebSocketDiTests.cs
+++ b/ObsWebSocket.Tests/ObsWebSocketDiTests.cs
@@ -265,8 +265,9 @@ public class ObsWebSocketDiTests
     /// Verifies that omitting ServerUri fails when the client is resolved, rather than later
     /// when a connection is attempted.
     /// </summary>
+    // No timeout: nothing here waits on anything, so a wall clock limit only fails the test when
+    // the machine is busy.
     [TestMethod]
-    [Timeout(1000)]
     public void Resolve_WithoutServerUri_FailsValidation()
     {
         ServiceCollection services = CreateServiceCollectionWithLogging();
@@ -274,7 +275,7 @@ public class ObsWebSocketDiTests
         {
             opts.Password = "abc";
         });
-        ServiceProvider provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
 
         OptionsValidationException ex = Assert.ThrowsExactly<OptionsValidationException>(() =>
             provider.GetRequiredService<ObsWebSocketClient>()

--- a/ObsWebSocket.Tests/ReadmeCompileCheck.cs
+++ b/ObsWebSocket.Tests/ReadmeCompileCheck.cs
@@ -2,8 +2,8 @@ using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using ObsWebSocket.Core;
 using ObsWebSocket.Core.Events.Generated;
-using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol;
+using ObsWebSocket.Core.Protocol.Common.InputSettings;
 using ObsWebSocket.Core.Protocol.Generated;
 using ObsWebSocket.Core.Protocol.Requests;
 using ObsWebSocket.Core.Protocol.Responses;
@@ -41,15 +41,24 @@ internal static class ReadmeCompileCheck
 
     internal static async Task BrowserSourceAsync(ObsWebSocketClient client, CancellationToken ct)
     {
-        var current = await client.Inputs.GetInputSettingsAsync<BrowserSourceSettings>("StreamOverlay", ct);
+        var current = await client.Inputs.GetInputSettingsAsync<BrowserSourceSettings>(
+            "StreamOverlay",
+            ct
+        );
         _ = current?.Url;
 
-        await client.Inputs.SetInputSettingsAsync("StreamOverlay",
-            new BrowserSourceSettings(Url: "https://myoverlay.example.com", Width: 1920, Height: 1080),
+        await client.Inputs.SetInputSettingsAsync(
+            "StreamOverlay",
+            new BrowserSourceSettings(
+                Url: "https://myoverlay.example.com",
+                Width: 1920,
+                Height: 1080
+            ),
             cancellationToken: ct
         );
 
-        await client.Inputs.SetInputSettingsAsync("StreamOverlay",
+        await client.Inputs.SetInputSettingsAsync(
+            "StreamOverlay",
             new OverlaySettings(Url: "https://myoverlay.example.com"),
             MyContext.Default.OverlaySettings,
             cancellationToken: ct
@@ -60,7 +69,8 @@ internal static class ReadmeCompileCheck
     {
         await client.Scenes.SwitchSceneAndWaitAsync("Scene", cancellationToken: ct);
         _ = await client.Sources.SourceExistsAsync("Source", ct);
-        await client.Filters.CreateSourceFilterAsync("Source",
+        await client.Filters.CreateSourceFilterAsync(
+            "Source",
             "MyFilter",
             "gain_filter",
             new OverlaySettings(),
@@ -76,7 +86,9 @@ internal static class ReadmeCompileCheck
 
     internal static async Task VersionAsync(ObsWebSocketClient client, CancellationToken ct)
     {
-        GetVersionResponseData? version = await client.General.GetVersionAsync(cancellationToken: ct);
+        GetVersionResponseData? version = await client.General.GetVersionAsync(
+            cancellationToken: ct
+        );
         _ = version?.ObsVersion;
     }
 
@@ -85,9 +97,15 @@ internal static class ReadmeCompileCheck
         List<BatchRequestItem> items =
         [
             new("GetVersion", null),
-            new("SetCurrentProgramScene", new SetCurrentProgramSceneRequestData(sceneName: "Intro")),
+            new(
+                "SetCurrentProgramScene",
+                new SetCurrentProgramSceneRequestData(sceneName: "Intro")
+            ),
             new("Sleep", new SleepRequestData(sleepMillis: 100)),
-            new("SetInputMute", new SetInputMuteRequestData { InputName = "Mic", InputMuted = false }),
+            new(
+                "SetInputMute",
+                new SetInputMuteRequestData { InputName = "Mic", InputMuted = false }
+            ),
         ];
 
         var results = await client.CallBatchAsync(
@@ -103,21 +121,32 @@ internal static class ReadmeCompileCheck
         }
     }
 
-    internal static async Task UtilitiesExtendedAsync(ObsWebSocketClient client, CancellationToken ct)
+    internal static async Task UtilitiesExtendedAsync(
+        ObsWebSocketClient client,
+        CancellationToken ct
+    )
     {
         await client.Scenes.SwitchSceneAsync("Scene", cancellationToken: ct);
         _ = await client.SceneItems.SetSceneItemEnabledAsync("Scene", "Source", null, ct);
         _ = await client.SceneItems.FindSceneItemIdAsync("Scene", "Source", ct);
         await client.Inputs.SetInputMutesAsync([("Mic", false), ("Desktop Audio", true)], ct);
         _ = await client.Sources.GetSourceScreenshotBytesAsync("Source", cancellationToken: ct);
-        _ = await client.Sources.GetSourceScreenshotOnCanvasBytesAsync("Source", cancellationToken: ct);
-        await client.Sources.SaveSourceScreenshotToFileAsync("Source", "shot.png", cancellationToken: ct);
+        _ = await client.Sources.GetSourceScreenshotOnCanvasBytesAsync(
+            "Source",
+            cancellationToken: ct
+        );
+        await client.Sources.SaveSourceScreenshotToFileAsync(
+            "Source",
+            "shot.png",
+            cancellationToken: ct
+        );
         _ = await client.Config.EnsureProfileActiveAsync("Profile", ct);
         _ = await client.Config.EnsureSceneCollectionActiveAsync("Collection", ct);
         _ = await client.Outputs.IsVirtualCamActiveAsync(ct);
         _ = await client.Outputs.SetVirtualCamActiveAndWaitAsync(true, cancellationToken: ct);
         await client.General.TriggerHotkeyAsync("OBSBasic.StartRecording", ct);
-        _ = await client.Inputs.CreateInputAsync("browser_source",
+        _ = await client.Inputs.CreateInputAsync(
+            "browser_source",
             "NewOverlay",
             new OverlaySettings(),
             MyContext.Default.OverlaySettings,
@@ -127,7 +156,9 @@ internal static class ReadmeCompileCheck
 
     internal static async Task EventStreamsAsync(ObsWebSocketClient client, CancellationToken ct)
     {
-        await foreach (var e in client.Scenes.CurrentProgramSceneChangedStream(cancellationToken: ct))
+        await foreach (
+            var e in client.Scenes.CurrentProgramSceneChangedStream(cancellationToken: ct)
+        )
         {
             _ = e.EventData.SceneName;
             break;
@@ -208,12 +239,19 @@ internal static class ReadmeCompileCheck
         await client.Inputs.SetInputVolumeMulAsync("Mic", 0.5, ct);
     }
 
-    internal static async Task TypedBatchResultsAsync(ObsWebSocketClient client, CancellationToken ct)
+    internal static async Task TypedBatchResultsAsync(
+        ObsWebSocketClient client,
+        CancellationToken ct
+    )
     {
         ObsBatchBuilder batch = new();
-        BatchRef<GetSceneItemListResponseData> intro = batch.SceneItems.GetSceneItemList(new(sceneName: "Intro"));
+        BatchRef<GetSceneItemListResponseData> intro = batch.SceneItems.GetSceneItemList(
+            new(sceneName: "Intro")
+        );
         BatchRef<GetVersionResponseData> version = batch.General.GetVersion();
-        BatchRef<GetSceneItemListResponseData> outro = batch.SceneItems.GetSceneItemList(new(sceneName: "Outro"));
+        BatchRef<GetSceneItemListResponseData> outro = batch.SceneItems.GetSceneItemList(
+            new(sceneName: "Outro")
+        );
 
         BatchResults results = await client.CallBatchAsync(batch, cancellationToken: ct);
 
@@ -238,7 +276,9 @@ internal static class ReadmeCompileCheck
         }
     }
 
-    internal static void HostIntegration(Microsoft.Extensions.Hosting.IHostApplicationBuilder builder)
+    internal static void HostIntegration(
+        Microsoft.Extensions.Hosting.IHostApplicationBuilder builder
+    )
     {
         _ = builder.AddObsWebSocketClient("obs");
         _ = builder.Services.WithAutoConnect();
@@ -247,7 +287,10 @@ internal static class ReadmeCompileCheck
 
     internal static void TelemetryAndKeyedRegistration(IServiceCollection services)
     {
-        _ = services.AddObsWebSocketClient("main", o => o.ServerUri = new Uri("ws://localhost:4455"));
+        _ = services.AddObsWebSocketClient(
+            "main",
+            o => o.ServerUri = new Uri("ws://localhost:4455")
+        );
         _ = services.AddObsWebSocketClient("booth", o => o.ServerUri = new Uri("ws://booth:4455"));
         _ = ObsWebSocketDiagnostics.ActivitySourceName;
         _ = ObsWebSocketDiagnostics.MeterName;
@@ -256,9 +299,17 @@ internal static class ReadmeCompileCheck
 
     internal static async Task ScreenshotsAsync(ObsWebSocketClient client, CancellationToken ct)
     {
-        byte[]? png = await client.Sources.GetSourceScreenshotBytesAsync("Intro", "png", cancellationToken: ct);
+        byte[]? png = await client.Sources.GetSourceScreenshotBytesAsync(
+            "Intro",
+            "png",
+            cancellationToken: ct
+        );
         _ = png;
-        await client.Sources.SaveSourceScreenshotToFileAsync("Intro", "shot.png", cancellationToken: ct);
+        await client.Sources.SaveSourceScreenshotToFileAsync(
+            "Intro",
+            "shot.png",
+            cancellationToken: ct
+        );
     }
 
     internal static async Task ReplayBufferAsync2(ObsWebSocketClient client, CancellationToken ct)
@@ -280,8 +331,6 @@ internal static class ReadmeCompileCheck
         {
             _ = $"{ex.RequestType} failed with {ex.Status?.Code}: {ex.Comment}";
         }
-        catch (ObsWebSocketTimeoutException)
-        {
-        }
+        catch (ObsWebSocketTimeoutException) { }
     }
 }

--- a/ObsWebSocket.Tests/ReadmeCompileCheck.cs
+++ b/ObsWebSocket.Tests/ReadmeCompileCheck.cs
@@ -276,6 +276,24 @@ internal static class ReadmeCompileCheck
         }
     }
 
+    internal static async Task TypedStatusFilterAsync(
+        ObsWebSocketClient client,
+        CancellationToken ct
+    )
+    {
+        try
+        {
+            await client.SceneItems.GetSceneItemListAsync(new("Missing"), ct);
+        }
+        catch (ObsWebSocketRequestException ex)
+            when (ex.StatusCode
+                is ObsWebSocket.Core.Protocol.Generated.RequestStatus.ResourceNotFound
+            )
+        {
+            // The scene, input or filter does not exist.
+        }
+    }
+
     internal static void HostIntegration(
         Microsoft.Extensions.Hosting.IHostApplicationBuilder builder
     )

--- a/ObsWebSocket.Tests/ReadmeCompileCheck.cs
+++ b/ObsWebSocket.Tests/ReadmeCompileCheck.cs
@@ -298,9 +298,7 @@ internal static class ReadmeCompileCheck
         Microsoft.Extensions.Hosting.IHostApplicationBuilder builder
     )
     {
-        _ = builder.AddObsWebSocketClient("obs");
-        _ = builder.Services.WithAutoConnect();
-        _ = builder.Services.AddHealthChecks().AddObsWebSocket();
+        _ = builder.AddObsWebSocketClient("obs").WithAutoConnect().WithHealthCheck();
     }
 
     internal static void TelemetryAndKeyedRegistration(IServiceCollection services)

--- a/ObsWebSocket.Tests/ReadmeCompileCheck.cs
+++ b/ObsWebSocket.Tests/ReadmeCompileCheck.cs
@@ -67,7 +67,7 @@ internal static class ReadmeCompileCheck
 
     internal static async Task UtilitiesAsync(ObsWebSocketClient client, CancellationToken ct)
     {
-        await client.Scenes.SwitchSceneAndWaitAsync("Scene", cancellationToken: ct);
+        await client.Scenes.SwitchProgramSceneAndWaitAsync("Scene", cancellationToken: ct);
         _ = await client.Sources.SourceExistsAsync("Source", ct);
         await client.Filters.CreateSourceFilterAsync(
             "Source",
@@ -126,7 +126,7 @@ internal static class ReadmeCompileCheck
         CancellationToken ct
     )
     {
-        await client.Scenes.SwitchSceneAsync("Scene", cancellationToken: ct);
+        await client.Scenes.SwitchProgramSceneAsync("Scene", cancellationToken: ct);
         _ = await client.SceneItems.SetSceneItemEnabledAsync("Scene", "Source", null, ct);
         _ = await client.SceneItems.FindSceneItemIdAsync("Scene", "Source", ct);
         await client.Inputs.SetInputMutesAsync([("Mic", false), ("Desktop Audio", true)], ct);
@@ -287,7 +287,7 @@ internal static class ReadmeCompileCheck
         }
         catch (ObsWebSocketRequestException ex)
             when (ex.StatusCode
-                is ObsWebSocket.Core.Protocol.Generated.RequestStatus.ResourceNotFound
+                is ObsWebSocket.Core.Protocol.Generated.RequestStatusCode.ResourceNotFound
             )
         {
             // The scene, input or filter does not exist.

--- a/ObsWebSocket.Tests/ReadmeCompileCheck.cs
+++ b/ObsWebSocket.Tests/ReadmeCompileCheck.cs
@@ -127,7 +127,7 @@ internal static class ReadmeCompileCheck
 
     internal static async Task EventStreamsAsync(ObsWebSocketClient client, CancellationToken ct)
     {
-        await foreach (var e in client.CurrentProgramSceneChangedStream(cancellationToken: ct))
+        await foreach (var e in client.Scenes.CurrentProgramSceneChangedStream(cancellationToken: ct))
         {
             _ = e.EventData.SceneName;
             break;

--- a/ObsWebSocket.Tests/ReadmeCompileCheck.cs
+++ b/ObsWebSocket.Tests/ReadmeCompileCheck.cs
@@ -253,4 +253,35 @@ internal static class ReadmeCompileCheck
         _ = ObsWebSocketDiagnostics.MeterName;
         _ = ObsWebSocketResilience.ReconnectPipelineKey;
     }
+
+    internal static async Task ScreenshotsAsync(ObsWebSocketClient client, CancellationToken ct)
+    {
+        byte[]? png = await client.Sources.GetSourceScreenshotBytesAsync("Intro", "png", cancellationToken: ct);
+        _ = png;
+        await client.Sources.SaveSourceScreenshotToFileAsync("Intro", "shot.png", cancellationToken: ct);
+    }
+
+    internal static async Task ReplayBufferAsync2(ObsWebSocketClient client, CancellationToken ct)
+    {
+        var status = await client.Outputs.GetReplayBufferStatusAsync(ct);
+        if (status.OutputActive)
+        {
+            await client.Outputs.SaveReplayBufferAsync(ct);
+        }
+    }
+
+    internal static async Task StudioModeAsync(ObsWebSocketClient client, CancellationToken ct)
+    {
+        try
+        {
+            await client.Ui.SetStudioModeEnabledAsync(new(true), ct);
+        }
+        catch (ObsWebSocketRequestException ex)
+        {
+            _ = $"{ex.RequestType} failed with {ex.Status?.Code}: {ex.Comment}";
+        }
+        catch (ObsWebSocketTimeoutException)
+        {
+        }
+    }
 }

--- a/ObsWebSocket.Tests/ReadmeCompileCheck.cs
+++ b/ObsWebSocket.Tests/ReadmeCompileCheck.cs
@@ -286,12 +286,25 @@ internal static class ReadmeCompileCheck
             await client.SceneItems.GetSceneItemListAsync(new("Missing"), ct);
         }
         catch (ObsWebSocketRequestException ex)
-            when (ex.StatusCode
-                is ObsWebSocket.Core.Protocol.Generated.RequestStatusCode.ResourceNotFound
-            )
+            when (ex.StatusCode is RequestStatusCode.ResourceNotFound)
         {
             // The scene, input or filter does not exist.
         }
+    }
+
+    internal static async Task NumbersAsync(ObsWebSocketClient client, CancellationToken ct)
+    {
+        int id =
+            await client.SceneItems.FindSceneItemIdAsync("Intro", "Logo", ct)
+            ?? throw new InvalidOperationException();
+        await client.SceneItems.SetSceneItemIndexAsync(
+            new(sceneItemId: id, sceneItemIndex: 0, sceneName: "Intro"),
+            ct
+        );
+
+        long bytes = (await client.Stream.GetStreamStatusAsync(ct)).OutputBytes;
+        double volume = (await client.Inputs.GetInputVolumeAsync(new("Mic"), ct)).InputVolumeMul;
+        _ = $"{bytes} {volume}";
     }
 
     internal static void HostIntegration(

--- a/ObsWebSocket.Tests/ScreenshotDecodeTests.cs
+++ b/ObsWebSocket.Tests/ScreenshotDecodeTests.cs
@@ -18,7 +18,7 @@ public sealed class ScreenshotDecodeTests
     {
         string dataUri = "data:image/png;base64," + Convert.ToBase64String(PngSignature);
 
-        byte[] decoded = SourcesRequestGroup.DecodeImageData(dataUri);
+        byte[] decoded = SourcesGroup.DecodeImageData(dataUri);
 
         CollectionAssert.AreEqual(PngSignature, decoded);
     }
@@ -26,7 +26,7 @@ public sealed class ScreenshotDecodeTests
     [TestMethod]
     public void DecodeImageData_WithBareBase64_StillDecodes()
     {
-        byte[] decoded = SourcesRequestGroup.DecodeImageData(
+        byte[] decoded = SourcesGroup.DecodeImageData(
             Convert.ToBase64String(PngSignature)
         );
 
@@ -35,5 +35,5 @@ public sealed class ScreenshotDecodeTests
 
     [TestMethod]
     public void DecodeImageData_WhenEmpty_Throws() =>
-        Assert.ThrowsExactly<ArgumentException>(() => SourcesRequestGroup.DecodeImageData(""));
+        Assert.ThrowsExactly<ArgumentException>(() => SourcesGroup.DecodeImageData(""));
 }

--- a/ObsWebSocket.Tests/ScreenshotDecodeTests.cs
+++ b/ObsWebSocket.Tests/ScreenshotDecodeTests.cs
@@ -10,8 +10,7 @@ namespace ObsWebSocket.Tests;
 public sealed class ScreenshotDecodeTests
 {
     // The eight byte PNG signature, which is what a caller checks to know it got an image.
-    private static readonly byte[] PngSignature =
-        [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+    private static readonly byte[] PngSignature = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
 
     [TestMethod]
     public void DecodeImageData_WithDataUriPrefix_ReturnsTheImageBytes()
@@ -26,9 +25,7 @@ public sealed class ScreenshotDecodeTests
     [TestMethod]
     public void DecodeImageData_WithBareBase64_StillDecodes()
     {
-        byte[] decoded = SourcesGroup.DecodeImageData(
-            Convert.ToBase64String(PngSignature)
-        );
+        byte[] decoded = SourcesGroup.DecodeImageData(Convert.ToBase64String(PngSignature));
 
         CollectionAssert.AreEqual(PngSignature, decoded);
     }

--- a/ObsWebSocket.Tests/ScreenshotDecodeTests.cs
+++ b/ObsWebSocket.Tests/ScreenshotDecodeTests.cs
@@ -1,0 +1,39 @@
+using ObsWebSocket.Core;
+
+namespace ObsWebSocket.Tests;
+
+/// <summary>
+/// OBS returns screenshots as a data URI, not as bare Base64. Decoding the whole string
+/// throws, so the in-memory screenshot helper silently returned nothing for every call.
+/// </summary>
+[TestClass]
+public sealed class ScreenshotDecodeTests
+{
+    // The eight byte PNG signature, which is what a caller checks to know it got an image.
+    private static readonly byte[] PngSignature =
+        [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+    [TestMethod]
+    public void DecodeImageData_WithDataUriPrefix_ReturnsTheImageBytes()
+    {
+        string dataUri = "data:image/png;base64," + Convert.ToBase64String(PngSignature);
+
+        byte[] decoded = SourcesRequestGroup.DecodeImageData(dataUri);
+
+        CollectionAssert.AreEqual(PngSignature, decoded);
+    }
+
+    [TestMethod]
+    public void DecodeImageData_WithBareBase64_StillDecodes()
+    {
+        byte[] decoded = SourcesRequestGroup.DecodeImageData(
+            Convert.ToBase64String(PngSignature)
+        );
+
+        CollectionAssert.AreEqual(PngSignature, decoded);
+    }
+
+    [TestMethod]
+    public void DecodeImageData_WhenEmpty_Throws() =>
+        Assert.ThrowsExactly<ArgumentException>(() => SourcesRequestGroup.DecodeImageData(""));
+}

--- a/ObsWebSocket.Tests/SerializerBehaviorTests.cs
+++ b/ObsWebSocket.Tests/SerializerBehaviorTests.cs
@@ -50,9 +50,8 @@ public class SerializerBehaviorTests
             )
             .RootElement.Clone();
 
-        SceneListChangedPayload? result = CreateJsonSerializer().DeserializePayload<SceneListChangedPayload>(
-            payload
-        );
+        SceneListChangedPayload? result = CreateJsonSerializer()
+            .DeserializePayload<SceneListChangedPayload>(payload);
 
         Assert.IsNotNull(result);
         Assert.IsNotNull(result.Scenes);
@@ -102,10 +101,7 @@ public class SerializerBehaviorTests
         Assert.AreEqual("scene-uuid-1", scenes[0].SceneUuid);
         Dictionary<string, JsonElement>? extensionData = scenes[0].ExtensionData;
         Assert.IsNotNull(extensionData);
-        Assert.AreEqual(
-            "extension-data-like-field",
-            extensionData["extraTag"].GetString()
-        );
+        Assert.AreEqual("extension-data-like-field", extensionData["extraTag"].GetString());
     }
 
     [TestMethod]
@@ -129,22 +125,11 @@ public class SerializerBehaviorTests
         Assert.IsTrue(filters[0].FilterEnabled ?? false);
         Assert.IsTrue(filters[0].FilterSettings.HasValue);
         JsonElement filterSettings = filters[0].FilterSettings.GetValueOrDefault();
-        Assert.AreEqual(
-            0.8d,
-            filterSettings.GetProperty("opacity").GetDouble(),
-            0.0001d
-        );
-        Assert.AreEqual(
-            1.2d,
-            filterSettings.GetProperty("gamma").GetDouble(),
-            0.0001d
-        );
+        Assert.AreEqual(0.8d, filterSettings.GetProperty("opacity").GetDouble(), 0.0001d);
+        Assert.AreEqual(1.2d, filterSettings.GetProperty("gamma").GetDouble(), 0.0001d);
         Dictionary<string, JsonElement>? extensionData = filters[0].ExtensionData;
         Assert.IsNotNull(extensionData);
-        Assert.AreEqual(
-            "present",
-            extensionData["customExtensionField"].GetString()
-        );
+        Assert.AreEqual("present", extensionData["customExtensionField"].GetString());
         JsonElement listExtension = extensionData["listExtension"];
         Assert.AreEqual(JsonValueKind.Array, listExtension.ValueKind);
         Assert.AreEqual(2, listExtension.GetArrayLength());
@@ -251,7 +236,9 @@ public class SerializerBehaviorTests
             )
             .RootElement.Clone();
 
-        CreateSceneRequestData? data = serializer.DeserializePayload<CreateSceneRequestData>(payload);
+        CreateSceneRequestData? data = serializer.DeserializePayload<CreateSceneRequestData>(
+            payload
+        );
         Assert.IsNull(data);
     }
 
@@ -275,7 +262,8 @@ public class SerializerBehaviorTests
         object? envelope = await serializer.DeserializeAsync(stream);
 
         _ = Assert.IsInstanceOfType<IncomingMessage<ReadOnlyMemory<byte>>>(envelope);
-        IncomingMessage<ReadOnlyMemory<byte>> incoming = (IncomingMessage<ReadOnlyMemory<byte>>)envelope;
+        IncomingMessage<ReadOnlyMemory<byte>> incoming =
+            (IncomingMessage<ReadOnlyMemory<byte>>)envelope;
         Assert.AreEqual(WebSocketOpCode.Hello, incoming.Op);
         Assert.IsTrue(incoming.D.Length > 0);
 
@@ -387,7 +375,9 @@ public class SerializerBehaviorTests
         byte[] bytes = BuildSceneItemListPayloadBytes();
 
         GetSceneItemListResponseData? payload =
-            serializer.DeserializePayload<GetSceneItemListResponseData>(new ReadOnlyMemory<byte>(bytes));
+            serializer.DeserializePayload<GetSceneItemListResponseData>(
+                new ReadOnlyMemory<byte>(bytes)
+            );
 
         Assert.IsNotNull(payload);
         List<Core.Protocol.Common.SceneItemStub>? sceneItems = payload.SceneItems;
@@ -411,7 +401,9 @@ public class SerializerBehaviorTests
         byte[] bytes = BuildInvalidFilterListPayloadBytes();
 
         GetSourceFilterListResponseData? payload =
-            serializer.DeserializePayload<GetSourceFilterListResponseData>(new ReadOnlyMemory<byte>(bytes));
+            serializer.DeserializePayload<GetSourceFilterListResponseData>(
+                new ReadOnlyMemory<byte>(bytes)
+            );
 
         Assert.IsNull(payload);
     }
@@ -420,29 +412,28 @@ public class SerializerBehaviorTests
     public void MsgPackSerializer_SerializeThenDeserialize_FilterPayload_RoundTripsWithValues()
     {
         MsgPackMessageSerializer serializer = CreateMsgPackSerializer();
-        GetSourceFilterListResponseData payload = new(
-            [
-                new Core.Protocol.Common.FilterStub
-                {
-                    FilterName = "Color Correction",
-                    FilterKind = "color_filter_v2",
-                    FilterIndex = 0,
-                    FilterEnabled = true,
-                },
-                new Core.Protocol.Common.FilterStub
-                {
-                    FilterName = "Limiter",
-                    FilterKind = "limiter_filter_v2",
-                    FilterIndex = 1,
-                    FilterEnabled = false,
-                },
-            ]
-        );
+        GetSourceFilterListResponseData payload = new([
+            new Core.Protocol.Common.FilterStub
+            {
+                FilterName = "Color Correction",
+                FilterKind = "color_filter_v2",
+                FilterIndex = 0,
+                FilterEnabled = true,
+            },
+            new Core.Protocol.Common.FilterStub
+            {
+                FilterName = "Limiter",
+                FilterKind = "limiter_filter_v2",
+                FilterIndex = 1,
+                FilterEnabled = false,
+            },
+        ]);
 
         byte[] bytes = MessagePack.MessagePackSerializer.Serialize(payload);
-        GetSourceFilterListResponseData? roundTrip = serializer.DeserializePayload<
-            GetSourceFilterListResponseData
-        >(new ReadOnlyMemory<byte>(bytes));
+        GetSourceFilterListResponseData? roundTrip =
+            serializer.DeserializePayload<GetSourceFilterListResponseData>(
+                new ReadOnlyMemory<byte>(bytes)
+            );
 
         Assert.IsNotNull(roundTrip);
         Assert.IsNotNull(roundTrip.Filters);
@@ -498,27 +489,13 @@ public class SerializerBehaviorTests
             )
         );
 
-        requiredTypes.Add(
-            typeof(HelloPayload)
-        );
-        requiredTypes.Add(
-            typeof(AuthenticationData)
-        );
-        requiredTypes.Add(
-            typeof(IdentifyPayload)
-        );
-        requiredTypes.Add(
-            typeof(IdentifiedPayload)
-        );
-        requiredTypes.Add(
-            typeof(ReidentifyPayload)
-        );
-        requiredTypes.Add(
-            typeof(RequestPayload)
-        );
-        requiredTypes.Add(
-            typeof(RequestBatchPayload)
-        );
+        requiredTypes.Add(typeof(HelloPayload));
+        requiredTypes.Add(typeof(AuthenticationData));
+        requiredTypes.Add(typeof(IdentifyPayload));
+        requiredTypes.Add(typeof(IdentifiedPayload));
+        requiredTypes.Add(typeof(ReidentifyPayload));
+        requiredTypes.Add(typeof(RequestPayload));
+        requiredTypes.Add(typeof(RequestBatchPayload));
         requiredTypes.Add(typeof(ObsWebSocket.Core.Protocol.RequestStatus));
 
         List<string> missing = [];
@@ -729,7 +706,9 @@ public class SerializerBehaviorTests
 
     private static bool HasFormatter(IFormatterResolver resolver, Type targetType)
     {
-        MethodInfo? method = typeof(IFormatterResolver).GetMethod(nameof(IFormatterResolver.GetFormatter));
+        MethodInfo? method = typeof(IFormatterResolver).GetMethod(
+            nameof(IFormatterResolver.GetFormatter)
+        );
         Assert.IsNotNull(method, "Could not locate IFormatterResolver.GetFormatter<T>.");
         object? formatter = method.MakeGenericMethod(targetType).Invoke(resolver, null);
         return formatter is not null;

--- a/ObsWebSocket.Tests/TestUtils.cs
+++ b/ObsWebSocket.Tests/TestUtils.cs
@@ -365,9 +365,10 @@ internal static class TestUtils
     /// <summary>
     /// Serializes an object to a JsonElement using default web options. Clones the element for safe use.
     /// </summary>
-    internal static JsonElement? ToJsonElement(object? obj) => obj == null
-            ? null
-            : obj is JsonElement element ? element.Clone() : JsonSerializer.SerializeToElement(obj, obj.GetType(), s_jsonSerializerOptions);
+    internal static JsonElement? ToJsonElement(object? obj) =>
+        obj == null ? null
+        : obj is JsonElement element ? element.Clone()
+        : JsonSerializer.SerializeToElement(obj, obj.GetType(), s_jsonSerializerOptions);
 
     /// <summary>
     /// Gets a delegate for a private instance method using reflection.

--- a/ObsWebSocket.Tests/TimeProviderTests.cs
+++ b/ObsWebSocket.Tests/TimeProviderTests.cs
@@ -36,7 +36,11 @@ public sealed class TimeProviderTests
             )
             .Returns(ValueTask.CompletedTask);
 
-        Task<GetVersionResponseData?> pending = client.CallAsync<GetVersionResponseData>("GetVersion", null, timeoutMs: 5000);
+        Task<GetVersionResponseData?> pending = client.CallAsync<GetVersionResponseData>(
+            "GetVersion",
+            null,
+            timeoutMs: 5000
+        );
 
         await Task.Delay(50, TestContext.CancellationTokenSource.Token);
         Assert.IsFalse(pending.IsCompleted, "wall-clock time must not advance the timeout");
@@ -47,9 +51,10 @@ public sealed class TimeProviderTests
 
         time.Advance(TimeSpan.FromMilliseconds(2));
 
-        ObsWebSocketTimeoutException ex = await Assert.ThrowsExactlyAsync<ObsWebSocketTimeoutException>(
-            async () => await pending
-        );
+        ObsWebSocketTimeoutException ex =
+            await Assert.ThrowsExactlyAsync<ObsWebSocketTimeoutException>(async () =>
+                await pending
+            );
         StringAssert.Contains(ex.Message, "timed out");
 
         await client.DisposeAsync();

--- a/ObsWebSocket.Tests/TypedSettingsTests.cs
+++ b/ObsWebSocket.Tests/TypedSettingsTests.cs
@@ -27,7 +27,8 @@ internal sealed record TestConsumerSettings(
 [JsonSerializable(typeof(TestConsumerSettings))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
-    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault)]
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault
+)]
 internal sealed partial class TestConsumerSettingsJsonContext : JsonSerializerContext { }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -40,13 +41,14 @@ public class TypedSettingsTests
     private static MsgPackMessageSerializer CreateMsgPackSerializer() =>
         new(NullLogger<MsgPackMessageSerializer>.Instance);
 
-
     // ── Section 1: Direct serialization (no client infrastructure) ────────────
 
     [TestMethod]
     public void BrowserSourceSettings_SerializeToJson_ProducesCorrectKeys()
     {
-        JsonTypeInfo<BrowserSourceSettings> typeInfo = ObsWebSocketSettingsJsonContext.Default.BrowserSourceSettings;
+        JsonTypeInfo<BrowserSourceSettings> typeInfo = ObsWebSocketSettingsJsonContext
+            .Default
+            .BrowserSourceSettings;
         BrowserSourceSettings settings = new(
             Url: "https://example.com",
             Width: 1920,
@@ -75,7 +77,9 @@ public class TypedSettingsTests
     [TestMethod]
     public void BrowserSourceSettings_NullProperties_AreOmittedFromJson()
     {
-        JsonTypeInfo<BrowserSourceSettings> typeInfo = ObsWebSocketSettingsJsonContext.Default.BrowserSourceSettings;
+        JsonTypeInfo<BrowserSourceSettings> typeInfo = ObsWebSocketSettingsJsonContext
+            .Default
+            .BrowserSourceSettings;
         BrowserSourceSettings settings = new(Url: "https://example.com"); // only Url set
 
         JsonElement element = JsonSerializer.SerializeToElement(settings, typeInfo);
@@ -83,15 +87,23 @@ public class TypedSettingsTests
         Assert.AreEqual("https://example.com", element.GetProperty("url").GetString());
         Assert.IsFalse(element.TryGetProperty("width", out _), "Null width should be absent");
         Assert.IsFalse(element.TryGetProperty("height", out _), "Null height should be absent");
-        Assert.IsFalse(element.TryGetProperty("fps_custom", out _), "Null fps_custom should be absent");
+        Assert.IsFalse(
+            element.TryGetProperty("fps_custom", out _),
+            "Null fps_custom should be absent"
+        );
         Assert.IsFalse(element.TryGetProperty("css", out _), "Null css should be absent");
-        Assert.IsFalse(element.TryGetProperty("reroute_audio", out _), "Null reroute_audio should be absent");
+        Assert.IsFalse(
+            element.TryGetProperty("reroute_audio", out _),
+            "Null reroute_audio should be absent"
+        );
     }
 
     [TestMethod]
     public void GainFilterSettings_SerializeToJson_ProducesCorrectKey()
     {
-        JsonTypeInfo<GainFilterSettings> typeInfo = ObsWebSocketSettingsJsonContext.Default.GainFilterSettings;
+        JsonTypeInfo<GainFilterSettings> typeInfo = ObsWebSocketSettingsJsonContext
+            .Default
+            .GainFilterSettings;
         GainFilterSettings settings = new(Db: -6.0);
 
         JsonElement element = JsonSerializer.SerializeToElement(settings, typeInfo);
@@ -103,7 +115,9 @@ public class TypedSettingsTests
     [TestMethod]
     public void ConsumerSettings_ExplicitTypeInfo_SerializesCorrectly()
     {
-        JsonTypeInfo<TestConsumerSettings> typeInfo = TestConsumerSettingsJsonContext.Default.TestConsumerSettings;
+        JsonTypeInfo<TestConsumerSettings> typeInfo = TestConsumerSettingsJsonContext
+            .Default
+            .TestConsumerSettings;
         TestConsumerSettings settings = new(CustomKey: "hello", CustomCount: 42);
 
         JsonElement element = JsonSerializer.SerializeToElement(settings, typeInfo);
@@ -115,7 +129,9 @@ public class TypedSettingsTests
     [TestMethod]
     public void BrowserSourceSettings_MsgPackRoundtrip_ThroughGetInputSettingsResponse()
     {
-        JsonTypeInfo<BrowserSourceSettings> typeInfo = ObsWebSocketSettingsJsonContext.Default.BrowserSourceSettings;
+        JsonTypeInfo<BrowserSourceSettings> typeInfo = ObsWebSocketSettingsJsonContext
+            .Default
+            .BrowserSourceSettings;
         BrowserSourceSettings original = new(
             Url: "https://example.com",
             Width: 1920,
@@ -127,9 +143,15 @@ public class TypedSettingsTests
         );
 
         JsonElement settingsElement = JsonSerializer.SerializeToElement(original, typeInfo);
-        GetInputSettingsResponseData response = new(inputSettings: settingsElement, inputKind: "browser_source");
+        GetInputSettingsResponseData response = new(
+            inputSettings: settingsElement,
+            inputKind: "browser_source"
+        );
 
-        byte[] bytes = MessagePackSerializer.Serialize(response, MsgPackMessageSerializer.s_msgPackOptions);
+        byte[] bytes = MessagePackSerializer.Serialize(
+            response,
+            MsgPackMessageSerializer.s_msgPackOptions
+        );
         GetInputSettingsResponseData? roundTripped = CreateMsgPackSerializer()
             .DeserializePayload<GetInputSettingsResponseData>(new ReadOnlyMemory<byte>(bytes));
 
@@ -150,7 +172,9 @@ public class TypedSettingsTests
     [TestMethod]
     public void GainFilterSettings_MsgPackRoundtrip_ThroughGetSourceFilterResponse()
     {
-        JsonTypeInfo<GainFilterSettings> typeInfo = ObsWebSocketSettingsJsonContext.Default.GainFilterSettings;
+        JsonTypeInfo<GainFilterSettings> typeInfo = ObsWebSocketSettingsJsonContext
+            .Default
+            .GainFilterSettings;
         GainFilterSettings original = new(Db: -3.5);
 
         JsonElement settingsElement = JsonSerializer.SerializeToElement(original, typeInfo);
@@ -161,7 +185,10 @@ public class TypedSettingsTests
             filterKind: "gain_filter"
         );
 
-        byte[] bytes = MessagePackSerializer.Serialize(response, MsgPackMessageSerializer.s_msgPackOptions);
+        byte[] bytes = MessagePackSerializer.Serialize(
+            response,
+            MsgPackMessageSerializer.s_msgPackOptions
+        );
         GetSourceFilterResponseData? roundTripped = CreateMsgPackSerializer()
             .DeserializePayload<GetSourceFilterResponseData>(new ReadOnlyMemory<byte>(bytes));
 
@@ -173,37 +200,65 @@ public class TypedSettingsTests
         Assert.AreEqual(-3.5, result.Db!.Value, 0.0001d);
     }
 
-
     // ── Section 2: SetInputSettingsAsync helpers ──────────────────────────────
 
     [TestMethod]
     [Timeout(TestTimeout)]
     public async Task SetInputSettingsAsync_LibraryType_SendsCorrectSettingsElement()
     {
-        (ObsWebSocketClient client, Mock<IWebSocketMessageSerializer> mockSerializer, Mock<IWebSocketConnection> mockConnection) =
-            TestUtils.SetupConnectedClientForceState();
-        _ = mockSerializer.Setup(s => s.DeserializePayload<object>(It.IsAny<object>())).Returns((object?)null);
+        (
+            ObsWebSocketClient client,
+            Mock<IWebSocketMessageSerializer> mockSerializer,
+            Mock<IWebSocketConnection> mockConnection
+        ) = TestUtils.SetupConnectedClientForceState();
+        _ = mockSerializer
+            .Setup(s => s.DeserializePayload<object>(It.IsAny<object>()))
+            .Returns((object?)null);
 
         BrowserSourceSettings settings = new(Url: "https://test.com", Width: 1280, Height: 720);
         JsonElement? capturedSettings = null;
 
-        _ = mockConnection.Setup(ws => ws.SendAsync(
-            It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<WebSocketMessageType>(), true, It.IsAny<CancellationToken>()))
-        .Callback((ReadOnlyMemory<byte> buffer, WebSocketMessageType _, bool _, CancellationToken _) =>
-        {
-            OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<OutgoingMessage<RequestPayload>>(
-                buffer.Span, TestUtils.s_jsonSerializerOptions);
-            if (msg?.D?.RequestType == "SetInputSettings")
-            {
-                string id = msg.D.RequestId!;
-                capturedSettings = msg.D.RequestData?.GetProperty("inputSettings");
-                _ = TestUtils.SimulateIncomingResponse(client, id, new RequestResponsePayload<object>(
-                    RequestType: "SetInputSettings", RequestId: id,
-                    RequestStatus: new RequestStatus(Result: true, Code: (int)Core.Protocol.Generated.RequestStatus.Success),
-                    ResponseData: null));
-            }
-        })
-        .Returns(ValueTask.CompletedTask);
+        _ = mockConnection
+            .Setup(ws =>
+                ws.SendAsync(
+                    It.IsAny<ReadOnlyMemory<byte>>(),
+                    It.IsAny<WebSocketMessageType>(),
+                    true,
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (
+                    ReadOnlyMemory<byte> buffer,
+                    WebSocketMessageType _,
+                    bool _,
+                    CancellationToken _
+                ) =>
+                {
+                    OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<
+                        OutgoingMessage<RequestPayload>
+                    >(buffer.Span, TestUtils.s_jsonSerializerOptions);
+                    if (msg?.D?.RequestType == "SetInputSettings")
+                    {
+                        string id = msg.D.RequestId!;
+                        capturedSettings = msg.D.RequestData?.GetProperty("inputSettings");
+                        _ = TestUtils.SimulateIncomingResponse(
+                            client,
+                            id,
+                            new RequestResponsePayload<object>(
+                                RequestType: "SetInputSettings",
+                                RequestId: id,
+                                RequestStatus: new RequestStatus(
+                                    Result: true,
+                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                ),
+                                ResponseData: null
+                            )
+                        );
+                    }
+                }
+            )
+            .Returns(ValueTask.CompletedTask);
 
         await client.Inputs.SetInputSettingsAsync("TestSource", settings, overlay: true);
 
@@ -211,38 +266,72 @@ public class TypedSettingsTests
         Assert.AreEqual("https://test.com", capturedSettings.Value.GetProperty("url").GetString());
         Assert.AreEqual(1280, capturedSettings.Value.GetProperty("width").GetInt32());
         Assert.AreEqual(720, capturedSettings.Value.GetProperty("height").GetInt32());
-        Assert.IsFalse(capturedSettings.Value.TryGetProperty("fps_custom", out _), "Null props should be absent");
+        Assert.IsFalse(
+            capturedSettings.Value.TryGetProperty("fps_custom", out _),
+            "Null props should be absent"
+        );
     }
 
     [TestMethod]
     [Timeout(TestTimeout)]
     public async Task SetInputSettingsAsync_ConsumerType_WithExplicitTypeInfo_SendsCorrectSettingsElement()
     {
-        (ObsWebSocketClient client, Mock<IWebSocketMessageSerializer> mockSerializer, Mock<IWebSocketConnection> mockConnection) =
-            TestUtils.SetupConnectedClientForceState();
-        _ = mockSerializer.Setup(s => s.DeserializePayload<object>(It.IsAny<object>())).Returns((object?)null);
+        (
+            ObsWebSocketClient client,
+            Mock<IWebSocketMessageSerializer> mockSerializer,
+            Mock<IWebSocketConnection> mockConnection
+        ) = TestUtils.SetupConnectedClientForceState();
+        _ = mockSerializer
+            .Setup(s => s.DeserializePayload<object>(It.IsAny<object>()))
+            .Returns((object?)null);
 
         TestConsumerSettings settings = new(CustomKey: "abc", CustomCount: 99);
-        JsonTypeInfo<TestConsumerSettings> typeInfo = TestConsumerSettingsJsonContext.Default.TestConsumerSettings;
+        JsonTypeInfo<TestConsumerSettings> typeInfo = TestConsumerSettingsJsonContext
+            .Default
+            .TestConsumerSettings;
         JsonElement? capturedSettings = null;
 
-        _ = mockConnection.Setup(ws => ws.SendAsync(
-            It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<WebSocketMessageType>(), true, It.IsAny<CancellationToken>()))
-        .Callback((ReadOnlyMemory<byte> buffer, WebSocketMessageType _, bool _, CancellationToken _) =>
-        {
-            OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<OutgoingMessage<RequestPayload>>(
-                buffer.Span, TestUtils.s_jsonSerializerOptions);
-            if (msg?.D?.RequestType == "SetInputSettings")
-            {
-                string id = msg.D.RequestId!;
-                capturedSettings = msg.D.RequestData?.GetProperty("inputSettings");
-                _ = TestUtils.SimulateIncomingResponse(client, id, new RequestResponsePayload<object>(
-                    RequestType: "SetInputSettings", RequestId: id,
-                    RequestStatus: new RequestStatus(Result: true, Code: (int)Core.Protocol.Generated.RequestStatus.Success),
-                    ResponseData: null));
-            }
-        })
-        .Returns(ValueTask.CompletedTask);
+        _ = mockConnection
+            .Setup(ws =>
+                ws.SendAsync(
+                    It.IsAny<ReadOnlyMemory<byte>>(),
+                    It.IsAny<WebSocketMessageType>(),
+                    true,
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (
+                    ReadOnlyMemory<byte> buffer,
+                    WebSocketMessageType _,
+                    bool _,
+                    CancellationToken _
+                ) =>
+                {
+                    OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<
+                        OutgoingMessage<RequestPayload>
+                    >(buffer.Span, TestUtils.s_jsonSerializerOptions);
+                    if (msg?.D?.RequestType == "SetInputSettings")
+                    {
+                        string id = msg.D.RequestId!;
+                        capturedSettings = msg.D.RequestData?.GetProperty("inputSettings");
+                        _ = TestUtils.SimulateIncomingResponse(
+                            client,
+                            id,
+                            new RequestResponsePayload<object>(
+                                RequestType: "SetInputSettings",
+                                RequestId: id,
+                                RequestStatus: new RequestStatus(
+                                    Result: true,
+                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                ),
+                                ResponseData: null
+                            )
+                        );
+                    }
+                }
+            )
+            .Returns(ValueTask.CompletedTask);
 
         await client.Inputs.SetInputSettingsAsync("TestSource", settings, typeInfo, overlay: true);
 
@@ -256,8 +345,12 @@ public class TypedSettingsTests
     {
         (ObsWebSocketClient client, _, _) = TestUtils.SetupConnectedClientForceState();
 
-        _ = await Assert.ThrowsExactlyAsync<ObsWebSocketException>(
-            () => client.Inputs.SetInputSettingsAsync("TestSource", new TestConsumerSettings(), overlay: true)
+        _ = await Assert.ThrowsExactlyAsync<ObsWebSocketException>(() =>
+            client.Inputs.SetInputSettingsAsync(
+                "TestSource",
+                new TestConsumerSettings(),
+                overlay: true
+            )
         );
     }
 
@@ -267,35 +360,74 @@ public class TypedSettingsTests
     [Timeout(TestTimeout)]
     public async Task GetInputSettingsAsync_LibraryType_DeserializesCorrectly()
     {
-        (ObsWebSocketClient client, Mock<IWebSocketMessageSerializer> mockSerializer, Mock<IWebSocketConnection> mockConnection) =
-            TestUtils.SetupConnectedClientForceState();
+        (
+            ObsWebSocketClient client,
+            Mock<IWebSocketMessageSerializer> mockSerializer,
+            Mock<IWebSocketConnection> mockConnection
+        ) = TestUtils.SetupConnectedClientForceState();
 
-        BrowserSourceSettings expected = new(Url: "https://obs.test", Width: 1920, Height: 1080, RerouteAudio: true);
-        JsonTypeInfo<BrowserSourceSettings> typeInfo = ObsWebSocketSettingsJsonContext.Default.BrowserSourceSettings;
+        BrowserSourceSettings expected = new(
+            Url: "https://obs.test",
+            Width: 1920,
+            Height: 1080,
+            RerouteAudio: true
+        );
+        JsonTypeInfo<BrowserSourceSettings> typeInfo = ObsWebSocketSettingsJsonContext
+            .Default
+            .BrowserSourceSettings;
         JsonElement settingsElement = JsonSerializer.SerializeToElement(expected, typeInfo);
-        GetInputSettingsResponseData responseDto = new(inputSettings: settingsElement, inputKind: "browser_source");
+        GetInputSettingsResponseData responseDto = new(
+            inputSettings: settingsElement,
+            inputKind: "browser_source"
+        );
 
-        _ = mockConnection.Setup(ws => ws.SendAsync(
-            It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<WebSocketMessageType>(), true, It.IsAny<CancellationToken>()))
-        .Callback((ReadOnlyMemory<byte> buffer, WebSocketMessageType _, bool _, CancellationToken _) =>
-        {
-            OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<OutgoingMessage<RequestPayload>>(
-                buffer.Span, TestUtils.s_jsonSerializerOptions);
-            if (msg?.D?.RequestType == "GetInputSettings")
-            {
-                JsonElement rawPayload = TestUtils.ToJsonElement(responseDto)!.Value;
-                _ = TestUtils.SimulateIncomingResponse(client, msg.D.RequestId!, new RequestResponsePayload<object>(
-                    RequestType: "GetInputSettings", RequestId: msg.D.RequestId!,
-                    RequestStatus: new RequestStatus(Result: true, Code: (int)Core.Protocol.Generated.RequestStatus.Success),
-                    ResponseData: rawPayload));
-            }
-        })
-        .Returns(ValueTask.CompletedTask);
+        _ = mockConnection
+            .Setup(ws =>
+                ws.SendAsync(
+                    It.IsAny<ReadOnlyMemory<byte>>(),
+                    It.IsAny<WebSocketMessageType>(),
+                    true,
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (
+                    ReadOnlyMemory<byte> buffer,
+                    WebSocketMessageType _,
+                    bool _,
+                    CancellationToken _
+                ) =>
+                {
+                    OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<
+                        OutgoingMessage<RequestPayload>
+                    >(buffer.Span, TestUtils.s_jsonSerializerOptions);
+                    if (msg?.D?.RequestType == "GetInputSettings")
+                    {
+                        JsonElement rawPayload = TestUtils.ToJsonElement(responseDto)!.Value;
+                        _ = TestUtils.SimulateIncomingResponse(
+                            client,
+                            msg.D.RequestId!,
+                            new RequestResponsePayload<object>(
+                                RequestType: "GetInputSettings",
+                                RequestId: msg.D.RequestId!,
+                                RequestStatus: new RequestStatus(
+                                    Result: true,
+                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                ),
+                                ResponseData: rawPayload
+                            )
+                        );
+                    }
+                }
+            )
+            .Returns(ValueTask.CompletedTask);
 
-        _ = mockSerializer.Setup(s => s.DeserializePayload<GetInputSettingsResponseData>(It.IsAny<object>()))
+        _ = mockSerializer
+            .Setup(s => s.DeserializePayload<GetInputSettingsResponseData>(It.IsAny<object>()))
             .Returns(responseDto);
 
-        BrowserSourceSettings? result = await client.Inputs.GetInputSettingsAsync<BrowserSourceSettings>("TestInput");
+        BrowserSourceSettings? result =
+            await client.Inputs.GetInputSettingsAsync<BrowserSourceSettings>("TestInput");
 
         Assert.IsNotNull(result);
         Assert.AreEqual("https://obs.test", result.Url);
@@ -309,35 +441,71 @@ public class TypedSettingsTests
     [Timeout(TestTimeout)]
     public async Task GetInputSettingsAsync_ConsumerType_WithExplicitTypeInfo_DeserializesCorrectly()
     {
-        (ObsWebSocketClient client, Mock<IWebSocketMessageSerializer> mockSerializer, Mock<IWebSocketConnection> mockConnection) =
-            TestUtils.SetupConnectedClientForceState();
+        (
+            ObsWebSocketClient client,
+            Mock<IWebSocketMessageSerializer> mockSerializer,
+            Mock<IWebSocketConnection> mockConnection
+        ) = TestUtils.SetupConnectedClientForceState();
 
         TestConsumerSettings expected = new(CustomKey: "xyz", CustomCount: 7);
-        JsonTypeInfo<TestConsumerSettings> typeInfo = TestConsumerSettingsJsonContext.Default.TestConsumerSettings;
+        JsonTypeInfo<TestConsumerSettings> typeInfo = TestConsumerSettingsJsonContext
+            .Default
+            .TestConsumerSettings;
         JsonElement settingsElement = JsonSerializer.SerializeToElement(expected, typeInfo);
-        GetInputSettingsResponseData responseDto = new(inputSettings: settingsElement, inputKind: "custom_source");
+        GetInputSettingsResponseData responseDto = new(
+            inputSettings: settingsElement,
+            inputKind: "custom_source"
+        );
 
-        _ = mockConnection.Setup(ws => ws.SendAsync(
-            It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<WebSocketMessageType>(), true, It.IsAny<CancellationToken>()))
-        .Callback((ReadOnlyMemory<byte> buffer, WebSocketMessageType _, bool _, CancellationToken _) =>
-        {
-            OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<OutgoingMessage<RequestPayload>>(
-                buffer.Span, TestUtils.s_jsonSerializerOptions);
-            if (msg?.D?.RequestType == "GetInputSettings")
-            {
-                JsonElement rawPayload = TestUtils.ToJsonElement(responseDto)!.Value;
-                _ = TestUtils.SimulateIncomingResponse(client, msg.D.RequestId!, new RequestResponsePayload<object>(
-                    RequestType: "GetInputSettings", RequestId: msg.D.RequestId!,
-                    RequestStatus: new RequestStatus(Result: true, Code: (int)Core.Protocol.Generated.RequestStatus.Success),
-                    ResponseData: rawPayload));
-            }
-        })
-        .Returns(ValueTask.CompletedTask);
+        _ = mockConnection
+            .Setup(ws =>
+                ws.SendAsync(
+                    It.IsAny<ReadOnlyMemory<byte>>(),
+                    It.IsAny<WebSocketMessageType>(),
+                    true,
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (
+                    ReadOnlyMemory<byte> buffer,
+                    WebSocketMessageType _,
+                    bool _,
+                    CancellationToken _
+                ) =>
+                {
+                    OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<
+                        OutgoingMessage<RequestPayload>
+                    >(buffer.Span, TestUtils.s_jsonSerializerOptions);
+                    if (msg?.D?.RequestType == "GetInputSettings")
+                    {
+                        JsonElement rawPayload = TestUtils.ToJsonElement(responseDto)!.Value;
+                        _ = TestUtils.SimulateIncomingResponse(
+                            client,
+                            msg.D.RequestId!,
+                            new RequestResponsePayload<object>(
+                                RequestType: "GetInputSettings",
+                                RequestId: msg.D.RequestId!,
+                                RequestStatus: new RequestStatus(
+                                    Result: true,
+                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                ),
+                                ResponseData: rawPayload
+                            )
+                        );
+                    }
+                }
+            )
+            .Returns(ValueTask.CompletedTask);
 
-        _ = mockSerializer.Setup(s => s.DeserializePayload<GetInputSettingsResponseData>(It.IsAny<object>()))
+        _ = mockSerializer
+            .Setup(s => s.DeserializePayload<GetInputSettingsResponseData>(It.IsAny<object>()))
             .Returns(responseDto);
 
-        TestConsumerSettings? result = await client.Inputs.GetInputSettingsAsync("TestInput", typeInfo);
+        TestConsumerSettings? result = await client.Inputs.GetInputSettingsAsync(
+            "TestInput",
+            typeInfo
+        );
 
         Assert.IsNotNull(result);
         Assert.AreEqual("xyz", result.CustomKey);
@@ -350,32 +518,66 @@ public class TypedSettingsTests
     [Timeout(TestTimeout)]
     public async Task SetSourceFilterSettingsAsync_LibraryType_SendsCorrectSettingsElement()
     {
-        (ObsWebSocketClient client, Mock<IWebSocketMessageSerializer> mockSerializer, Mock<IWebSocketConnection> mockConnection) =
-            TestUtils.SetupConnectedClientForceState();
-        _ = mockSerializer.Setup(s => s.DeserializePayload<object>(It.IsAny<object>())).Returns((object?)null);
+        (
+            ObsWebSocketClient client,
+            Mock<IWebSocketMessageSerializer> mockSerializer,
+            Mock<IWebSocketConnection> mockConnection
+        ) = TestUtils.SetupConnectedClientForceState();
+        _ = mockSerializer
+            .Setup(s => s.DeserializePayload<object>(It.IsAny<object>()))
+            .Returns((object?)null);
 
         GainFilterSettings settings = new(Db: -12.0);
         JsonElement? capturedSettings = null;
 
-        _ = mockConnection.Setup(ws => ws.SendAsync(
-            It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<WebSocketMessageType>(), true, It.IsAny<CancellationToken>()))
-        .Callback((ReadOnlyMemory<byte> buffer, WebSocketMessageType _, bool _, CancellationToken _) =>
-        {
-            OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<OutgoingMessage<RequestPayload>>(
-                buffer.Span, TestUtils.s_jsonSerializerOptions);
-            if (msg?.D?.RequestType == "SetSourceFilterSettings")
-            {
-                string id = msg.D.RequestId!;
-                capturedSettings = msg.D.RequestData?.GetProperty("filterSettings");
-                _ = TestUtils.SimulateIncomingResponse(client, id, new RequestResponsePayload<object>(
-                    RequestType: "SetSourceFilterSettings", RequestId: id,
-                    RequestStatus: new RequestStatus(Result: true, Code: (int)Core.Protocol.Generated.RequestStatus.Success),
-                    ResponseData: null));
-            }
-        })
-        .Returns(ValueTask.CompletedTask);
+        _ = mockConnection
+            .Setup(ws =>
+                ws.SendAsync(
+                    It.IsAny<ReadOnlyMemory<byte>>(),
+                    It.IsAny<WebSocketMessageType>(),
+                    true,
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (
+                    ReadOnlyMemory<byte> buffer,
+                    WebSocketMessageType _,
+                    bool _,
+                    CancellationToken _
+                ) =>
+                {
+                    OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<
+                        OutgoingMessage<RequestPayload>
+                    >(buffer.Span, TestUtils.s_jsonSerializerOptions);
+                    if (msg?.D?.RequestType == "SetSourceFilterSettings")
+                    {
+                        string id = msg.D.RequestId!;
+                        capturedSettings = msg.D.RequestData?.GetProperty("filterSettings");
+                        _ = TestUtils.SimulateIncomingResponse(
+                            client,
+                            id,
+                            new RequestResponsePayload<object>(
+                                RequestType: "SetSourceFilterSettings",
+                                RequestId: id,
+                                RequestStatus: new RequestStatus(
+                                    Result: true,
+                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                ),
+                                ResponseData: null
+                            )
+                        );
+                    }
+                }
+            )
+            .Returns(ValueTask.CompletedTask);
 
-        await client.Filters.SetSourceFilterSettingsAsync("AudioSource", "Gain", settings, overlay: true);
+        await client.Filters.SetSourceFilterSettingsAsync(
+            "AudioSource",
+            "Gain",
+            settings,
+            overlay: true
+        );
 
         Assert.IsNotNull(capturedSettings);
         Assert.AreEqual(-12.0, capturedSettings.Value.GetProperty("db").GetDouble(), 0.0001d);
@@ -385,37 +587,77 @@ public class TypedSettingsTests
     [Timeout(TestTimeout)]
     public async Task SetSourceFilterSettingsAsync_ConsumerType_WithExplicitTypeInfo_SendsCorrectSettingsElement()
     {
-        (ObsWebSocketClient client, Mock<IWebSocketMessageSerializer> mockSerializer, Mock<IWebSocketConnection> mockConnection) =
-            TestUtils.SetupConnectedClientForceState();
-        _ = mockSerializer.Setup(s => s.DeserializePayload<object>(It.IsAny<object>())).Returns((object?)null);
+        (
+            ObsWebSocketClient client,
+            Mock<IWebSocketMessageSerializer> mockSerializer,
+            Mock<IWebSocketConnection> mockConnection
+        ) = TestUtils.SetupConnectedClientForceState();
+        _ = mockSerializer
+            .Setup(s => s.DeserializePayload<object>(It.IsAny<object>()))
+            .Returns((object?)null);
 
         TestConsumerSettings settings = new(CustomKey: "filter-val");
-        JsonTypeInfo<TestConsumerSettings> typeInfo = TestConsumerSettingsJsonContext.Default.TestConsumerSettings;
+        JsonTypeInfo<TestConsumerSettings> typeInfo = TestConsumerSettingsJsonContext
+            .Default
+            .TestConsumerSettings;
         JsonElement? capturedSettings = null;
 
-        _ = mockConnection.Setup(ws => ws.SendAsync(
-            It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<WebSocketMessageType>(), true, It.IsAny<CancellationToken>()))
-        .Callback((ReadOnlyMemory<byte> buffer, WebSocketMessageType _, bool _, CancellationToken _) =>
-        {
-            OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<OutgoingMessage<RequestPayload>>(
-                buffer.Span, TestUtils.s_jsonSerializerOptions);
-            if (msg?.D?.RequestType == "SetSourceFilterSettings")
-            {
-                string id = msg.D.RequestId!;
-                capturedSettings = msg.D.RequestData?.GetProperty("filterSettings");
-                _ = TestUtils.SimulateIncomingResponse(client, id, new RequestResponsePayload<object>(
-                    RequestType: "SetSourceFilterSettings", RequestId: id,
-                    RequestStatus: new RequestStatus(Result: true, Code: (int)Core.Protocol.Generated.RequestStatus.Success),
-                    ResponseData: null));
-            }
-        })
-        .Returns(ValueTask.CompletedTask);
+        _ = mockConnection
+            .Setup(ws =>
+                ws.SendAsync(
+                    It.IsAny<ReadOnlyMemory<byte>>(),
+                    It.IsAny<WebSocketMessageType>(),
+                    true,
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (
+                    ReadOnlyMemory<byte> buffer,
+                    WebSocketMessageType _,
+                    bool _,
+                    CancellationToken _
+                ) =>
+                {
+                    OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<
+                        OutgoingMessage<RequestPayload>
+                    >(buffer.Span, TestUtils.s_jsonSerializerOptions);
+                    if (msg?.D?.RequestType == "SetSourceFilterSettings")
+                    {
+                        string id = msg.D.RequestId!;
+                        capturedSettings = msg.D.RequestData?.GetProperty("filterSettings");
+                        _ = TestUtils.SimulateIncomingResponse(
+                            client,
+                            id,
+                            new RequestResponsePayload<object>(
+                                RequestType: "SetSourceFilterSettings",
+                                RequestId: id,
+                                RequestStatus: new RequestStatus(
+                                    Result: true,
+                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                ),
+                                ResponseData: null
+                            )
+                        );
+                    }
+                }
+            )
+            .Returns(ValueTask.CompletedTask);
 
-        await client.Filters.SetSourceFilterSettingsAsync("AudioSource", "CustomFilter", settings, typeInfo, overlay: true);
+        await client.Filters.SetSourceFilterSettingsAsync(
+            "AudioSource",
+            "CustomFilter",
+            settings,
+            typeInfo,
+            overlay: true
+        );
 
         Assert.IsNotNull(capturedSettings);
         Assert.AreEqual("filter-val", capturedSettings.Value.GetProperty("custom_key").GetString());
-        Assert.IsFalse(capturedSettings.Value.TryGetProperty("custom_count", out _), "Null props should be absent");
+        Assert.IsFalse(
+            capturedSettings.Value.TryGetProperty("custom_count", out _),
+            "Null props should be absent"
+        );
     }
 
     // ── Section 5: GetSourceFilterSettingsAsync helpers ───────────────────────
@@ -424,36 +666,74 @@ public class TypedSettingsTests
     [Timeout(TestTimeout)]
     public async Task GetSourceFilterSettingsAsync_LibraryType_DeserializesCorrectly()
     {
-        (ObsWebSocketClient client, Mock<IWebSocketMessageSerializer> mockSerializer, Mock<IWebSocketConnection> mockConnection) =
-            TestUtils.SetupConnectedClientForceState();
+        (
+            ObsWebSocketClient client,
+            Mock<IWebSocketMessageSerializer> mockSerializer,
+            Mock<IWebSocketConnection> mockConnection
+        ) = TestUtils.SetupConnectedClientForceState();
 
         GainFilterSettings expected = new(Db: -6.0);
-        JsonTypeInfo<GainFilterSettings> typeInfo = ObsWebSocketSettingsJsonContext.Default.GainFilterSettings;
+        JsonTypeInfo<GainFilterSettings> typeInfo = ObsWebSocketSettingsJsonContext
+            .Default
+            .GainFilterSettings;
         JsonElement settingsElement = JsonSerializer.SerializeToElement(expected, typeInfo);
         GetSourceFilterResponseData responseDto = new(
-            filterSettings: settingsElement, filterEnabled: true, filterIndex: 0, filterKind: "gain_filter");
+            filterSettings: settingsElement,
+            filterEnabled: true,
+            filterIndex: 0,
+            filterKind: "gain_filter"
+        );
 
-        _ = mockConnection.Setup(ws => ws.SendAsync(
-            It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<WebSocketMessageType>(), true, It.IsAny<CancellationToken>()))
-        .Callback((ReadOnlyMemory<byte> buffer, WebSocketMessageType _, bool _, CancellationToken _) =>
-        {
-            OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<OutgoingMessage<RequestPayload>>(
-                buffer.Span, TestUtils.s_jsonSerializerOptions);
-            if (msg?.D?.RequestType == "GetSourceFilter")
-            {
-                JsonElement rawPayload = TestUtils.ToJsonElement(responseDto)!.Value;
-                _ = TestUtils.SimulateIncomingResponse(client, msg.D.RequestId!, new RequestResponsePayload<object>(
-                    RequestType: "GetSourceFilter", RequestId: msg.D.RequestId!,
-                    RequestStatus: new RequestStatus(Result: true, Code: (int)Core.Protocol.Generated.RequestStatus.Success),
-                    ResponseData: rawPayload));
-            }
-        })
-        .Returns(ValueTask.CompletedTask);
+        _ = mockConnection
+            .Setup(ws =>
+                ws.SendAsync(
+                    It.IsAny<ReadOnlyMemory<byte>>(),
+                    It.IsAny<WebSocketMessageType>(),
+                    true,
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (
+                    ReadOnlyMemory<byte> buffer,
+                    WebSocketMessageType _,
+                    bool _,
+                    CancellationToken _
+                ) =>
+                {
+                    OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<
+                        OutgoingMessage<RequestPayload>
+                    >(buffer.Span, TestUtils.s_jsonSerializerOptions);
+                    if (msg?.D?.RequestType == "GetSourceFilter")
+                    {
+                        JsonElement rawPayload = TestUtils.ToJsonElement(responseDto)!.Value;
+                        _ = TestUtils.SimulateIncomingResponse(
+                            client,
+                            msg.D.RequestId!,
+                            new RequestResponsePayload<object>(
+                                RequestType: "GetSourceFilter",
+                                RequestId: msg.D.RequestId!,
+                                RequestStatus: new RequestStatus(
+                                    Result: true,
+                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                ),
+                                ResponseData: rawPayload
+                            )
+                        );
+                    }
+                }
+            )
+            .Returns(ValueTask.CompletedTask);
 
-        _ = mockSerializer.Setup(s => s.DeserializePayload<GetSourceFilterResponseData>(It.IsAny<object>()))
+        _ = mockSerializer
+            .Setup(s => s.DeserializePayload<GetSourceFilterResponseData>(It.IsAny<object>()))
             .Returns(responseDto);
 
-        GainFilterSettings? result = await client.Filters.GetSourceFilterSettingsAsync<GainFilterSettings>("AudioSource", "Gain");
+        GainFilterSettings? result =
+            await client.Filters.GetSourceFilterSettingsAsync<GainFilterSettings>(
+                "AudioSource",
+                "Gain"
+            );
 
         Assert.IsNotNull(result);
         Assert.AreEqual(-6.0, result.Db!.Value, 0.0001d);
@@ -463,36 +743,74 @@ public class TypedSettingsTests
     [Timeout(TestTimeout)]
     public async Task GetSourceFilterSettingsAsync_ConsumerType_WithExplicitTypeInfo_DeserializesCorrectly()
     {
-        (ObsWebSocketClient client, Mock<IWebSocketMessageSerializer> mockSerializer, Mock<IWebSocketConnection> mockConnection) =
-            TestUtils.SetupConnectedClientForceState();
+        (
+            ObsWebSocketClient client,
+            Mock<IWebSocketMessageSerializer> mockSerializer,
+            Mock<IWebSocketConnection> mockConnection
+        ) = TestUtils.SetupConnectedClientForceState();
 
         TestConsumerSettings expected = new(CustomKey: "my-filter", CustomCount: 3);
-        JsonTypeInfo<TestConsumerSettings> typeInfo = TestConsumerSettingsJsonContext.Default.TestConsumerSettings;
+        JsonTypeInfo<TestConsumerSettings> typeInfo = TestConsumerSettingsJsonContext
+            .Default
+            .TestConsumerSettings;
         JsonElement settingsElement = JsonSerializer.SerializeToElement(expected, typeInfo);
         GetSourceFilterResponseData responseDto = new(
-            filterSettings: settingsElement, filterEnabled: true, filterIndex: 0, filterKind: "custom_filter");
+            filterSettings: settingsElement,
+            filterEnabled: true,
+            filterIndex: 0,
+            filterKind: "custom_filter"
+        );
 
-        _ = mockConnection.Setup(ws => ws.SendAsync(
-            It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<WebSocketMessageType>(), true, It.IsAny<CancellationToken>()))
-        .Callback((ReadOnlyMemory<byte> buffer, WebSocketMessageType _, bool _, CancellationToken _) =>
-        {
-            OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<OutgoingMessage<RequestPayload>>(
-                buffer.Span, TestUtils.s_jsonSerializerOptions);
-            if (msg?.D?.RequestType == "GetSourceFilter")
-            {
-                JsonElement rawPayload = TestUtils.ToJsonElement(responseDto)!.Value;
-                _ = TestUtils.SimulateIncomingResponse(client, msg.D.RequestId!, new RequestResponsePayload<object>(
-                    RequestType: "GetSourceFilter", RequestId: msg.D.RequestId!,
-                    RequestStatus: new RequestStatus(Result: true, Code: (int)Core.Protocol.Generated.RequestStatus.Success),
-                    ResponseData: rawPayload));
-            }
-        })
-        .Returns(ValueTask.CompletedTask);
+        _ = mockConnection
+            .Setup(ws =>
+                ws.SendAsync(
+                    It.IsAny<ReadOnlyMemory<byte>>(),
+                    It.IsAny<WebSocketMessageType>(),
+                    true,
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (
+                    ReadOnlyMemory<byte> buffer,
+                    WebSocketMessageType _,
+                    bool _,
+                    CancellationToken _
+                ) =>
+                {
+                    OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<
+                        OutgoingMessage<RequestPayload>
+                    >(buffer.Span, TestUtils.s_jsonSerializerOptions);
+                    if (msg?.D?.RequestType == "GetSourceFilter")
+                    {
+                        JsonElement rawPayload = TestUtils.ToJsonElement(responseDto)!.Value;
+                        _ = TestUtils.SimulateIncomingResponse(
+                            client,
+                            msg.D.RequestId!,
+                            new RequestResponsePayload<object>(
+                                RequestType: "GetSourceFilter",
+                                RequestId: msg.D.RequestId!,
+                                RequestStatus: new RequestStatus(
+                                    Result: true,
+                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                ),
+                                ResponseData: rawPayload
+                            )
+                        );
+                    }
+                }
+            )
+            .Returns(ValueTask.CompletedTask);
 
-        _ = mockSerializer.Setup(s => s.DeserializePayload<GetSourceFilterResponseData>(It.IsAny<object>()))
+        _ = mockSerializer
+            .Setup(s => s.DeserializePayload<GetSourceFilterResponseData>(It.IsAny<object>()))
             .Returns(responseDto);
 
-        TestConsumerSettings? result = await client.Filters.GetSourceFilterSettingsAsync("AudioSource", "CustomFilter", typeInfo);
+        TestConsumerSettings? result = await client.Filters.GetSourceFilterSettingsAsync(
+            "AudioSource",
+            "CustomFilter",
+            typeInfo
+        );
 
         Assert.IsNotNull(result);
         Assert.AreEqual("my-filter", result.CustomKey);
@@ -505,45 +823,78 @@ public class TypedSettingsTests
     [Timeout(TestTimeout)]
     public async Task CreateInputAsync_LibraryType_SendsCorrectSettingsElement()
     {
-        (ObsWebSocketClient client, Mock<IWebSocketMessageSerializer> mockSerializer, Mock<IWebSocketConnection> mockConnection) =
-            TestUtils.SetupConnectedClientForceState();
+        (
+            ObsWebSocketClient client,
+            Mock<IWebSocketMessageSerializer> mockSerializer,
+            Mock<IWebSocketConnection> mockConnection
+        ) = TestUtils.SetupConnectedClientForceState();
 
         BrowserSourceSettings settings = new(Url: "https://create.test", Width: 800, Height: 600);
         JsonElement? capturedSettings = null;
         CreateInputResponseData responseDto = new(sceneItemId: 42);
 
-        _ = mockConnection.Setup(ws => ws.SendAsync(
-            It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<WebSocketMessageType>(), true, It.IsAny<CancellationToken>()))
-        .Callback((ReadOnlyMemory<byte> buffer, WebSocketMessageType _, bool _, CancellationToken _) =>
-        {
-            OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<OutgoingMessage<RequestPayload>>(
-                buffer.Span, TestUtils.s_jsonSerializerOptions);
-            if (msg?.D?.RequestType == "CreateInput")
-            {
-                string id = msg.D.RequestId!;
-                capturedSettings = msg.D.RequestData?.GetProperty("inputSettings");
-                JsonElement rawPayload = TestUtils.ToJsonElement(responseDto)!.Value;
-                _ = TestUtils.SimulateIncomingResponse(client, id, new RequestResponsePayload<object>(
-                    RequestType: "CreateInput", RequestId: id,
-                    RequestStatus: new RequestStatus(Result: true, Code: (int)Core.Protocol.Generated.RequestStatus.Success),
-                    ResponseData: rawPayload));
-            }
-        })
-        .Returns(ValueTask.CompletedTask);
+        _ = mockConnection
+            .Setup(ws =>
+                ws.SendAsync(
+                    It.IsAny<ReadOnlyMemory<byte>>(),
+                    It.IsAny<WebSocketMessageType>(),
+                    true,
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (
+                    ReadOnlyMemory<byte> buffer,
+                    WebSocketMessageType _,
+                    bool _,
+                    CancellationToken _
+                ) =>
+                {
+                    OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<
+                        OutgoingMessage<RequestPayload>
+                    >(buffer.Span, TestUtils.s_jsonSerializerOptions);
+                    if (msg?.D?.RequestType == "CreateInput")
+                    {
+                        string id = msg.D.RequestId!;
+                        capturedSettings = msg.D.RequestData?.GetProperty("inputSettings");
+                        JsonElement rawPayload = TestUtils.ToJsonElement(responseDto)!.Value;
+                        _ = TestUtils.SimulateIncomingResponse(
+                            client,
+                            id,
+                            new RequestResponsePayload<object>(
+                                RequestType: "CreateInput",
+                                RequestId: id,
+                                RequestStatus: new RequestStatus(
+                                    Result: true,
+                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                ),
+                                ResponseData: rawPayload
+                            )
+                        );
+                    }
+                }
+            )
+            .Returns(ValueTask.CompletedTask);
 
-        _ = mockSerializer.Setup(s => s.DeserializePayload<CreateInputResponseData>(It.IsAny<object>()))
+        _ = mockSerializer
+            .Setup(s => s.DeserializePayload<CreateInputResponseData>(It.IsAny<object>()))
             .Returns(responseDto);
 
-        CreateInputResponseData? result = await client.Inputs.CreateInputAsync(inputKind: "browser_source",
+        CreateInputResponseData? result = await client.Inputs.CreateInputAsync(
+            inputKind: "browser_source",
             inputName: "New Browser",
             settings: settings,
             sceneName: "Scene A",
-            sceneItemEnabled: true);
+            sceneItemEnabled: true
+        );
 
         Assert.IsNotNull(result);
         Assert.AreEqual(42, result.SceneItemId);
         Assert.IsNotNull(capturedSettings);
-        Assert.AreEqual("https://create.test", capturedSettings.Value.GetProperty("url").GetString());
+        Assert.AreEqual(
+            "https://create.test",
+            capturedSettings.Value.GetProperty("url").GetString()
+        );
         Assert.AreEqual(800, capturedSettings.Value.GetProperty("width").GetInt32());
     }
 
@@ -551,40 +902,72 @@ public class TypedSettingsTests
     [Timeout(TestTimeout)]
     public async Task CreateInputAsync_ConsumerType_WithExplicitTypeInfo_SendsCorrectSettingsElement()
     {
-        (ObsWebSocketClient client, Mock<IWebSocketMessageSerializer> mockSerializer, Mock<IWebSocketConnection> mockConnection) =
-            TestUtils.SetupConnectedClientForceState();
+        (
+            ObsWebSocketClient client,
+            Mock<IWebSocketMessageSerializer> mockSerializer,
+            Mock<IWebSocketConnection> mockConnection
+        ) = TestUtils.SetupConnectedClientForceState();
 
         TestConsumerSettings settings = new(CustomKey: "my-input", CustomCount: 5);
-        JsonTypeInfo<TestConsumerSettings> typeInfo = TestConsumerSettingsJsonContext.Default.TestConsumerSettings;
+        JsonTypeInfo<TestConsumerSettings> typeInfo = TestConsumerSettingsJsonContext
+            .Default
+            .TestConsumerSettings;
         JsonElement? capturedSettings = null;
         CreateInputResponseData responseDto = new(sceneItemId: 7);
 
-        _ = mockConnection.Setup(ws => ws.SendAsync(
-            It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<WebSocketMessageType>(), true, It.IsAny<CancellationToken>()))
-        .Callback((ReadOnlyMemory<byte> buffer, WebSocketMessageType _, bool _, CancellationToken _) =>
-        {
-            OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<OutgoingMessage<RequestPayload>>(
-                buffer.Span, TestUtils.s_jsonSerializerOptions);
-            if (msg?.D?.RequestType == "CreateInput")
-            {
-                string id = msg.D.RequestId!;
-                capturedSettings = msg.D.RequestData?.GetProperty("inputSettings");
-                JsonElement rawPayload = TestUtils.ToJsonElement(responseDto)!.Value;
-                _ = TestUtils.SimulateIncomingResponse(client, id, new RequestResponsePayload<object>(
-                    RequestType: "CreateInput", RequestId: id,
-                    RequestStatus: new RequestStatus(Result: true, Code: (int)Core.Protocol.Generated.RequestStatus.Success),
-                    ResponseData: rawPayload));
-            }
-        })
-        .Returns(ValueTask.CompletedTask);
+        _ = mockConnection
+            .Setup(ws =>
+                ws.SendAsync(
+                    It.IsAny<ReadOnlyMemory<byte>>(),
+                    It.IsAny<WebSocketMessageType>(),
+                    true,
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (
+                    ReadOnlyMemory<byte> buffer,
+                    WebSocketMessageType _,
+                    bool _,
+                    CancellationToken _
+                ) =>
+                {
+                    OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<
+                        OutgoingMessage<RequestPayload>
+                    >(buffer.Span, TestUtils.s_jsonSerializerOptions);
+                    if (msg?.D?.RequestType == "CreateInput")
+                    {
+                        string id = msg.D.RequestId!;
+                        capturedSettings = msg.D.RequestData?.GetProperty("inputSettings");
+                        JsonElement rawPayload = TestUtils.ToJsonElement(responseDto)!.Value;
+                        _ = TestUtils.SimulateIncomingResponse(
+                            client,
+                            id,
+                            new RequestResponsePayload<object>(
+                                RequestType: "CreateInput",
+                                RequestId: id,
+                                RequestStatus: new RequestStatus(
+                                    Result: true,
+                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                ),
+                                ResponseData: rawPayload
+                            )
+                        );
+                    }
+                }
+            )
+            .Returns(ValueTask.CompletedTask);
 
-        _ = mockSerializer.Setup(s => s.DeserializePayload<CreateInputResponseData>(It.IsAny<object>()))
+        _ = mockSerializer
+            .Setup(s => s.DeserializePayload<CreateInputResponseData>(It.IsAny<object>()))
             .Returns(responseDto);
 
-        CreateInputResponseData? result = await client.Inputs.CreateInputAsync(inputKind: "custom_source",
+        CreateInputResponseData? result = await client.Inputs.CreateInputAsync(
+            inputKind: "custom_source",
             inputName: "My Custom",
             settings: settings,
-            typeInfo: typeInfo);
+            typeInfo: typeInfo
+        );
 
         Assert.IsNotNull(result);
         Assert.AreEqual(7, result.SceneItemId);
@@ -599,35 +982,66 @@ public class TypedSettingsTests
     [Timeout(TestTimeout)]
     public async Task CreateSourceFilterAsync_LibraryType_SendsCorrectSettingsElement()
     {
-        (ObsWebSocketClient client, Mock<IWebSocketMessageSerializer> mockSerializer, Mock<IWebSocketConnection> mockConnection) =
-            TestUtils.SetupConnectedClientForceState();
-        _ = mockSerializer.Setup(s => s.DeserializePayload<object>(It.IsAny<object>())).Returns((object?)null);
+        (
+            ObsWebSocketClient client,
+            Mock<IWebSocketMessageSerializer> mockSerializer,
+            Mock<IWebSocketConnection> mockConnection
+        ) = TestUtils.SetupConnectedClientForceState();
+        _ = mockSerializer
+            .Setup(s => s.DeserializePayload<object>(It.IsAny<object>()))
+            .Returns((object?)null);
 
         GainFilterSettings settings = new(Db: -3.0);
         JsonElement? capturedSettings = null;
 
-        _ = mockConnection.Setup(ws => ws.SendAsync(
-            It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<WebSocketMessageType>(), true, It.IsAny<CancellationToken>()))
-        .Callback((ReadOnlyMemory<byte> buffer, WebSocketMessageType _, bool _, CancellationToken _) =>
-        {
-            OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<OutgoingMessage<RequestPayload>>(
-                buffer.Span, TestUtils.s_jsonSerializerOptions);
-            if (msg?.D?.RequestType == "CreateSourceFilter")
-            {
-                string id = msg.D.RequestId!;
-                capturedSettings = msg.D.RequestData?.GetProperty("filterSettings");
-                _ = TestUtils.SimulateIncomingResponse(client, id, new RequestResponsePayload<object>(
-                    RequestType: "CreateSourceFilter", RequestId: id,
-                    RequestStatus: new RequestStatus(Result: true, Code: (int)Core.Protocol.Generated.RequestStatus.Success),
-                    ResponseData: null));
-            }
-        })
-        .Returns(ValueTask.CompletedTask);
+        _ = mockConnection
+            .Setup(ws =>
+                ws.SendAsync(
+                    It.IsAny<ReadOnlyMemory<byte>>(),
+                    It.IsAny<WebSocketMessageType>(),
+                    true,
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (
+                    ReadOnlyMemory<byte> buffer,
+                    WebSocketMessageType _,
+                    bool _,
+                    CancellationToken _
+                ) =>
+                {
+                    OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<
+                        OutgoingMessage<RequestPayload>
+                    >(buffer.Span, TestUtils.s_jsonSerializerOptions);
+                    if (msg?.D?.RequestType == "CreateSourceFilter")
+                    {
+                        string id = msg.D.RequestId!;
+                        capturedSettings = msg.D.RequestData?.GetProperty("filterSettings");
+                        _ = TestUtils.SimulateIncomingResponse(
+                            client,
+                            id,
+                            new RequestResponsePayload<object>(
+                                RequestType: "CreateSourceFilter",
+                                RequestId: id,
+                                RequestStatus: new RequestStatus(
+                                    Result: true,
+                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                ),
+                                ResponseData: null
+                            )
+                        );
+                    }
+                }
+            )
+            .Returns(ValueTask.CompletedTask);
 
-        await client.Filters.CreateSourceFilterAsync(sourceName: "AudioSource",
+        await client.Filters.CreateSourceFilterAsync(
+            sourceName: "AudioSource",
             filterName: "My Gain",
             filterKind: "gain_filter",
-            settings: settings);
+            settings: settings
+        );
 
         Assert.IsNotNull(capturedSettings);
         Assert.AreEqual(-3.0, capturedSettings.Value.GetProperty("db").GetDouble(), 0.0001d);
@@ -637,37 +1051,70 @@ public class TypedSettingsTests
     [Timeout(TestTimeout)]
     public async Task CreateSourceFilterAsync_ConsumerType_WithExplicitTypeInfo_SendsCorrectSettingsElement()
     {
-        (ObsWebSocketClient client, Mock<IWebSocketMessageSerializer> mockSerializer, Mock<IWebSocketConnection> mockConnection) =
-            TestUtils.SetupConnectedClientForceState();
-        _ = mockSerializer.Setup(s => s.DeserializePayload<object>(It.IsAny<object>())).Returns((object?)null);
+        (
+            ObsWebSocketClient client,
+            Mock<IWebSocketMessageSerializer> mockSerializer,
+            Mock<IWebSocketConnection> mockConnection
+        ) = TestUtils.SetupConnectedClientForceState();
+        _ = mockSerializer
+            .Setup(s => s.DeserializePayload<object>(It.IsAny<object>()))
+            .Returns((object?)null);
 
         TestConsumerSettings settings = new(CustomKey: "my-filter", CustomCount: 1);
-        JsonTypeInfo<TestConsumerSettings> typeInfo = TestConsumerSettingsJsonContext.Default.TestConsumerSettings;
+        JsonTypeInfo<TestConsumerSettings> typeInfo = TestConsumerSettingsJsonContext
+            .Default
+            .TestConsumerSettings;
         JsonElement? capturedSettings = null;
 
-        _ = mockConnection.Setup(ws => ws.SendAsync(
-            It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<WebSocketMessageType>(), true, It.IsAny<CancellationToken>()))
-        .Callback((ReadOnlyMemory<byte> buffer, WebSocketMessageType _, bool _, CancellationToken _) =>
-        {
-            OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<OutgoingMessage<RequestPayload>>(
-                buffer.Span, TestUtils.s_jsonSerializerOptions);
-            if (msg?.D?.RequestType == "CreateSourceFilter")
-            {
-                string id = msg.D.RequestId!;
-                capturedSettings = msg.D.RequestData?.GetProperty("filterSettings");
-                _ = TestUtils.SimulateIncomingResponse(client, id, new RequestResponsePayload<object>(
-                    RequestType: "CreateSourceFilter", RequestId: id,
-                    RequestStatus: new RequestStatus(Result: true, Code: (int)Core.Protocol.Generated.RequestStatus.Success),
-                    ResponseData: null));
-            }
-        })
-        .Returns(ValueTask.CompletedTask);
+        _ = mockConnection
+            .Setup(ws =>
+                ws.SendAsync(
+                    It.IsAny<ReadOnlyMemory<byte>>(),
+                    It.IsAny<WebSocketMessageType>(),
+                    true,
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (
+                    ReadOnlyMemory<byte> buffer,
+                    WebSocketMessageType _,
+                    bool _,
+                    CancellationToken _
+                ) =>
+                {
+                    OutgoingMessage<RequestPayload>? msg = JsonSerializer.Deserialize<
+                        OutgoingMessage<RequestPayload>
+                    >(buffer.Span, TestUtils.s_jsonSerializerOptions);
+                    if (msg?.D?.RequestType == "CreateSourceFilter")
+                    {
+                        string id = msg.D.RequestId!;
+                        capturedSettings = msg.D.RequestData?.GetProperty("filterSettings");
+                        _ = TestUtils.SimulateIncomingResponse(
+                            client,
+                            id,
+                            new RequestResponsePayload<object>(
+                                RequestType: "CreateSourceFilter",
+                                RequestId: id,
+                                RequestStatus: new RequestStatus(
+                                    Result: true,
+                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                ),
+                                ResponseData: null
+                            )
+                        );
+                    }
+                }
+            )
+            .Returns(ValueTask.CompletedTask);
 
-        await client.Filters.CreateSourceFilterAsync(sourceName: "VideoSource",
+        await client.Filters.CreateSourceFilterAsync(
+            sourceName: "VideoSource",
             filterName: "CustomFilter",
             filterKind: "custom_filter_kind",
             settings: settings,
-            typeInfo: typeInfo);
+            typeInfo: typeInfo
+        );
 
         Assert.IsNotNull(capturedSettings);
         Assert.AreEqual("my-filter", capturedSettings.Value.GetProperty("custom_key").GetString());

--- a/ObsWebSocket.Tests/TypedSettingsTests.cs
+++ b/ObsWebSocket.Tests/TypedSettingsTests.cs
@@ -250,7 +250,7 @@ public class TypedSettingsTests
                                 RequestId: id,
                                 RequestStatus: new RequestStatus(
                                     Result: true,
-                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                    Code: (int)Core.Protocol.Generated.RequestStatusCode.Success
                                 ),
                                 ResponseData: null
                             )
@@ -323,7 +323,7 @@ public class TypedSettingsTests
                                 RequestId: id,
                                 RequestStatus: new RequestStatus(
                                     Result: true,
-                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                    Code: (int)Core.Protocol.Generated.RequestStatusCode.Success
                                 ),
                                 ResponseData: null
                             )
@@ -412,7 +412,7 @@ public class TypedSettingsTests
                                 RequestId: msg.D.RequestId!,
                                 RequestStatus: new RequestStatus(
                                     Result: true,
-                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                    Code: (int)Core.Protocol.Generated.RequestStatusCode.Success
                                 ),
                                 ResponseData: rawPayload
                             )
@@ -488,7 +488,7 @@ public class TypedSettingsTests
                                 RequestId: msg.D.RequestId!,
                                 RequestStatus: new RequestStatus(
                                     Result: true,
-                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                    Code: (int)Core.Protocol.Generated.RequestStatusCode.Success
                                 ),
                                 ResponseData: rawPayload
                             )
@@ -562,7 +562,7 @@ public class TypedSettingsTests
                                 RequestId: id,
                                 RequestStatus: new RequestStatus(
                                     Result: true,
-                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                    Code: (int)Core.Protocol.Generated.RequestStatusCode.Success
                                 ),
                                 ResponseData: null
                             )
@@ -634,7 +634,7 @@ public class TypedSettingsTests
                                 RequestId: id,
                                 RequestStatus: new RequestStatus(
                                     Result: true,
-                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                    Code: (int)Core.Protocol.Generated.RequestStatusCode.Success
                                 ),
                                 ResponseData: null
                             )
@@ -715,7 +715,7 @@ public class TypedSettingsTests
                                 RequestId: msg.D.RequestId!,
                                 RequestStatus: new RequestStatus(
                                     Result: true,
-                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                    Code: (int)Core.Protocol.Generated.RequestStatusCode.Success
                                 ),
                                 ResponseData: rawPayload
                             )
@@ -792,7 +792,7 @@ public class TypedSettingsTests
                                 RequestId: msg.D.RequestId!,
                                 RequestStatus: new RequestStatus(
                                     Result: true,
-                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                    Code: (int)Core.Protocol.Generated.RequestStatusCode.Success
                                 ),
                                 ResponseData: rawPayload
                             )
@@ -866,7 +866,7 @@ public class TypedSettingsTests
                                 RequestId: id,
                                 RequestStatus: new RequestStatus(
                                     Result: true,
-                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                    Code: (int)Core.Protocol.Generated.RequestStatusCode.Success
                                 ),
                                 ResponseData: rawPayload
                             )
@@ -948,7 +948,7 @@ public class TypedSettingsTests
                                 RequestId: id,
                                 RequestStatus: new RequestStatus(
                                     Result: true,
-                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                    Code: (int)Core.Protocol.Generated.RequestStatusCode.Success
                                 ),
                                 ResponseData: rawPayload
                             )
@@ -1026,7 +1026,7 @@ public class TypedSettingsTests
                                 RequestId: id,
                                 RequestStatus: new RequestStatus(
                                     Result: true,
-                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                    Code: (int)Core.Protocol.Generated.RequestStatusCode.Success
                                 ),
                                 ResponseData: null
                             )
@@ -1098,7 +1098,7 @@ public class TypedSettingsTests
                                 RequestId: id,
                                 RequestStatus: new RequestStatus(
                                     Result: true,
-                                    Code: (int)Core.Protocol.Generated.RequestStatus.Success
+                                    Code: (int)Core.Protocol.Generated.RequestStatusCode.Success
                                 ),
                                 ResponseData: null
                             )

--- a/README.md
+++ b/README.md
@@ -343,6 +343,16 @@ catch (ObsWebSocketTimeoutException)
 }
 ```
 
+`StatusCode` reports the same status as the protocol's `RequestStatus` enum, so a filter can name
+the reason instead of a number:
+
+```csharp
+catch (ObsWebSocketRequestException ex) when (ex.StatusCode is RequestStatus.ResourceNotFound)
+{
+    // The scene, input or filter does not exist.
+}
+```
+
 `ObsWebSocketSerializationException` covers payloads that cannot be written or read, and all three
 derive from `ObsWebSocketException`.
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ using ObsWebSocket.Core;
 
 HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 
-builder.AddObsWebSocketClient("obs");   // endpoint from ConnectionStrings:obs
-builder.Services.WithAutoConnect();     // connect on start, disconnect on stop
+builder.AddObsWebSocketClient("obs")    // endpoint from ConnectionStrings:obs
+       .WithAutoConnect();              // connect on start, disconnect on stop
 builder.Services.AddHostedService<Worker>();
 
 await builder.Build().RunAsync();
@@ -284,9 +284,9 @@ and `ToWireValue()` converts an enum back.
 ## Host integration
 
 ```csharp
-builder.AddObsWebSocketClient("obs");          // reads ConnectionStrings:obs
-builder.Services.WithAutoConnect();            // connects on start, disconnects on stop
-builder.Services.AddHealthChecks().AddObsWebSocket();
+builder.AddObsWebSocketClient("obs")   // reads ConnectionStrings:obs
+       .WithAutoConnect()              // connects on start, disconnects on stop
+       .WithHealthCheck();
 ```
 
 The password may travel in the connection string or be set on the options; either way it is kept off

--- a/README.md
+++ b/README.md
@@ -18,29 +18,16 @@ Modern .NET client for OBS Studio WebSocket v5, with generated protocol types an
 dotnet add package ObsWebSocket.Core
 ```
 
-## Features
-
-- Strongly typed request/response DTOs generated from the obs-websocket protocol
-- Strongly typed event args, observable as `IAsyncEnumerable<T>` or as classic events
-- Typed batch builder that pairs each request type with its own payload
-- Async-first API with cancellation support
-- DI helpers via `AddObsWebSocketClient()`
-- JSON and MessagePack transports (configurable per environment)
-- Reconnect, timeout, and event subscription options
-- Typed settings helpers for inputs, filters, transitions, outputs, and stream service, working with built-in library types or your own AOT-safe source-generated types
-
 > **OBS WebSocket v5 only** (OBS Studio 28+). Enable the server via *Tools → WebSocket Server Settings* in OBS.
 
-## Quick Start
+## Quick start
 
 `appsettings.json`:
 
 ```json
 {
-  "Obs": {
-    "ServerUri": "ws://localhost:4455",
-    "Password": "",
-    "Format": "Json"
+  "ConnectionStrings": {
+    "obs": "ws://localhost:4455?password=secret"
   }
 }
 ```
@@ -51,10 +38,11 @@ dotnet add package ObsWebSocket.Core
 using ObsWebSocket.Core;
 
 HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
-builder.Services.Configure<ObsWebSocketClientOptions>(
-    builder.Configuration.GetSection("Obs"));
-builder.Services.AddObsWebSocketClient();
+
+builder.AddObsWebSocketClient("obs");   // endpoint from ConnectionStrings:obs
+builder.Services.WithAutoConnect();     // connect on start, disconnect on stop
 builder.Services.AddHostedService<Worker>();
+
 await builder.Build().RunAsync();
 ```
 
@@ -64,33 +52,44 @@ await builder.Build().RunAsync();
 using ObsWebSocket.Core;
 using ObsWebSocket.Core.Events.Generated;
 
-public sealed class Worker(ObsWebSocketClient client) : IHostedService
+public sealed class Worker(ObsWebSocketClient client) : BackgroundService
 {
-    public async Task StartAsync(CancellationToken ct)
+    protected override async Task ExecuteAsync(CancellationToken ct)
     {
-        client.CurrentProgramSceneChanged += OnSceneChanged;
-        await client.ConnectAsync(ct);
+        var version = await client.General.GetVersionAsync(ct);
+        Console.WriteLine($"Connected to OBS {version.ObsVersion}");
 
-        var version = await client.General.GetVersionAsync(cancellationToken: ct);
-        Console.WriteLine($"Connected to OBS {version?.ObsVersion}");
+        await foreach (var e in client.CurrentProgramSceneChangedStream(cancellationToken: ct))
+        {
+            Console.WriteLine($"Scene changed: {e.EventData.SceneName}");
+        }
     }
-
-    public async Task StopAsync(CancellationToken ct)
-    {
-        client.CurrentProgramSceneChanged -= OnSceneChanged;
-        if (client.IsConnected) await client.DisconnectAsync();
-    }
-
-    private static void OnSceneChanged(object? _, CurrentProgramSceneChangedEventArgs e) =>
-        Console.WriteLine($"Scene changed: {e.EventData.SceneName}");
 }
 ```
 
-## Observing Events
+## Everything is grouped by category
 
-Every OBS event is exposed as an async sequence. The stream subscribes for the lifetime of the
-loop and unsubscribes when it ends, so there is no handler bookkeeping and cancellation is the
-only thing that stops it:
+The client mirrors the categories the OBS protocol defines, and the conveniences this library adds
+sit in the same group as the requests they wrap, so there is one way to reach anything:
+
+```csharp
+await client.Scenes.GetSceneListAsync(new(), ct);                                   // generated request
+await client.Scenes.SwitchProgramSceneAndWaitAsync("Intro", cancellationToken: ct);  // convenience
+await client.Inputs.SetInputVolumeDbAsync("Mic", -6, ct);
+await client.SceneItems.SetSceneItemEnabledAsync("Intro", "Logo", false, ct);
+```
+
+The groups are `Canvases`, `Config`, `Filters`, `General`, `Inputs`, `MediaInputs`, `Outputs`,
+`Record`, `SceneItems`, `Scenes`, `Sources`, `Stream`, `Transitions` and `Ui`. They come from the
+protocol definition, so a refresh that recategorises a request moves it here too.
+
+`WaitForEventAsync` and `CallBatchAsync` stay directly on the client, since neither belongs to one
+category.
+
+## Observing events
+
+Every OBS event is exposed as an async sequence. The stream subscribes for the lifetime of the loop
+and unsubscribes when it ends, so there is no handler bookkeeping:
 
 ```csharp
 await foreach (var e in client.CurrentProgramSceneChangedStream(cancellationToken: ct))
@@ -102,21 +101,19 @@ await foreach (var e in client.CurrentProgramSceneChangedStream(cancellationToke
 Streams buffer a bounded number of events and drop the oldest when a consumer falls behind, so a
 slow loop cannot stall the receive loop. Pass `capacity` to change that.
 
-The classic events are unchanged and still work, including alongside a stream over the same event:
+The classic events still work, including alongside a stream over the same event:
 
 ```csharp
 client.CurrentProgramSceneChanged += (_, e) =>
     Console.WriteLine($"Program scene is now {e.EventData.SceneName}");
 ```
 
-To wait for a single occurrence rather than a sequence, use `WaitForEventAsync`. It subscribes
-before returning, so you can start the wait and then trigger the action without racing it:
+To wait for a single occurrence, use `WaitForEventAsync`. It subscribes before returning, so you can
+start the wait and then trigger the action without racing it:
 
 ```csharp
-// Next occurrence, no timeout
 var changed = await client.WaitForEventAsync<CurrentProgramSceneChangedEventArgs>(ct);
 
-// Next matching occurrence, giving up after 5 seconds
 var intro = await client.WaitForEventAsync<CurrentProgramSceneChangedEventArgs>(
     e => e.EventData.SceneName == "Intro",
     TimeSpan.FromSeconds(5),
@@ -124,38 +121,37 @@ var intro = await client.WaitForEventAsync<CurrentProgramSceneChangedEventArgs>(
 );
 ```
 
-## Common Use Cases
+It throws `TimeoutException` when the wait elapses.
+
+## Common use cases
 
 ### Update a text source
 
 ```csharp
-// One-liner helper
 await client.Inputs.SetInputTextAsync("NewsTicker", "Breaking: Live now!", ct);
 
-// Or use a typed settings object to update multiple properties at once
+// or several properties at once, with a typed settings object
 var settings = new TextGdiPlusInputSettings(Text: "Breaking: Live now!", WordWrap: true);
 await client.Inputs.SetInputSettingsAsync("NewsTicker", settings, cancellationToken: ct);
 ```
 
-`TextGdiPlusInputSettings` is a built-in library type. The same pattern applies to `TextFreetype2InputSettings`, `BrowserSourceSettings`, and the filter settings types, which live in `ObsWebSocket.Core.Protocol.Common.InputSettings` and `ObsWebSocket.Core.Protocol.Common.FilterSettings`.
+`TextGdiPlusInputSettings` is a built-in library type, as are `TextFreetype2InputSettings`,
+`BrowserSourceSettings` and the filter settings types, which live in
+`ObsWebSocket.Core.Protocol.Common.InputSettings` and `.FilterSettings`.
 
 ### Check and save the replay buffer
 
 ```csharp
-var status = await client.Outputs.GetReplayBufferStatusAsync(cancellationToken: ct);
-if (status?.OutputActive == true)
+var status = await client.Outputs.GetReplayBufferStatusAsync(ct);
+if (status.OutputActive)
 {
-    await client.Outputs.SaveReplayBufferAsync(cancellationToken: ct);
-    Console.WriteLine("Replay saved.");
+    await client.Outputs.SaveReplayBufferAsync(ct);
 }
 ```
 
 ### Create or update a browser source
 
-Use a library type for common properties, or define your own type to target exactly what you need:
-
 ```csharp
-// Library type, covers the standard browser source properties
 var current = await client.Inputs.GetInputSettingsAsync<BrowserSourceSettings>("StreamOverlay", ct);
 Console.WriteLine($"Current URL: {current?.Url}");
 
@@ -166,14 +162,15 @@ await client.Inputs.SetInputSettingsAsync(
 );
 ```
 
+Define your own type to target exactly what you need, and stay AOT-safe by passing its `JsonTypeInfo`:
+
 ```csharp
-// Consumer type, define only the properties you care about, fully AOT-safe
 [JsonSerializable(typeof(OverlaySettings))]
 internal partial class MyContext : JsonSerializerContext { }
 
 internal sealed record OverlaySettings(
-    [property: JsonPropertyName("url")]  string? Url = null,
-    [property: JsonPropertyName("css")]  string? Css = null
+    [property: JsonPropertyName("url")] string? Url = null,
+    [property: JsonPropertyName("css")] string? Css = null
 );
 
 await client.Inputs.SetInputSettingsAsync(
@@ -184,79 +181,74 @@ await client.Inputs.SetInputSettingsAsync(
 );
 ```
 
-Both `Set` overloads take `overlay` before the cancellation token. It defaults to `true`, which merges your values onto the existing settings. Pass `overlay: false` to replace them outright.
+Both `Set` overloads take `overlay` before the cancellation token. It defaults to `true`, merging
+your values onto the existing settings; pass `overlay: false` to replace them.
 
-> Raw `JsonElement` access is also available. All settings helpers have counterparts in the generated types under `ObsWebSocket.Core.Protocol.Requests` if you need full control.
-
-## Requests and helpers
-
-Everything the client can do is reached through the category the OBS protocol puts it in, so a
-generated request and a convenience that wraps several of them sit together and read the same way:
+### Screenshots
 
 ```csharp
-await client.Scenes.GetSceneListAsync(new(), ct);            // generated request
-await client.Scenes.SwitchProgramSceneAndWaitAsync("Intro", cancellationToken: ct);  // convenience
+byte[]? png = await client.Sources.GetSourceScreenshotBytesAsync("Intro", "png", cancellationToken: ct);
+await client.Sources.SaveSourceScreenshotToFileAsync("Intro", "shot.png", cancellationToken: ct);
 ```
 
-The categories are OBS's own: `Canvases`, `Config`, `Filters`, `General`, `Inputs`, `MediaInputs`,
-`Outputs`, `Record`, `SceneItems`, `Scenes`, `Sources`, `Stream`, `Transitions`, `Ui`. They follow
-the protocol, so a refresh that recategorises a request moves it here too. The batch builder uses
-the same grouping.
+## Batches
 
-`WaitForEventAsync` and `CallBatchAsync` stay directly on the client, since neither belongs to one
-category.
+Send several requests in one round trip. Each returns a reference carrying its response type:
 
-Every typed settings helper has two overloads: an implicit one for library-registered types, and an explicit one taking a `JsonTypeInfo<T>` for consumer-provided types. Use the explicit overload to stay AOT-safe.
+```csharp
+ObsBatchBuilder batch = new();
+BatchRef<GetVersionResponseData> version = batch.General.GetVersion();
+BatchRef<GetSceneListResponseData> scenes = batch.Scenes.GetSceneList(new());
+_ = batch.General.Sleep(new(sleepMillis: 100));
+_ = batch.Inputs.SetInputMute(new() { InputName = "Mic", InputMuted = false });
 
-**Settings read/write:**
+BatchResults results = await client.CallBatchAsync(
+    batch,
+    executionType: RequestBatchExecutionType.SerialRealtime,
+    haltOnFailure: false,
+    cancellationToken: ct
+);
 
-| Helper | Notes |
-|---|---|
-| `GetInputSettingsAsync<T>` / `SetInputSettingsAsync<T>` | Input settings; Set supports `overlay` |
-| `GetInputDefaultSettingsAsync<T>` | Default settings for a given input kind |
-| `GetSourceFilterSettingsAsync<T>` / `SetSourceFilterSettingsAsync<T>` | Filter settings; Set supports `overlay` |
-| `GetSourceFilterDefaultSettingsAsync<T>` | Default settings for a given filter kind |
-| `GetCurrentSceneTransitionSettingsAsync<T>` / `SetCurrentSceneTransitionSettingsAsync<T>` | Transition settings |
-| `GetOutputSettingsAsync<T>` / `SetOutputSettingsAsync<T>` | Output settings |
-| `GetStreamServiceSettingsAsync<T>` / `SetStreamServiceSettingsAsync<T>` | Stream service settings |
+Console.WriteLine(results.Get(version).ObsVersion);
+Console.WriteLine(results.Get(scenes).Scenes?.Count);
+```
 
-Most of these take optional parameters ahead of the cancellation token, so pass it as `cancellationToken: ct`.
+`results.Get(reference)` restates neither the position nor the type, so a request type may appear
+many times in one batch and each reference still resolves to its own result.
 
-**Scenes and scene items:**
+`Sleep` is only valid inside a batch, and pairs with `SerialRealtime` to pace a sequence.
 
-- `SwitchSceneAsync(scene, cancellationToken: ct)` switches the Program scene, or Preview with `switchToProgram: false`. Optional `transitionName` and `transitionDurationMs` apply to that switch only.
-- `SwitchSceneAndWaitAsync(scene, cancellationToken: ct)` does the same and waits for the event confirming it.
-- `SetSceneItemEnabledAsync(scene, sourceName, isEnabled, ct)` returns the resulting state. Leave `isEnabled` null to toggle. There is an overload taking a numeric `sceneItemId`.
-- `FindSceneItemIdAsync(scene, sourceName, ct)` returns null instead of throwing when the item is not in the scene.
-- `SourceExistsAsync(name, ct)` and `SceneExistsAsync(name, ct)` check for existence.
+`TryGet` reports a failed or missing result instead of throwing, and `Get` throws
+`ObsWebSocketRequestException` carrying the OBS status code when that request was rejected:
 
-**Inputs and filters:**
+```csharp
+if (!results.AllSucceeded())
+{
+    foreach (var failed in results.GetFailures())
+    {
+        Console.WriteLine($"{failed.RequestType}: {failed.RequestStatus.Comment}");
+    }
+}
+```
 
-- `SetInputTextAsync(name, text, ct)` is shorthand for updating text source content.
-- `SetInputVolumeDbAsync(name, db, ct)` and `SetInputVolumeMulAsync(name, mul, ct)` each pick one unit. The underlying request accepts either and fails when given neither.
-- `SetInputMutesAsync(inputMutes, ct)` sets many mute states in one batch, taking `IEnumerable<(string InputName, bool IsMuted)>`.
-- `CreateInputAsync<T>(kind, name, settings, ...)` creates an input with typed settings, optionally placing it in a scene.
-- `CreateSourceFilterAsync<T>(source, filterName, kind, settings, ct)` adds a typed filter.
+With `haltOnFailure: true` OBS stops at the first failure, so fewer results come back than requests
+were sent; reading a reference past that point throws, and `Count` reports how many ran.
 
-**Screenshots:**
+`Add` covers anything the generated methods do not, including a raw `JsonElement`, and an overload
+taking a `JsonTypeInfo<T>` keeps a custom payload AOT-safe:
 
-- `GetSourceScreenshotBytesAsync(source, ...)` returns the decoded image bytes rather than a base64 data URI.
-- `GetSourceScreenshotOnCanvasBytesAsync(source, ...)` does the same at full canvas dimensions.
-- `SaveSourceScreenshotToFileAsync(source, filePath, ...)` writes straight to disk.
+```csharp
+batch.Add("GetStats");
+batch.Add("SetInputSettings", myJsonElement);
+```
 
-**Outputs:**
+> `RequestBatchExecutionType.Parallel` is best avoided when you care about the results. OBS collects
+> them in completion order but labels them from the submission order, so every result carries
+> another request's `responseData` and `requestStatus`. That happens before the response leaves OBS,
+> so it cannot be corrected here; references refuse to resolve on such a batch and say why. See
+> [#16](https://github.com/Agash/ObsWebSocket/issues/16).
 
-- `SetRecordActiveAndWaitAsync(activate, timeout, ct)` and `SetStreamActiveAndWaitAsync(...)` start or stop the output and wait for OBS to confirm, returning the resulting `OutputState`.
-- `IsRecordActiveAsync(ct)`, `IsStreamActiveAsync(ct)`, and `IsVirtualCamActiveAsync(ct)` read current state.
-- `SetVirtualCamActiveAndWaitAsync(activate, timeout, ct)` does the same for the virtual camera.
-
-**Application state:**
-
-- `EnsureProfileActiveAsync(name, ct)` and `EnsureSceneCollectionActiveAsync(name, ct)` switch only if needed, returning whether the target is active afterwards rather than throwing when it does not exist.
-- `TriggerHotkeyAsync(hotkeyName, ct)` fires a hotkey by name.
-- `WaitForEventAsync<TEventArgs>(...)` awaits a single event. See [Observing Events](#observing-events).
-
-### Typed protocol enums
+## Typed protocol enums
 
 Protocol enums that travel as strings have a real C# enum, so states can be matched rather than
 compared against constants:
@@ -284,85 +276,10 @@ await client.MediaInputs.PlayMediaAsync("Stinger", ct);
 await client.MediaInputs.TriggerMediaActionAsync("Stinger", MediaInputAction.Restart, ct);
 ```
 
-The wire constants remain available as `const` strings on `ObsOutputState` and
-`ObsMediaInputAction`, and `ToWireValue()` converts an enum back when you need the raw form.
-
-For direct low-level access, all generated request/response types are in:
-- `ObsWebSocket.Core.Protocol.Requests`
-- `ObsWebSocket.Core.Protocol.Responses`
-- `ObsWebSocket.Core.Events.Generated`
-
-### Batch API
-
-Send several requests in one round trip, with OBS executing them back to back. Requests are
-grouped by the protocol's own categories, and each one hands back a reference carrying its
-response type:
-
-```csharp
-ObsBatchBuilder batch = new();
-BatchRef<GetVersionResponseData> version = batch.General.GetVersion();
-BatchRef<GetSceneListResponseData> scenes = batch.Scenes.GetSceneList(new());
-_ = batch.General.Sleep(new(sleepMillis: 100));
-_ = batch.Inputs.SetInputMute(new() { InputName = "Mic", InputMuted = false });
-
-BatchResults results = await client.CallBatchAsync(
-    batch,
-    executionType: RequestBatchExecutionType.SerialRealtime,
-    haltOnFailure: false,
-    cancellationToken: ct
-);
-
-Console.WriteLine(results.Get(version).ObsVersion);
-Console.WriteLine(results.Get(scenes).Scenes?.Count);
-```
-
-`results.Get(reference)` returns the response record for that request, so neither its position nor
-its type is restated. A request type may appear many times in one batch and each reference still
-resolves to its own result.
-
-`Sleep` is only valid inside a batch, and pairs with `SerialRealtime` to pace a sequence.
-
-`TryGet` reports a failed or missing result instead of throwing, and `Get` throws
-`ObsWebSocketRequestException` carrying the OBS status code when that request was rejected:
-
-```csharp
-if (!results.AllSucceeded())
-{
-    foreach (var failed in results.GetFailures())
-    {
-        Console.WriteLine($"{failed.RequestType}: {failed.RequestStatus.Comment}");
-    }
-}
-```
-
-With `haltOnFailure: true` OBS stops at the first failure, so fewer results come back than
-requests were sent. Reading a reference past that point throws, and `Count` reports how many ran.
-
-`Add` takes anything the generated methods do not cover, including a raw `JsonElement` payload,
-and an overload accepting a `JsonTypeInfo<T>` keeps a custom payload AOT-safe:
-
-```csharp
-batch.Add("GetStats").Add("SetInputSettings", myJsonElement);
-```
-
-The lower-level form still works, and remains the way to build a batch ahead of time:
-
-```csharp
-List<BatchRequestItem> items =
-[
-    new("GetVersion", null),
-    new("SetCurrentProgramScene", new SetCurrentProgramSceneRequestData(sceneName: "Intro")),
-];
-
-var raw = await client.CallBatchAsync(items, cancellationToken: ct);
-```
-
-Either way, an item's `RequestData` should be `null`, a generated `*RequestData` DTO, or a `JsonElement` built with `Utf8JsonWriter`. Anonymous types and reflection-based serialization are not AOT-safe here.
+The wire constants remain available as `const` strings on `ObsOutputState` and `ObsMediaInputAction`,
+and `ToWireValue()` converts an enum back.
 
 ## Host integration
-
-Connect with the host rather than writing a background service for it, and expose the connection
-as a health check:
 
 ```csharp
 builder.AddObsWebSocketClient("obs");          // reads ConnectionStrings:obs
@@ -370,23 +287,29 @@ builder.Services.WithAutoConnect();            // connects on start, disconnects
 builder.Services.AddHealthChecks().AddObsWebSocket();
 ```
 
-```json
+The password may travel in the connection string or be set on the options; either way it is kept off
+`ServerUri`. A connection that cannot be established at startup is logged rather than thrown, because
+OBS is often started after the application, and reconnect takes over from there.
+
+Options are read through `IOptionsMonitor`, so editing configuration takes effect without a restart.
+Timeouts and reconnect settings apply to the next call that uses them; changing the endpoint,
+password or transport reconnects, which `WithAutoConnect` performs.
+
+To configure in code instead:
+
+```csharp
+builder.Services.AddObsWebSocketClient(o =>
 {
-  "ConnectionStrings": {
-    "obs": "ws://localhost:4455?password=secret"
-  }
-}
+    o.ServerUri = new Uri("ws://localhost:4455");
+    o.Password = "secret";
+    o.Format = SerializationFormat.MsgPack;
+});
 ```
 
-The password may travel in the connection string or be set on the options; either way it is kept
-off `ServerUri`. A connection that cannot be established at startup is logged rather than thrown,
-because OBS is often started after the application, and reconnect takes over from there.
+Options are validated when the client is resolved, so a missing or malformed `ServerUri` fails at
+startup with the offending option named, rather than on the first connection attempt.
 
-Options are read through `IOptionsMonitor`, so editing configuration takes effect without a
-restart. Timeouts and reconnect settings apply to the next call that uses them; changing the
-endpoint, password or transport reconnects, which `WithAutoConnect` performs.
-
-## Multiple OBS instances
+### Multiple OBS instances
 
 Register clients by name and resolve them with `[FromKeyedServices]`:
 
@@ -410,7 +333,6 @@ try
 }
 catch (ObsWebSocketRequestException ex)
 {
-    // OBS rejected the request. ex.Status carries the protocol code and comment.
     Console.WriteLine($"{ex.RequestType} failed with {ex.Status?.Code}: {ex.Comment}");
 }
 catch (ObsWebSocketTimeoutException)
@@ -420,23 +342,23 @@ catch (ObsWebSocketTimeoutException)
 ```
 
 `ObsWebSocketSerializationException` covers payloads that cannot be written or read, and all three
-derive from `ObsWebSocketException` if you would rather catch the lot.
+derive from `ObsWebSocketException`.
 
-Options are validated when the client is resolved, so a missing or malformed `ServerUri` fails at
-startup with the offending option named, rather than on the first connection attempt.
+Requests return their response data non-nullable; a successful request that carries no payload
+raises `ObsWebSocketException` rather than handing back null.
 
 ## Reconnect
 
-Reconnect delays grow by `ReconnectBackoffMultiplier`, are capped at `MaxReconnectDelayMs`, and
-carry jitter so that several clients recovering from one outage do not retry in lockstep.
-Authentication failures are never retried, since they cannot succeed on a second attempt.
+Reconnect delays grow by `ReconnectBackoffMultiplier`, are capped at `MaxReconnectDelayMs`, and carry
+jitter so several clients recovering from one outage do not retry in lockstep. Authentication
+failures are never retried, since they cannot succeed on a second attempt.
 
 To replace the policy outright rather than tune those options, register your own pipeline under
 `ObsWebSocketResilience.ReconnectPipelineKey` after adding the client.
 
 ## Telemetry
 
-The client emits traces and metrics under the name `ObsWebSocket.Core`, inert until something
+Traces and metrics are published under the name `ObsWebSocket.Core`, inert until something
 subscribes:
 
 ```csharp
@@ -446,34 +368,30 @@ builder.Services.AddOpenTelemetry()
 ```
 
 One activity per request, and one per batch rather than per item. Counters cover requests sent,
-requests failed, events received and reconnect attempts, plus a request-duration histogram.
+requests failed, events received and reconnect attempts, plus a request-duration histogram. The
+instruments are created from `IMeterFactory`, so they belong to the container that built them.
 
 Timeouts and reconnect delays run on an injectable `TimeProvider`, so tests can drive them with
 `FakeTimeProvider` instead of waiting.
 
-## Example App
+## Serialization
+
+JSON and MessagePack are both supported, selected with `Format`. Everything in this document behaves
+identically on either, and the validation suite exercises both.
+
+## Example app
 
 `ObsWebSocket.Example` is a host-based sample with configuration and DI.
 
-- **Interactive mode**: command loop (`help`, `version`, `scene`, `watch`, `batch-example`, `get-all-settings-types`, etc.)
-- **Transport validation mode**: exercises JSON and MsgPack across the whole surface, then enters the interactive loop
-- **One-shot mode**: pass a command as a process argument for CI/automation, `ObsWebSocket.Example run-transport-tests`
+- **Interactive mode**: command loop (`help`, `version`, `scene`, `watch`, `media`, `status`, `batch-example`, and more)
+- **Transport validation mode**: exercises the surface on JSON and MessagePack, then enters the interactive loop
+- **One-shot mode**: `ObsWebSocket.Example run-transport-tests`
 
 `run-transport-tests` creates its own scene and input, so it does not depend on a particular OBS
-layout, and removes them afterwards. On each transport it covers the settings modes, event streams,
-`WaitForEventAsync`, the typed batch builder including duplicate request types and partial failure,
-typed protocol enums, and the scene, input, volume and output helpers.
-
-It reads the same `Obs` section as above, plus:
-
-```json
-{
-  "ExampleValidation": {
-    "RunValidationOnStartup": false,
-    "ValidationIterations": 1
-  }
-}
-```
+layout, and removes them afterwards. On each transport it asserts real values for the settings modes,
+event streams and buffering, `WaitForEventAsync`, the typed batch builder including duplicate request
+types, partial failure and truncation, typed protocol enums, screenshots, and the scene, input,
+volume and output helpers.
 
 ## Native AOT
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ public sealed class Worker(ObsWebSocketClient client) : BackgroundService
         var version = await client.General.GetVersionAsync(ct);
         Console.WriteLine($"Connected to OBS {version.ObsVersion}");
 
-        await foreach (var e in client.CurrentProgramSceneChangedStream(cancellationToken: ct))
+        await foreach (var e in client.Scenes.CurrentProgramSceneChangedStream(cancellationToken: ct))
         {
             Console.WriteLine($"Scene changed: {e.EventData.SceneName}");
         }
@@ -69,12 +69,14 @@ public sealed class Worker(ObsWebSocketClient client) : BackgroundService
 
 ## Everything is grouped by category
 
-The client mirrors the categories the OBS protocol defines, and the conveniences this library adds
-sit in the same group as the requests they wrap, so there is one way to reach anything:
+The client mirrors the categories the OBS protocol defines. Requests, event streams and the
+conveniences this library adds all sit in the group their category owns, so there is one way to
+reach anything:
 
 ```csharp
 await client.Scenes.GetSceneListAsync(new(), ct);                                   // generated request
 await client.Scenes.SwitchProgramSceneAndWaitAsync("Intro", cancellationToken: ct);  // convenience
+await client.Scenes.CurrentProgramSceneChangedStream(cancellationToken: ct);         // event stream
 await client.Inputs.SetInputVolumeDbAsync("Mic", -6, ct);
 await client.SceneItems.SetSceneItemEnabledAsync("Intro", "Logo", false, ct);
 ```
@@ -88,11 +90,11 @@ category.
 
 ## Observing events
 
-Every OBS event is exposed as an async sequence. The stream subscribes for the lifetime of the loop
-and unsubscribes when it ends, so there is no handler bookkeeping:
+Every OBS event is exposed as an async sequence on its category group. The stream subscribes for the
+lifetime of the loop and unsubscribes when it ends, so there is no handler bookkeeping:
 
 ```csharp
-await foreach (var e in client.CurrentProgramSceneChangedStream(cancellationToken: ct))
+await foreach (var e in client.Scenes.CurrentProgramSceneChangedStream(cancellationToken: ct))
 {
     Console.WriteLine($"Program scene is now {e.EventData.SceneName}");
 }

--- a/README.md
+++ b/README.md
@@ -281,6 +281,23 @@ await client.MediaInputs.TriggerMediaActionAsync("Stinger", MediaInputAction.Res
 The wire constants remain available as `const` strings on `ObsOutputState` and `ObsMediaInputAction`,
 and `ToWireValue()` converts an enum back.
 
+## Numbers
+
+The protocol has a single `Number` type because JSON does, so a scene item id and a volume
+multiplier look identical in the definition. Fields that hold whole numbers are generated as `int`
+or `long` rather than `double`:
+
+```csharp
+int id = await client.SceneItems.FindSceneItemIdAsync("Intro", "Logo", ct) ?? throw new(...);
+await client.SceneItems.SetSceneItemIndexAsync(new(sceneItemId: id, sceneItemIndex: 0, sceneName: "Intro"), ct);
+
+long bytes = (await client.Stream.GetStreamStatusAsync(ct)).OutputBytes;
+double volume = (await client.Inputs.GetInputVolumeAsync(new("Mic"), ct)).InputVolumeMul;
+```
+
+Which fields those are is an explicit list in the generator, not a rule over field names, so a
+volume can never be silently truncated by a naming coincidence.
+
 ## Host integration
 
 ```csharp
@@ -316,13 +333,20 @@ startup with the offending option named, rather than on the first connection att
 Register clients by name and resolve them with `[FromKeyedServices]`:
 
 ```csharp
-builder.Services.AddObsWebSocketClient("main", o => o.ServerUri = new Uri("ws://localhost:4455"));
-builder.Services.AddObsWebSocketClient("booth", o => o.ServerUri = new Uri("ws://booth:4455"));
+builder.Services.AddObsWebSocketClient("main", o => o.ServerUri = new Uri("ws://localhost:4455"))
+       .WithAutoConnect()
+       .WithHealthCheck();
+
+builder.Services.AddObsWebSocketClient("booth", o => o.ServerUri = new Uri("ws://booth:4455"))
+       .WithAutoConnect();
 
 public sealed class Worker(
     [FromKeyedServices("main")] ObsWebSocketClient main,
     [FromKeyedServices("booth")] ObsWebSocketClient booth);
 ```
+
+Each client gets its own options instance, its own connection service and a health check named after
+its key, so the two do not collide.
 
 ## Errors
 
@@ -343,11 +367,13 @@ catch (ObsWebSocketTimeoutException)
 }
 ```
 
-`StatusCode` reports the same status as the protocol's `RequestStatus` enum, so a filter can name
-the reason instead of a number:
+`StatusCode` reports the status as the `RequestStatusCode` enum, so a filter can name the reason
+instead of a number:
 
 ```csharp
-catch (ObsWebSocketRequestException ex) when (ex.StatusCode is RequestStatus.ResourceNotFound)
+using ObsWebSocket.Core.Protocol.Generated;
+
+catch (ObsWebSocketRequestException ex) when (ex.StatusCode is RequestStatusCode.ResourceNotFound)
 {
     // The scene, input or filter does not exist.
 }


### PR DESCRIPTION
Follow-up to #14. Everything here was found by auditing the built assembly rather than the source, which turned up surface that #14 already claimed was done.

## Grouping, finished

- 60 event stream accessors were still flat extensions on the client, so half the surface was grouped and half was not. They move onto their category group, generated from the same `category` field in `protocol.json` that the requests use. `{Category}RequestGroup` becomes `{Category}Group`.
- Both client helper files had been left as ~130 lines of banner comments with nothing under them when their methods moved into groups.
- `WaitForEventAsync` had overloads split across two static classes, and the two `CallBatchAsync` overloads returned different types, so picking the lambda one silently gave untyped results.

## The protocol's numbers

JSON has one numeric type, so every `Number` became `double` and callers read scene item ids, frame counts and byte counts as floating point. Which fields are integral is not recoverable from the definition: `sceneItemId` and `inputVolumeMul` are both `Number` with a `>= 0` restriction. The classification is an explicit table, not a rule over field names, because guessing wrong on a volume field truncates it silently while an unlisted field only stays `double`. 32 field names become `int` or `long`, 10 stay `double`, and an unlisted field reports OBSWSGEN012.

## Client options

`AddObsWebSocketClient` returns a builder, so `WithAutoConnect`, `WithHealthCheck` and `WithReconnectPipeline` chain off it. `WithAutoConnect` previously hung off `IServiceCollection` and could not target one of two named clients.

## Fixes

- `GetSourceScreenshot` returns a data URI, so the in-memory helper threw and returned null for every call. The file variant was unaffected, which is why it went unnoticed.
- Six helpers decided "not found" by substring matching the exception message. `ObsWebSocketRequestException.StatusCode` exposes the reported status as the protocol enum and they match on that.
- The `RequestStatus` enum shared a name with the `RequestStatus` record on every response, which is the pair a caller has to disambiguate to write a status filter. It is `RequestStatusCode`.
- csharpier was pinned in `dotnet-tools.json` and never run; 69 of 99 files had drifted. Some of that drift was misleading rather than cosmetic. CI checks it now.
- Three tests failed only under parallel load, each for a real reason: two drove a `FakeTimeProvider` and then waited on real `Task.Delay`, and one put a 1s wall clock limit on a test that only builds a container.

## Verification

Validated live against OBS 32.2.2 on both transports, 29 checks each with value assertions. Writing an int over MessagePack is asserted explicitly, including `0`, which also covers the falsy-field fix from #11.

Closes #14